### PR TITLE
StyleCop

### DIFF
--- a/src/ImageSharp/Common/Helpers/ImageMaths.cs
+++ b/src/ImageSharp/Common/Helpers/ImageMaths.cs
@@ -171,8 +171,8 @@ namespace ImageSharp
             const float Epsilon = .00001f;
             int width = bitmap.Width;
             int height = bitmap.Height;
-            Point topLeft = new Point();
-            Point bottomRight = new Point();
+            Point topLeft = default(Point);
+            Point bottomRight = default(Point);
 
             Func<PixelAccessor<TColor, TPacked>, int, int, float, bool> delegateFunc;
 

--- a/src/ImageSharp/Filters/Processors/IImageFilter.cs
+++ b/src/ImageSharp/Filters/Processors/IImageFilter.cs
@@ -1,4 +1,9 @@
-﻿namespace ImageSharp.Processors
+﻿// <copyright file="IImageFilter.cs" company="James Jackson-South">
+// Copyright (c) James Jackson-South and contributors.
+// Licensed under the Apache License, Version 2.0.
+// </copyright>
+
+namespace ImageSharp.Processors
 {
     /// <summary>
     /// Encapsulates methods to alter the pixels of an image. The processor operates on the original source pixels.

--- a/src/ImageSharp/Formats/Bmp/BmpDecoderCore.cs
+++ b/src/ImageSharp/Formats/Bmp/BmpDecoderCore.cs
@@ -290,7 +290,7 @@ namespace ImageSharp.Formats
                             byte g = (byte)(((temp & Rgb16GMask) >> 5) * ScaleG);
                             byte b = (byte)((temp & Rgb16BMask) * ScaleR);
 
-                            int arrayOffset = ((row * width) + x);
+                            int arrayOffset = (row * width) + x;
 
                             // Stored in b-> g-> r order.
                             TColor packed = default(TColor);
@@ -330,7 +330,7 @@ namespace ImageSharp.Formats
                         for (int x = 0; x < width; x++)
                         {
                             int offset = rowOffset + (x * 3);
-                            int arrayOffset = ((row * width) + x);
+                            int arrayOffset = (row * width) + x;
 
                             // Stored in b-> g-> r-> a order.
                             TColor packed = default(TColor);
@@ -370,7 +370,7 @@ namespace ImageSharp.Formats
                         for (int x = 0; x < width; x++)
                         {
                             int offset = rowOffset + (x * 4);
-                            int arrayOffset = ((row * width) + x);
+                            int arrayOffset = (row * width) + x;
 
                             // Stored in b-> g-> r-> a order.
                             TColor packed = default(TColor);

--- a/src/ImageSharp/Formats/Gif/GifEncoderCore.cs
+++ b/src/ImageSharp/Formats/Gif/GifEncoderCore.cs
@@ -168,7 +168,7 @@ namespace ImageSharp.Formats
             writer.Write((ushort)descriptor.Width);
             writer.Write((ushort)descriptor.Height);
 
-            PackedField field = new PackedField();
+            PackedField field = default(PackedField);
             field.SetBit(0, descriptor.GlobalColorTableFlag); // 1   : Global color table flag = 1 || 0 (GCT used/ not used)
             field.SetBits(1, 3, descriptor.GlobalColorTableSize); // 2-4 : color resolution
             field.SetBit(4, false); // 5   : GCT sort flag = 0
@@ -254,7 +254,7 @@ namespace ImageSharp.Formats
 
             writer.Write(intro);
 
-            PackedField field = new PackedField();
+            PackedField field = default(PackedField);
             field.SetBits(3, 3, (int)extension.DisposalMethod); // 1-3 : Reserved, 4-6 : Disposal
 
             // TODO: Allow this as an option.
@@ -285,7 +285,7 @@ namespace ImageSharp.Formats
             writer.Write((ushort)image.Width);
             writer.Write((ushort)image.Height);
 
-            PackedField field = new PackedField();
+            PackedField field = default(PackedField);
             field.SetBit(0, true); // 1: Local color table flag = 1 (LCT used)
             field.SetBit(1, false); // 2: Interlace flag 0
             field.SetBit(2, false); // 3: Sort flag 0

--- a/src/ImageSharp/Formats/Gif/PackedField.cs
+++ b/src/ImageSharp/Formats/Gif/PackedField.cs
@@ -55,7 +55,7 @@ namespace ImageSharp.Formats
         /// <returns>The <see cref="PackedField"/></returns>
         public static PackedField FromInt(byte value)
         {
-            PackedField packed = new PackedField();
+            PackedField packed = default(PackedField);
             packed.SetBits(0, 8, value);
             return packed;
         }

--- a/src/ImageSharp/Formats/Jpg/JpegEncoderCore.cs
+++ b/src/ImageSharp/Formats/Jpg/JpegEncoderCore.cs
@@ -488,9 +488,9 @@ namespace ImageSharp.Formats
             int componentCount = 3;
 
             // Write the Start Of Image marker.
-            WriteApplicationHeader((short)image.HorizontalResolution, (short)image.VerticalResolution);
+            this.WriteApplicationHeader((short)image.HorizontalResolution, (short)image.VerticalResolution);
 
-            WriteProfiles(image);
+            this.WriteProfiles(image);
 
             // Write the quantization tables.
             this.WriteDQT();
@@ -574,7 +574,7 @@ namespace ImageSharp.Formats
             where TColor : struct, IPackedPixel<TPacked>
             where TPacked : struct
         {
-            WriteProfile(image.ExifProfile);
+            this.WriteProfile(image.ExifProfile);
         }
 
         private void WriteProfile(ExifProfile exifProfile)

--- a/src/ImageSharp/Formats/Jpg/JpegEncoderCore.cs
+++ b/src/ImageSharp/Formats/Jpg/JpegEncoderCore.cs
@@ -3,8 +3,6 @@
 // Licensed under the Apache License, Version 2.0.
 // </copyright>
 
-using System.Numerics;
-
 namespace ImageSharp.Formats
 {
     using System;

--- a/src/ImageSharp/Formats/Jpg/JpegEncoderCore.cs
+++ b/src/ImageSharp/Formats/Jpg/JpegEncoderCore.cs
@@ -49,7 +49,8 @@ namespace ImageSharp.Formats
         /// The values are derived from section K.1 after converting from natural to
         /// zig-zag order.
         /// </summary>
-        private readonly byte[,] unscaledQuant = {
+        private readonly byte[,] unscaledQuant =
+        {
             {
                 // Luminance.
                 16, 11, 12, 14, 12, 10, 16, 14, 13, 14, 18, 17, 16, 19, 24, 40,
@@ -71,7 +72,8 @@ namespace ImageSharp.Formats
         /// The Huffman encoding specifications.
         /// This encoder uses the same Huffman encoding for all images.
         /// </summary>
-        private readonly HuffmanSpec[] theHuffmanSpec = {
+        private readonly HuffmanSpec[] theHuffmanSpec =
+        {
             // Luminance DC.
             new HuffmanSpec(
                 new byte[]

--- a/src/ImageSharp/Formats/Png/PngEncoderCore.cs
+++ b/src/ImageSharp/Formats/Png/PngEncoderCore.cs
@@ -611,7 +611,7 @@ namespace ImageSharp.Formats
         /// <param name="stream">The stream.</param>
         private void WriteDataChunks(Stream stream)
         {
-            byte[] data =  this.EncodePixelData();
+            byte[] data = this.EncodePixelData();
 
             byte[] buffer;
             int bufferLength;

--- a/src/ImageSharp/Formats/Png/Zlib/ZlibDeflateStream.cs
+++ b/src/ImageSharp/Formats/Png/Zlib/ZlibDeflateStream.cs
@@ -184,8 +184,8 @@ namespace ImageSharp.Formats
                     this.deflateStream.Dispose();
                     this.deflateStream = null;
                 }
-                else {
-
+                else
+                {
                     // Hack: empty input?
                     this.rawStream.WriteByte(3);
                     this.rawStream.WriteByte(0);

--- a/src/ImageSharp/Formats/Png/Zlib/ZlibDeflateStream.cs
+++ b/src/ImageSharp/Formats/Png/Zlib/ZlibDeflateStream.cs
@@ -196,7 +196,7 @@ namespace ImageSharp.Formats
                 this.rawStream.WriteByte((byte)((crc >> 24) & 0xFF));
                 this.rawStream.WriteByte((byte)((crc >> 16) & 0xFF));
                 this.rawStream.WriteByte((byte)((crc >> 8) & 0xFF));
-                this.rawStream.WriteByte((byte)((crc) & 0xFF));
+                this.rawStream.WriteByte((byte)(crc & 0xFF));
             }
 
             base.Dispose(disposing);

--- a/src/ImageSharp/IO/EndianBinaryReader.cs
+++ b/src/ImageSharp/IO/EndianBinaryReader.cs
@@ -575,8 +575,7 @@ namespace ImageSharp.IO
                 int read = this.BaseStream.Read(data, index, size - index);
                 if (read == 0)
                 {
-                    throw new EndOfStreamException
-                        (
+                    throw new EndOfStreamException(
                         string.Format(
                             "End of stream reached with {0} byte{1} left to read.",
                             size - index,

--- a/src/ImageSharp/IO/EndianBitConverter.cs
+++ b/src/ImageSharp/IO/EndianBitConverter.cs
@@ -325,7 +325,7 @@ namespace ImageSharp.IO
         }
         #endregion
 
-        #region	Decimal conversions
+        #region Decimal conversions
         /// <summary>
         /// Returns a decimal value converted from sixteen bytes 
         /// at a specified position in a byte array.

--- a/src/ImageSharp/Image/ImageIOExtensions.cs
+++ b/src/ImageSharp/Image/ImageIOExtensions.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="ImageExtensions.cs" company="James Jackson-South">
+﻿// <copyright file="ImageIOExtensions.cs" company="James Jackson-South">
 // Copyright (c) James Jackson-South and contributors.
 // Licensed under the Apache License, Version 2.0.
 // </copyright>

--- a/src/ImageSharp/Image/ImageProcessingExtensions.cs
+++ b/src/ImageSharp/Image/ImageProcessingExtensions.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="ImageExtensions.cs" company="James Jackson-South">
+﻿// <copyright file="ImageProcessingExtensions.cs" company="James Jackson-South">
 // Copyright (c) James Jackson-South and contributors.
 // Licensed under the Apache License, Version 2.0.
 // </copyright>

--- a/src/ImageSharp/Image/ImageProperty.cs
+++ b/src/ImageSharp/Image/ImageProperty.cs
@@ -94,7 +94,7 @@ namespace ImageSharp
         {
             ImageProperty other = obj as ImageProperty;
 
-            return Equals(other);
+            return this.Equals(other);
         }
 
         /// <summary>

--- a/src/ImageSharp/Profiles/Exif/ExifReader.cs
+++ b/src/ImageSharp/Profiles/Exif/ExifReader.cs
@@ -442,7 +442,7 @@ namespace ImageSharp
         {
             if (!this.ValidateArray(data, 8, 4))
             {
-                return new Rational();
+                return default(Rational);
             }
 
             uint numerator = BitConverter.ToUInt32(data, 0);
@@ -470,7 +470,7 @@ namespace ImageSharp
         {
             if (!this.ValidateArray(data, 8, 4))
             {
-                return new SignedRational();
+                return default(SignedRational);
             }
 
             int numerator = BitConverter.ToInt32(data, 0);

--- a/src/ImageSharp/Profiles/Exif/ExifReader.cs
+++ b/src/ImageSharp/Profiles/Exif/ExifReader.cs
@@ -361,8 +361,7 @@ namespace ImageSharp
             }
         }
 
-        private static TDataType[] ToArray<TDataType>(ExifDataType dataType, byte[] data,
-          ConverterMethod<TDataType> converter)
+        private static TDataType[] ToArray<TDataType>(ExifDataType dataType, byte[] data, ConverterMethod<TDataType> converter)
         {
             int dataTypeSize = (int)ExifValue.GetSize(dataType);
             int length = data.Length / dataTypeSize;

--- a/src/ImageSharp/Profiles/Exif/ExifTagDescriptionAttribute.cs
+++ b/src/ImageSharp/Profiles/Exif/ExifTagDescriptionAttribute.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="ExifTag.cs" company="James Jackson-South">
+﻿// <copyright file="ExifTagDescriptionAttribute.cs" company="James Jackson-South">
 // Copyright (c) James Jackson-South and contributors.
 // Licensed under the Apache License, Version 2.0.
 // </copyright>

--- a/src/ImageSharp/Profiles/Exif/ExifTagDescriptionAttribute.cs
+++ b/src/ImageSharp/Profiles/Exif/ExifTagDescriptionAttribute.cs
@@ -6,7 +6,6 @@
 namespace ImageSharp
 {
     using System;
-    using System.Linq;
     using System.Reflection;
 
     /// <summary>
@@ -18,9 +17,9 @@ namespace ImageSharp
         private object value;
         private string description;
 
-        ///<summary>
+        /// <summary>
         /// Initializes a new instance of the ExifTagDescriptionAttribute class.
-        ///</summary>
+        /// </summary>
         /// <param name="value">The value of the exif tag.</param>
         /// <param name="description">The description for the value of the exif tag.</param>
         public ExifTagDescriptionAttribute(object value, string description)

--- a/src/ImageSharp/Profiles/Exif/ExifValue.cs
+++ b/src/ImageSharp/Profiles/Exif/ExifValue.cs
@@ -103,10 +103,10 @@ namespace ImageSharp
             return !Equals(left, right);
         }
 
-        ///<summary>
+        /// <summary>
         /// Determines whether the specified object is equal to the current exif value.
-        ///</summary>
-        ///<param name="obj">The object to compare this exif value with.</param>
+        /// </summary>
+        /// <param name="obj">The object to compare this exif value with.</param>
         public override bool Equals(object obj)
         {
             if (ReferenceEquals(this, obj))
@@ -117,10 +117,10 @@ namespace ImageSharp
             return this.Equals(obj as ExifValue);
         }
 
-        ///<summary>
+        /// <summary>
         /// Determines whether the specified exif value is equal to the current exif value.
-        ///</summary>
-        ///<param name="other">The exif value to compare this exif value with.</param>
+        /// </summary>
+        /// <param name="other">The exif value to compare this exif value with.</param>
         public bool Equals(ExifValue other)
         {
             if (ReferenceEquals(other, null))

--- a/src/ImageSharp/Profiles/Exif/ExifWriter.cs
+++ b/src/ImageSharp/Profiles/Exif/ExifWriter.cs
@@ -16,7 +16,7 @@ namespace ImageSharp
         {
             ExifTag.ImageWidth, ExifTag.ImageLength, ExifTag.BitsPerSample, ExifTag.Compression,
             ExifTag.PhotometricInterpretation, ExifTag.Thresholding, ExifTag.CellWidth,
-            ExifTag.CellLength, ExifTag.FillOrder,ExifTag.ImageDescription, ExifTag.Make,
+            ExifTag.CellLength, ExifTag.FillOrder, ExifTag.ImageDescription, ExifTag.Make,
             ExifTag.Model, ExifTag.StripOffsets, ExifTag.Orientation, ExifTag.SamplesPerPixel,
             ExifTag.RowsPerStrip, ExifTag.StripByteCounts, ExifTag.MinSampleValue,
             ExifTag.MaxSampleValue, ExifTag.XResolution, ExifTag.YResolution,

--- a/src/ImageSharp/Properties/AssemblyInfo.cs
+++ b/src/ImageSharp/Properties/AssemblyInfo.cs
@@ -1,7 +1,11 @@
-﻿using System.Resources;
+﻿// <copyright file="AssemblyInfo.cs" company="James Jackson-South">
+// Copyright (c) James Jackson-South and contributors.
+// Licensed under the Apache License, Version 2.0.
+// </copyright>
+
+using System.Resources;
 using System.Reflection;
 using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
@@ -28,6 +32,7 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyInformationalVersion("1.0.0.0")]
 
 // Ensure the internals can be tested.
 [assembly: InternalsVisibleTo("ImageSharp.Benchmarks")]

--- a/src/ImageSharp/Properties/AssemblyInfo.cs
+++ b/src/ImageSharp/Properties/AssemblyInfo.cs
@@ -3,8 +3,8 @@
 // Licensed under the Apache License, Version 2.0.
 // </copyright>
 
-using System.Resources;
 using System.Reflection;
+using System.Resources;
 using System.Runtime.CompilerServices;
 
 // General Information about an assembly is controlled through the following 

--- a/src/ImageSharp/Quantizers/Wu/WuQuantizer.cs
+++ b/src/ImageSharp/Quantizers/Wu/WuQuantizer.cs
@@ -3,12 +3,11 @@
 // Licensed under the Apache License, Version 2.0.
 // </copyright>
 
-using System.Numerics;
-
 namespace ImageSharp.Quantizers
 {
     using System;
     using System.Collections.Generic;
+    using System.Numerics;
     using System.Threading.Tasks;
 
     /// <summary>

--- a/src/ImageSharp/Quantizers/Wu/WuQuantizer.cs
+++ b/src/ImageSharp/Quantizers/Wu/WuQuantizer.cs
@@ -1,5 +1,5 @@
 ﻿// <copyright file="WuQuantizer.cs" company="James Jackson-South">
-// Copyright © James Jackson-South and contributors.
+// Copyright (c) James Jackson-South and contributors.
 // Licensed under the Apache License, Version 2.0.
 // </copyright>
 

--- a/src/ImageSharp/Samplers/AutoOrient.cs
+++ b/src/ImageSharp/Samplers/AutoOrient.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="EntropyCrop.cs" company="James Jackson-South">
+﻿// <copyright file="AutoOrient.cs" company="James Jackson-South">
 // Copyright (c) James Jackson-South and contributors.
 // Licensed under the Apache License, Version 2.0.
 // </copyright>

--- a/src/ImageSharp/Samplers/Options/Orientation.cs
+++ b/src/ImageSharp/Samplers/Options/Orientation.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="AnchorPosition.cs" company="James Jackson-South">
+﻿// <copyright file="Orientation.cs" company="James Jackson-South">
 // Copyright (c) James Jackson-South and contributors.
 // Licensed under the Apache License, Version 2.0.
 // </copyright>

--- a/src/ImageSharp/Samplers/Processors/Convolution/Convolution2PassFilter.cs
+++ b/src/ImageSharp/Samplers/Processors/Convolution/Convolution2PassFilter.cs
@@ -85,7 +85,7 @@ namespace ImageSharp.Processors
                 {
                     for (int x = startX; x < endX; x++)
                     {
-                        Vector4 destination = new Vector4();
+                        Vector4 destination = default(Vector4);
 
                         // Apply each matrix multiplier to the color components for each pixel.
                         for (int fy = 0; fy < kernelHeight; fy++)

--- a/src/ImageSharp/Samplers/Processors/OilPaintingProcessor.cs
+++ b/src/ImageSharp/Samplers/Processors/OilPaintingProcessor.cs
@@ -119,7 +119,7 @@ namespace ImageSharp.Processors
                                         float sourceBlue = color.Z;
                                         float sourceGreen = color.Y;
 
-                                        int currentIntensity = (int)Math.Round(((sourceBlue + sourceGreen + sourceRed) / 3.0 * (levels - 1)));
+                                        int currentIntensity = (int)Math.Round((sourceBlue + sourceGreen + sourceRed) / 3.0 * (levels - 1));
 
                                         intensityBin[currentIntensity] += 1;
                                         blueBin[currentIntensity] += sourceBlue;

--- a/src/ImageSharp/Samplers/Processors/RotateProcessor.cs
+++ b/src/ImageSharp/Samplers/Processors/RotateProcessor.cs
@@ -39,7 +39,7 @@ namespace ImageSharp.Processors
         {
             const float Epsilon = .0001F;
 
-            if (Math.Abs(Angle) < Epsilon || Math.Abs(Angle - 90) < Epsilon || Math.Abs(Angle - 180) < Epsilon || Math.Abs(Angle - 270) < Epsilon)
+            if (Math.Abs(this.Angle) < Epsilon || Math.Abs(this.Angle - 90) < Epsilon || Math.Abs(this.Angle - 180) < Epsilon || Math.Abs(this.Angle - 270) < Epsilon)
             {
                 return;
             }
@@ -54,7 +54,7 @@ namespace ImageSharp.Processors
         /// <inheritdoc/>
         public override void Apply(ImageBase<TColor, TPacked> target, ImageBase<TColor, TPacked> source, Rectangle targetRectangle, Rectangle sourceRectangle, int startY, int endY)
         {
-            if (OptimizedApply(target, source))
+            if (this.OptimizedApply(target, source))
             {
                 return;
             }
@@ -93,25 +93,25 @@ namespace ImageSharp.Processors
         private bool OptimizedApply(ImageBase<TColor, TPacked> target, ImageBase<TColor, TPacked> source)
         {
             const float Epsilon = .0001F;
-            if (Math.Abs(Angle) < Epsilon)
+            if (Math.Abs(this.Angle) < Epsilon)
             {
                 target.ClonePixels(target.Width, target.Height, source.Pixels);
                 return true;
             }
 
-            if (Math.Abs(Angle - 90) < Epsilon)
+            if (Math.Abs(this.Angle - 90) < Epsilon)
             {
                 this.Rotate90(target, source);
                 return true;
             }
 
-            if (Math.Abs(Angle - 180) < Epsilon)
+            if (Math.Abs(this.Angle - 180) < Epsilon)
             {
                 this.Rotate180(target, source);
                 return true;
             }
 
-            if (Math.Abs(Angle - 270) < Epsilon)
+            if (Math.Abs(this.Angle - 270) < Epsilon)
             {
                 this.Rotate270(target, source);
                 return true;

--- a/src/ImageSharp/Samplers/Processors/RotateProcessor.cs
+++ b/src/ImageSharp/Samplers/Processors/RotateProcessor.cs
@@ -3,10 +3,9 @@
 // Licensed under the Apache License, Version 2.0.
 // </copyright>
 
-using System;
-
 namespace ImageSharp.Processors
 {
+    using System;
     using System.Numerics;
     using System.Threading.Tasks;
 

--- a/src/ImageSharp/project.json
+++ b/src/ImageSharp/project.json
@@ -43,7 +43,8 @@
     "System.Text.Encoding.Extensions": "4.0.11",
     "System.Threading": "4.0.11",
     "System.Threading.Tasks": "4.0.11",
-    "System.Threading.Tasks.Parallel": "4.0.1"
+    "System.Threading.Tasks.Parallel": "4.0.1",
+    "StyleCop.Analyzers": "1.0.0"
   },
   "frameworks": {
     "netstandard1.1": {}

--- a/src/ImageSharp/project.json
+++ b/src/ImageSharp/project.json
@@ -24,7 +24,8 @@
   "buildOptions": {
     "allowUnsafe": true,
     "debugType": "portable",
-    "xmlDoc": true
+    "xmlDoc": true,
+    "additionalArguments": [ "/additionalfile:stylecop.json" ]
   },
   "dependencies": {
     "System.Collections": "4.0.11",

--- a/src/ImageSharp/project.json
+++ b/src/ImageSharp/project.json
@@ -45,7 +45,7 @@
     "System.Threading": "4.0.11",
     "System.Threading.Tasks": "4.0.11",
     "System.Threading.Tasks.Parallel": "4.0.1",
-    "StyleCop.Analyzers": "1.0.0"
+    "StyleCop.Analyzers": { "version": "1.0.0", "type": "build" }
   },
   "frameworks": {
     "netstandard1.1": {}

--- a/src/ImageSharp/stylecop.json
+++ b/src/ImageSharp/stylecop.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://raw.githubusercontent.com/DotNetAnalyzers/StyleCopAnalyzers/master/StyleCop.Analyzers/StyleCop.Analyzers/Settings/stylecop.schema.json",
+  "settings": {
+    "documentationRules": {
+      "companyName": "James Jackson-South",
+      "copyrightText": "Copyright (c) James Jackson-South and contributors.\nLicensed under the Apache License, Version 2.0."
+    }
+  }
+}


### PR DESCRIPTION
This adds StyleCop.Analyzers that will enable StyleCop during the build. The documentation for the library can be found here: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/DOCUMENTATION.md. I added stylecop.json file and you can find more information about how that file works here: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/Configuration.md.