### PR TITLE
Enable Visual Studio code coverage

### DIFF
--- a/CodeCoverage.runsettings
+++ b/CodeCoverage.runsettings
@@ -6,13 +6,13 @@
         <Configuration>	
           <CodeCoverage>
             <ModulePaths>
-				<Include>
-					<ModulePath>.*ImageSharp.dll</ModulePath>
-				</Include>
-				<Exclude>
-					<ModulePath>.*tests*</ModulePath>
-					<ModulePath>.*Tests*</ModulePath>
-				</Exclude>
+				      <Include>
+					      <ModulePath>.*ImageSharp.dll</ModulePath>
+				      </Include>
+				      <Exclude>
+					      <ModulePath>.*tests*</ModulePath>
+					      <ModulePath>.*Tests*</ModulePath>
+				      </Exclude>
             </ModulePaths>
           </CodeCoverage>
         </Configuration>

--- a/CodeCoverage.runsettings
+++ b/CodeCoverage.runsettings
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RunSettings>
+  <DataCollectionRunSettings>
+    <DataCollectors>
+      <DataCollector friendlyName="Code Coverage" uri="datacollector://Microsoft/CodeCoverage/2.0" assemblyQualifiedName="Microsoft.VisualStudio.Coverage.DynamicCoverageDataCollector, Microsoft.VisualStudio.TraceCollector, Version=11.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+        <Configuration>	
+          <CodeCoverage>
+            <ModulePaths>
+				<Include>
+					<ModulePath>.*ImageSharp.dll</ModulePath>
+				</Include>
+				<Exclude>
+					<ModulePath>.*tests*</ModulePath>
+					<ModulePath>.*Tests*</ModulePath>
+				</Exclude>
+            </ModulePaths>
+          </CodeCoverage>
+        </Configuration>
+      </DataCollector>
+    </DataCollectors>
+  </DataCollectionRunSettings>
+</RunSettings>

--- a/ImageSharp.sln
+++ b/ImageSharp.sln
@@ -14,6 +14,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "SolutionItems", "SolutionIt
 		build\appveyor-project-version-patch.js = build\appveyor-project-version-patch.js
 		build\appveyor-semver.ps1 = build\appveyor-semver.ps1
 		appveyor.yml = appveyor.yml
+		CodeCoverage.runsettings = CodeCoverage.runsettings
 		build\dotnet-latest.ps1 = build\dotnet-latest.ps1
 		global.json = global.json
 		build\package.json = build\package.json

--- a/tests/ImageSharp.Tests/project.json
+++ b/tests/ImageSharp.Tests/project.json
@@ -23,7 +23,8 @@
         "Microsoft.NETCore.App": {
           "type": "platform",
           "version": "1.0.0-*"
-        }
+        },
+        "Microsoft.CodeCoverage": "1.0.2"
       }
     },
     "net451": {}


### PR DESCRIPTION
Visual Studio code coverage wasn't working for me due to some missing Shim dll so I fixed it - by adding MS codecoverage as a dependency. 

I also added a runsettings file to make sure only the right dlls end up in the coverage. You will need to import this from Test - TestSettings - Select test settings file 😄 