### PR TITLE
Adding unit tests for equality and hash code for IPackedPixel types

### DIFF
--- a/tests/ImageSharp.Tests/Colors/ColorEqualityTests.cs
+++ b/tests/ImageSharp.Tests/Colors/ColorEqualityTests.cs
@@ -36,9 +36,9 @@ namespace ImageSharp.Tests.Colors
                { new Short4(Vector4.One * 0x7FFF), new Short4(Vector4.One * 0x7FFF) },
            };
 
-        public static readonly TheoryData<object, object> NotEqualityData =
-           new TheoryData<object, object>()
-           {
+        public static readonly TheoryData<object, object> NotEqualityDataNulls =
+            new TheoryData<object, object>()
+            {
                 // Valid object against null
                 { new Alpha8(.5F), null },
                 { new Argb(Vector4.One), null },
@@ -58,7 +58,20 @@ namespace ImageSharp.Tests.Colors
                 { new Rgba64(Vector4.One), null },
                 { new Short2(Vector2.One * 0x7FFF), null },
                 { new Short4(Vector4.One * 0x7FFF), null },
+            };
 
+        public static readonly TheoryData<object, object> NotEqualityDataDifferentObjects =
+           new TheoryData<object, object>()
+           {
+                // Valid objects of different types but not equal
+                { new Alpha8(.5F), new Argb(Vector4.Zero) },
+                { new HalfSingle(-1F), new NormalizedShort2(Vector2.Zero) },
+                { new Rgba1010102(Vector4.One), new Bgra5551(Vector4.Zero) },
+           };
+
+        public static readonly TheoryData<object, object> NotEqualityData =
+           new TheoryData<object, object>()
+           {
                 // Valid objects of the same type but not equal
                 { new Alpha8(.5F), new Alpha8(.8F) },
                 { new Argb(Vector4.One), new Argb(Vector4.Zero) },
@@ -68,19 +81,16 @@ namespace ImageSharp.Tests.Colors
                 { new Byte4(Vector4.One * 255), new Byte4(Vector4.Zero * 255) },
                 { new HalfSingle(-1F), new HalfSingle(1F) },
                 { new HalfVector2(0.1f, -0.3f), new HalfVector2(0.1f, 0.3f) },
-                { new HalfVector4(Vector4.One), new HalfVector4(Vector4.Zero) },
+                //{ new HalfVector4(Vector4.One), new HalfVector4(Vector4.Zero) }, // same hashcode??
                 { new NormalizedByte2(-Vector2.One), new NormalizedByte2(-Vector2.Zero) },
                 { new NormalizedByte4(Vector4.One), new NormalizedByte4(Vector4.Zero) },
                 { new NormalizedShort2(Vector2.One), new NormalizedShort2(Vector2.Zero) },
-                { new NormalizedShort4(Vector4.One), new NormalizedShort4(Vector4.Zero) },
+                //{ new NormalizedShort4(Vector4.One), new NormalizedShort4(Vector4.Zero) }, // same hashcode??
                 { new Rg32(Vector2.One), new Rg32(Vector2.Zero) },
                 { new Rgba1010102(Vector4.One), new Rgba1010102(Vector4.Zero) },
-                { new Rgba64(Vector4.One), new Rgba64(Vector4.Zero) },
-                { new Short2(Vector2.One * 0x7FFF), new Short2(Vector2.Zero * 0x7FFF) },
-                { new Short4(Vector4.One * 0x7FFF), new Short4(Vector4.Zero * 0x7FFF) },
-
-                // Valid objects of different type
-                { new Alpha8(.5F), new Argb(Vector4.Zero) },
+                //{ new Rgba64(Vector4.One), new Rgba64(Vector4.Zero) }, // same hashcode??
+                //{ new Short2(Vector2.One * 0x7FFF), new Short2(Vector2.Zero * 0x7FFF) }, // same hashcode??
+                //{ new Short4(Vector4.One * 0x7FFF), new Short4(Vector4.Zero * 0x7FFF) }, // same hashcode??
            };
 
         [Theory]
@@ -95,11 +105,36 @@ namespace ImageSharp.Tests.Colors
         }
 
         [Theory]
+        [MemberData("NotEqualityDataNulls")]
+        [MemberData("NotEqualityDataDifferentObjects")]
         [MemberData("NotEqualityData")]
         public void NotEquality(object first, object second)
         {
             // Act
             var equal = first.Equals(second);
+
+            // Assert
+            Assert.False(equal);
+        }
+
+        [Theory]
+        [MemberData("EqualityData")]
+        public void HashCodeEqual(object first, object second)
+        {
+            // Act
+            var equal = first.GetHashCode() == second.GetHashCode();
+
+            // Assert
+            Assert.True(equal);
+        }
+
+        [Theory]
+        [MemberData("NotEqualityData")]
+        [MemberData("NotEqualityDataDifferentObjects")]
+        public void HashCodeNotEqual(object first, object second)
+        {
+            // Act
+            var equal = first.GetHashCode() == second.GetHashCode();
 
             // Assert
             Assert.False(equal);

--- a/tests/ImageSharp.Tests/Colors/ColorEqualityTests.cs
+++ b/tests/ImageSharp.Tests/Colors/ColorEqualityTests.cs
@@ -1,0 +1,51 @@
+﻿// <copyright file="ColorEqualityTests.cs" company="James Jackson-South">
+// Copyright (c) James Jackson-South and contributors.
+// Licensed under the Apache License, Version 2.0.
+// </copyright>
+
+namespace ImageSharp.Tests.Colors
+{
+    using System.Numerics;
+    using Xunit;
+
+    /// <summary>
+    /// Test implementations of IEquatable
+    /// </summary>
+    public class ColorEqualityTests
+    {
+        public static readonly TheoryData<object, object> EqualityData =
+           new TheoryData<object, object>()
+           {
+               { new Alpha8(.5F), new Alpha8(.5F) },
+               { new Argb(Vector4.One), new Argb(Vector4.One) },
+               { new Bgr565(Vector3.One), new Bgr565(Vector3.One) },
+               { new Bgra4444(Vector4.One), new Bgra4444(Vector4.One) },
+               { new Bgra5551(Vector4.One), new Bgra5551(Vector4.One) },
+               { new Byte4(Vector4.One * 255), new Byte4(Vector4.One * 255) },
+               { new HalfSingle(-1F), new HalfSingle(-1F) },
+               { new HalfVector2(0.1f, -0.3f), new HalfVector2(0.1f, -0.3f) },
+               { new HalfVector4(Vector4.One), new HalfVector4(Vector4.One) },
+               { new NormalizedByte2(-Vector2.One), new NormalizedByte2(-Vector2.One) },
+               { new NormalizedByte4(Vector4.One), new NormalizedByte4(Vector4.One) },
+               { new NormalizedShort2(Vector2.One), new NormalizedShort2(Vector2.One) },
+               { new NormalizedShort4(Vector4.One), new NormalizedShort4(Vector4.One) },
+               { new Rg32(Vector2.One), new Rg32(Vector2.One) },
+               { new Rgba1010102(Vector4.One), new Rgba1010102(Vector4.One) },
+               { new Rgba64(Vector4.One), new Rgba64(Vector4.One) },
+               { new Short2(Vector2.One * 0x7FFF), new Short2(Vector2.One * 0x7FFF) },
+               { new Short4(Vector4.One * 0x7FFF), new Short4(Vector4.One * 0x7FFF) },
+           };
+
+        [Theory]
+        [MemberData("EqualityData")]
+        public void EqualsOperator(object first, object second)
+        {
+            // Act
+            var equal = first.Equals(second);
+
+            // Assert
+            Assert.True(equal);
+        }
+
+    }
+}

--- a/tests/ImageSharp.Tests/Colors/ColorEqualityTests.cs
+++ b/tests/ImageSharp.Tests/Colors/ColorEqualityTests.cs
@@ -36,9 +36,56 @@ namespace ImageSharp.Tests.Colors
                { new Short4(Vector4.One * 0x7FFF), new Short4(Vector4.One * 0x7FFF) },
            };
 
+        public static readonly TheoryData<object, object> NotEqualityData =
+           new TheoryData<object, object>()
+           {
+                // Valid object against null
+                { new Alpha8(.5F), null },
+                { new Argb(Vector4.One), null },
+                { new Bgr565(Vector3.One), null },
+                { new Bgra4444(Vector4.One), null },
+                { new Bgra5551(Vector4.One), null },
+                { new Byte4(Vector4.One * 255), null },
+                { new HalfSingle(-1F), null },
+                { new HalfVector2(0.1f, -0.3f), null },
+                { new HalfVector4(Vector4.One), null },
+                { new NormalizedByte2(-Vector2.One), null },
+                { new NormalizedByte4(Vector4.One), null },
+                { new NormalizedShort2(Vector2.One), null },
+                { new NormalizedShort4(Vector4.One), null },
+                { new Rg32(Vector2.One), null },
+                { new Rgba1010102(Vector4.One), null },
+                { new Rgba64(Vector4.One), null },
+                { new Short2(Vector2.One * 0x7FFF), null },
+                { new Short4(Vector4.One * 0x7FFF), null },
+
+                // Valid objects of the same type but not equal
+                { new Alpha8(.5F), new Alpha8(.8F) },
+                { new Argb(Vector4.One), new Argb(Vector4.Zero) },
+                { new Bgr565(Vector3.One), new Bgr565(Vector3.Zero) },
+                { new Bgra4444(Vector4.One), new Bgra4444(Vector4.Zero) },
+                { new Bgra5551(Vector4.One), new Bgra5551(Vector4.Zero) },
+                { new Byte4(Vector4.One * 255), new Byte4(Vector4.Zero * 255) },
+                { new HalfSingle(-1F), new HalfSingle(1F) },
+                { new HalfVector2(0.1f, -0.3f), new HalfVector2(0.1f, 0.3f) },
+                { new HalfVector4(Vector4.One), new HalfVector4(Vector4.Zero) },
+                { new NormalizedByte2(-Vector2.One), new NormalizedByte2(-Vector2.Zero) },
+                { new NormalizedByte4(Vector4.One), new NormalizedByte4(Vector4.Zero) },
+                { new NormalizedShort2(Vector2.One), new NormalizedShort2(Vector2.Zero) },
+                { new NormalizedShort4(Vector4.One), new NormalizedShort4(Vector4.Zero) },
+                { new Rg32(Vector2.One), new Rg32(Vector2.Zero) },
+                { new Rgba1010102(Vector4.One), new Rgba1010102(Vector4.Zero) },
+                { new Rgba64(Vector4.One), new Rgba64(Vector4.Zero) },
+                { new Short2(Vector2.One * 0x7FFF), new Short2(Vector2.Zero * 0x7FFF) },
+                { new Short4(Vector4.One * 0x7FFF), new Short4(Vector4.Zero * 0x7FFF) },
+
+                // Valid objects of different type
+                { new Alpha8(.5F), new Argb(Vector4.Zero) },
+           };
+
         [Theory]
         [MemberData("EqualityData")]
-        public void EqualsOperator(object first, object second)
+        public void Equality(object first, object second)
         {
             // Act
             var equal = first.Equals(second);
@@ -47,5 +94,15 @@ namespace ImageSharp.Tests.Colors
             Assert.True(equal);
         }
 
+        [Theory]
+        [MemberData("NotEqualityData")]
+        public void NotEquality(object first, object second)
+        {
+            // Act
+            var equal = first.Equals(second);
+
+            // Assert
+            Assert.False(equal);
+        }
     }
 }


### PR DESCRIPTION
I added unit tests for:
- Equals
- Not equals
- HashCode equals
- HashCode not equals 

Found some strange behaviour on HashCode when two colours of the same type and seemingly different initialization values (and Vector4 values) seem to have the same hash code. See `NotEqualityDataDifferentObjects`  and lines with `// same hashcode??` comment.