### PR TITLE
Refactoring Epsilon const value to remove duplication.

### DIFF
--- a/src/ImageSharp/Colors/ColorspaceTransforms.cs
+++ b/src/ImageSharp/Colors/ColorspaceTransforms.cs
@@ -8,7 +8,6 @@ namespace ImageSharp
     using System;
     using System.Numerics;
     using Colors.Spaces;
-    using Common;
 
     /// <summary>
     /// Packed vector type containing four 8-bit unsigned normalized values ranging from 0 to 255.

--- a/src/ImageSharp/Colors/ColorspaceTransforms.cs
+++ b/src/ImageSharp/Colors/ColorspaceTransforms.cs
@@ -8,6 +8,7 @@ namespace ImageSharp
     using System;
     using System.Numerics;
     using Colors.Spaces;
+    using Common;
 
     /// <summary>
     /// Packed vector type containing four 8-bit unsigned normalized values ranging from 0 to 255.
@@ -19,11 +20,6 @@ namespace ImageSharp
     /// </remarks>
     public partial struct Color
     {
-        /// <summary>
-        /// The epsilon for comparing floating point numbers.
-        /// </summary>
-        private const float Epsilon = 0.001F;
-
         /// <summary>
         /// Allows the implicit conversion of an instance of <see cref="Color"/> to a
         /// <see cref="Bgra32"/>.
@@ -110,12 +106,12 @@ namespace ImageSharp
             float s = color.S;
             float v = color.V;
 
-            if (Math.Abs(s) < Epsilon)
+            if (Math.Abs(s) < Constants.Epsilon)
             {
                 return new Color(v, v, v, 1);
             }
 
-            float h = (Math.Abs(color.H - 360) < Epsilon) ? 0 : color.H / 60;
+            float h = (Math.Abs(color.H - 360) < Constants.Epsilon) ? 0 : color.H / 60;
             int i = (int)Math.Truncate(h);
             float f = h - i;
 
@@ -183,9 +179,9 @@ namespace ImageSharp
             float s = color.S;
             float l = color.L;
 
-            if (Math.Abs(l) > Epsilon)
+            if (Math.Abs(l) > Constants.Epsilon)
             {
-                if (Math.Abs(s) < Epsilon)
+                if (Math.Abs(s) < Constants.Epsilon)
                 {
                     r = g = b = l;
                 }

--- a/src/ImageSharp/Colors/Spaces/CieLab.cs
+++ b/src/ImageSharp/Colors/Spaces/CieLab.cs
@@ -8,7 +8,6 @@ namespace ImageSharp.Colors.Spaces
     using System;
     using System.ComponentModel;
     using System.Numerics;
-    using Common;
 
     /// <summary>
     /// Represents an CIE LAB 1976 color.

--- a/src/ImageSharp/Colors/Spaces/CieLab.cs
+++ b/src/ImageSharp/Colors/Spaces/CieLab.cs
@@ -8,6 +8,7 @@ namespace ImageSharp.Colors.Spaces
     using System;
     using System.ComponentModel;
     using System.Numerics;
+    using Common;
 
     /// <summary>
     /// Represents an CIE LAB 1976 color.
@@ -19,11 +20,6 @@ namespace ImageSharp.Colors.Spaces
         /// Represents a <see cref="CieLab"/> that has L, A, B values set to zero.
         /// </summary>
         public static readonly CieLab Empty = default(CieLab);
-
-        /// <summary>
-        /// The epsilon for comparing floating point numbers.
-        /// </summary>
-        private const float Epsilon = 0.001f;
 
         /// <summary>
         /// The backing vector for SIMD support.
@@ -166,7 +162,7 @@ namespace ImageSharp.Colors.Spaces
         /// <inheritdoc/>
         public bool Equals(CieLab other)
         {
-            return this.AlmostEquals(other, Epsilon);
+            return this.AlmostEquals(other, Constants.Epsilon);
         }
 
         /// <inheritdoc/>

--- a/src/ImageSharp/Colors/Spaces/CieXyz.cs
+++ b/src/ImageSharp/Colors/Spaces/CieXyz.cs
@@ -8,6 +8,7 @@ namespace ImageSharp.Colors.Spaces
     using System;
     using System.ComponentModel;
     using System.Numerics;
+    using Common;
 
     /// <summary>
     /// Represents an CIE 1931 color
@@ -19,11 +20,6 @@ namespace ImageSharp.Colors.Spaces
         /// Represents a <see cref="CieXyz"/> that has Y, Cb, and Cr values set to zero.
         /// </summary>
         public static readonly CieXyz Empty = default(CieXyz);
-
-        /// <summary>
-        /// The epsilon for comparing floating point numbers.
-        /// </summary>
-        private const float Epsilon = 0.001f;
 
         /// <summary>
         /// The backing vector for SIMD support.
@@ -157,7 +153,7 @@ namespace ImageSharp.Colors.Spaces
         /// <inheritdoc/>
         public bool Equals(CieXyz other)
         {
-            return this.AlmostEquals(other, Epsilon);
+            return this.AlmostEquals(other, Constants.Epsilon);
         }
 
         /// <inheritdoc/>

--- a/src/ImageSharp/Colors/Spaces/CieXyz.cs
+++ b/src/ImageSharp/Colors/Spaces/CieXyz.cs
@@ -8,7 +8,6 @@ namespace ImageSharp.Colors.Spaces
     using System;
     using System.ComponentModel;
     using System.Numerics;
-    using Common;
 
     /// <summary>
     /// Represents an CIE 1931 color

--- a/src/ImageSharp/Colors/Spaces/Cmyk.cs
+++ b/src/ImageSharp/Colors/Spaces/Cmyk.cs
@@ -8,6 +8,7 @@ namespace ImageSharp.Colors.Spaces
     using System;
     using System.ComponentModel;
     using System.Numerics;
+    using Common;
 
     /// <summary>
     /// Represents an CMYK (cyan, magenta, yellow, keyline) color.
@@ -18,11 +19,6 @@ namespace ImageSharp.Colors.Spaces
         /// Represents a <see cref="Cmyk"/> that has C, M, Y, and K values set to zero.
         /// </summary>
         public static readonly Cmyk Empty = default(Cmyk);
-
-        /// <summary>
-        /// The epsilon for comparing floating point numbers.
-        /// </summary>
-        private const float Epsilon = 0.001f;
 
         /// <summary>
         /// The backing vector for SIMD support.
@@ -90,7 +86,7 @@ namespace ImageSharp.Colors.Spaces
 
             float k = Math.Min(c, Math.Min(m, y));
 
-            if (Math.Abs(k - 1.0f) <= Epsilon)
+            if (Math.Abs(k - 1.0f) <= Constants.Epsilon)
             {
                 return new Cmyk(0, 0, 0, 1);
             }
@@ -167,7 +163,7 @@ namespace ImageSharp.Colors.Spaces
         /// <inheritdoc/>
         public bool Equals(Cmyk other)
         {
-            return this.AlmostEquals(other, Epsilon);
+            return this.AlmostEquals(other, Constants.Epsilon);
         }
 
         /// <inheritdoc/>

--- a/src/ImageSharp/Colors/Spaces/Cmyk.cs
+++ b/src/ImageSharp/Colors/Spaces/Cmyk.cs
@@ -8,7 +8,6 @@ namespace ImageSharp.Colors.Spaces
     using System;
     using System.ComponentModel;
     using System.Numerics;
-    using Common;
 
     /// <summary>
     /// Represents an CMYK (cyan, magenta, yellow, keyline) color.

--- a/src/ImageSharp/Colors/Spaces/Hsl.cs
+++ b/src/ImageSharp/Colors/Spaces/Hsl.cs
@@ -8,6 +8,7 @@ namespace ImageSharp.Colors.Spaces
     using System;
     using System.ComponentModel;
     using System.Numerics;
+    using Common;
 
     /// <summary>
     /// Represents a Hsl (hue, saturation, lightness) color.
@@ -18,11 +19,6 @@ namespace ImageSharp.Colors.Spaces
         /// Represents a <see cref="Hsl"/> that has H, S, and L values set to zero.
         /// </summary>
         public static readonly Hsl Empty = default(Hsl);
-
-        /// <summary>
-        /// The epsilon for comparing floating point numbers.
-        /// </summary>
-        private const float Epsilon = 0.001F;
 
         /// <summary>
         /// The backing vector for SIMD support.
@@ -85,20 +81,20 @@ namespace ImageSharp.Colors.Spaces
             float s = 0;
             float l = (max + min) / 2;
 
-            if (Math.Abs(chroma) < Epsilon)
+            if (Math.Abs(chroma) < Constants.Epsilon)
             {
                 return new Hsl(0, s, l);
             }
 
-            if (Math.Abs(r - max) < Epsilon)
+            if (Math.Abs(r - max) < Constants.Epsilon)
             {
                 h = (g - b) / chroma;
             }
-            else if (Math.Abs(g - max) < Epsilon)
+            else if (Math.Abs(g - max) < Constants.Epsilon)
             {
                 h = 2 + ((b - r) / chroma);
             }
-            else if (Math.Abs(b - max) < Epsilon)
+            else if (Math.Abs(b - max) < Constants.Epsilon)
             {
                 h = 4 + ((r - g) / chroma);
             }
@@ -186,7 +182,7 @@ namespace ImageSharp.Colors.Spaces
         /// <inheritdoc/>
         public bool Equals(Hsl other)
         {
-            return this.AlmostEquals(other, Epsilon);
+            return this.AlmostEquals(other, Constants.Epsilon);
         }
 
         /// <inheritdoc/>

--- a/src/ImageSharp/Colors/Spaces/Hsl.cs
+++ b/src/ImageSharp/Colors/Spaces/Hsl.cs
@@ -8,7 +8,6 @@ namespace ImageSharp.Colors.Spaces
     using System;
     using System.ComponentModel;
     using System.Numerics;
-    using Common;
 
     /// <summary>
     /// Represents a Hsl (hue, saturation, lightness) color.

--- a/src/ImageSharp/Colors/Spaces/Hsv.cs
+++ b/src/ImageSharp/Colors/Spaces/Hsv.cs
@@ -8,7 +8,6 @@ namespace ImageSharp.Colors.Spaces
     using System;
     using System.ComponentModel;
     using System.Numerics;
-    using Common;
 
     /// <summary>
     /// Represents a HSV (hue, saturation, value) color. Also known as HSB (hue, saturation, brightness).

--- a/src/ImageSharp/Colors/Spaces/Hsv.cs
+++ b/src/ImageSharp/Colors/Spaces/Hsv.cs
@@ -8,6 +8,7 @@ namespace ImageSharp.Colors.Spaces
     using System;
     using System.ComponentModel;
     using System.Numerics;
+    using Common;
 
     /// <summary>
     /// Represents a HSV (hue, saturation, value) color. Also known as HSB (hue, saturation, brightness).
@@ -18,11 +19,6 @@ namespace ImageSharp.Colors.Spaces
         /// Represents a <see cref="Hsv"/> that has H, S, and V values set to zero.
         /// </summary>
         public static readonly Hsv Empty = default(Hsv);
-
-        /// <summary>
-        /// The epsilon for comparing floating point numbers.
-        /// </summary>
-        private const float Epsilon = 0.001F;
 
         /// <summary>
         /// The backing vector for SIMD support.
@@ -85,20 +81,20 @@ namespace ImageSharp.Colors.Spaces
             float s = 0;
             float v = max;
 
-            if (Math.Abs(chroma) < Epsilon)
+            if (Math.Abs(chroma) < Constants.Epsilon)
             {
                 return new Hsv(0, s, v);
             }
 
-            if (Math.Abs(r - max) < Epsilon)
+            if (Math.Abs(r - max) < Constants.Epsilon)
             {
                 h = (g - b) / chroma;
             }
-            else if (Math.Abs(g - max) < Epsilon)
+            else if (Math.Abs(g - max) < Constants.Epsilon)
             {
                 h = 2 + ((b - r) / chroma);
             }
-            else if (Math.Abs(b - max) < Epsilon)
+            else if (Math.Abs(b - max) < Constants.Epsilon)
             {
                 h = 4 + ((r - g) / chroma);
             }
@@ -179,7 +175,7 @@ namespace ImageSharp.Colors.Spaces
         /// <inheritdoc/>
         public bool Equals(Hsv other)
         {
-            return this.AlmostEquals(other, Epsilon);
+            return this.AlmostEquals(other, Constants.Epsilon);
         }
 
         /// <inheritdoc/>

--- a/src/ImageSharp/Colors/Vector4BlendTransforms.cs
+++ b/src/ImageSharp/Colors/Vector4BlendTransforms.cs
@@ -7,7 +7,6 @@ namespace ImageSharp
 {
     using System;
     using System.Numerics;
-    using Common;
 
     /// <summary>
     /// Transform algorithms that match the equations defined in the W3C Compositing and Blending Level 1 specification.

--- a/src/ImageSharp/Colors/Vector4BlendTransforms.cs
+++ b/src/ImageSharp/Colors/Vector4BlendTransforms.cs
@@ -7,6 +7,7 @@ namespace ImageSharp
 {
     using System;
     using System.Numerics;
+    using Common;
 
     /// <summary>
     /// Transform algorithms that match the equations defined in the W3C Compositing and Blending Level 1 specification.
@@ -14,11 +15,6 @@ namespace ImageSharp
     /// </summary>
     public class Vector4BlendTransforms
     {
-        /// <summary>
-        /// The epsilon for comparing floating point numbers.
-        /// </summary>
-        private const float Epsilon = 0.0001F;
-
         /// <summary>
         /// The blending formula simply selects the source vector.
         /// </summary>
@@ -203,13 +199,13 @@ namespace ImageSharp
             amount = amount.Clamp(0, 1);
 
             // Santize on zero alpha
-            if (Math.Abs(backdrop.W) < Epsilon)
+            if (Math.Abs(backdrop.W) < Constants.Epsilon)
             {
                 source.W *= amount;
                 return source;
             }
 
-            if (Math.Abs(source.W) < Epsilon)
+            if (Math.Abs(source.W) < Constants.Epsilon)
             {
                 return backdrop;
             }
@@ -266,7 +262,7 @@ namespace ImageSharp
         /// </returns>
         private static float BlendDodge(float b, float s)
         {
-            return Math.Abs(s - 1F) < Epsilon ? s : Math.Min(b / (1F - s), 1F);
+            return Math.Abs(s - 1F) < Constants.Epsilon ? s : Math.Min(b / (1F - s), 1F);
         }
 
         /// <summary>
@@ -279,7 +275,7 @@ namespace ImageSharp
         /// </returns>
         private static float BlendBurn(float b, float s)
         {
-            return Math.Abs(s) < Epsilon ? s : Math.Max(1F - ((1F - b) / s), 0F);
+            return Math.Abs(s) < Constants.Epsilon ? s : Math.Max(1F - ((1F - b) / s), 0F);
         }
 
         /// <summary>

--- a/src/ImageSharp/Common/CommonConstants.cs
+++ b/src/ImageSharp/Common/CommonConstants.cs
@@ -1,0 +1,18 @@
+﻿// <copyright file="CommonConstants.cs" company="James Jackson-South">
+// Copyright (c) James Jackson-South and contributors.
+// Licensed under the Apache License, Version 2.0.
+// </copyright>
+
+namespace ImageSharp.Common
+{
+    /// <summary>
+    /// Common constants used throughout the project
+    /// </summary>
+    public static class CommonConstants
+    {
+        /// <summary>
+        /// The epsilon for comparing floating point numbers.
+        /// </summary>
+        public static readonly float Epsilon = 0.001f;
+    }
+}

--- a/src/ImageSharp/Common/Constants.cs
+++ b/src/ImageSharp/Common/Constants.cs
@@ -3,7 +3,7 @@
 // Licensed under the Apache License, Version 2.0.
 // </copyright>
 
-namespace ImageSharp.Common
+namespace ImageSharp
 {
     /// <summary>
     /// Common constants used throughout the project

--- a/src/ImageSharp/Common/Constants.cs
+++ b/src/ImageSharp/Common/Constants.cs
@@ -8,7 +8,7 @@ namespace ImageSharp.Common
     /// <summary>
     /// Common constants used throughout the project
     /// </summary>
-    public static class Constants
+    internal static class Constants
     {
         /// <summary>
         /// The epsilon for comparing floating point numbers.

--- a/src/ImageSharp/Common/Constants.cs
+++ b/src/ImageSharp/Common/Constants.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="CommonConstants.cs" company="James Jackson-South">
+﻿// <copyright file="Constants.cs" company="James Jackson-South">
 // Copyright (c) James Jackson-South and contributors.
 // Licensed under the Apache License, Version 2.0.
 // </copyright>
@@ -8,7 +8,7 @@ namespace ImageSharp.Common
     /// <summary>
     /// Common constants used throughout the project
     /// </summary>
-    public static class CommonConstants
+    public static class Constants
     {
         /// <summary>
         /// The epsilon for comparing floating point numbers.

--- a/src/ImageSharp/Common/Helpers/ImageMaths.cs
+++ b/src/ImageSharp/Common/Helpers/ImageMaths.cs
@@ -8,7 +8,6 @@ namespace ImageSharp
     using System;
     using System.Linq;
     using System.Numerics;
-    using Common;
 
     /// <summary>
     /// Provides common mathematical methods.

--- a/src/ImageSharp/Common/Helpers/ImageMaths.cs
+++ b/src/ImageSharp/Common/Helpers/ImageMaths.cs
@@ -8,6 +8,7 @@ namespace ImageSharp
     using System;
     using System.Linq;
     using System.Numerics;
+    using Common;
 
     /// <summary>
     /// Provides common mathematical methods.
@@ -91,9 +92,7 @@ namespace ImageSharp
         /// </returns>
         public static float SinC(float x)
         {
-            const float Epsilon = .00001F;
-
-            if (Math.Abs(x) > Epsilon)
+            if (Math.Abs(x) > Constants.Epsilon)
             {
                 x *= (float)Math.PI;
                 return Clean((float)Math.Sin(x) / x);
@@ -166,7 +165,6 @@ namespace ImageSharp
         public static Rectangle GetFilteredBoundingRectangle<TColor>(ImageBase<TColor> bitmap, float componentValue, RgbaComponent channel = RgbaComponent.B)
             where TColor : struct, IPackedPixel, IEquatable<TColor>
         {
-            const float Epsilon = .00001f;
             int width = bitmap.Width;
             int height = bitmap.Height;
             Point topLeft = default(Point);
@@ -178,19 +176,19 @@ namespace ImageSharp
             switch (channel)
             {
                 case RgbaComponent.R:
-                    delegateFunc = (pixels, x, y, b) => Math.Abs(pixels[x, y].ToVector4().X - b) > Epsilon;
+                    delegateFunc = (pixels, x, y, b) => Math.Abs(pixels[x, y].ToVector4().X - b) > Constants.Epsilon;
                     break;
 
                 case RgbaComponent.G:
-                    delegateFunc = (pixels, x, y, b) => Math.Abs(pixels[x, y].ToVector4().Y - b) > Epsilon;
+                    delegateFunc = (pixels, x, y, b) => Math.Abs(pixels[x, y].ToVector4().Y - b) > Constants.Epsilon;
                     break;
 
                 case RgbaComponent.B:
-                    delegateFunc = (pixels, x, y, b) => Math.Abs(pixels[x, y].ToVector4().Z - b) > Epsilon;
+                    delegateFunc = (pixels, x, y, b) => Math.Abs(pixels[x, y].ToVector4().Z - b) > Constants.Epsilon;
                     break;
 
                 default:
-                    delegateFunc = (pixels, x, y, b) => Math.Abs(pixels[x, y].ToVector4().W - b) > Epsilon;
+                    delegateFunc = (pixels, x, y, b) => Math.Abs(pixels[x, y].ToVector4().W - b) > Constants.Epsilon;
                     break;
             }
 
@@ -278,9 +276,7 @@ namespace ImageSharp
         /// </returns>.
         private static float Clean(float x)
         {
-            const float Epsilon = .00001F;
-
-            if (Math.Abs(x) < Epsilon)
+            if (Math.Abs(x) < Constants.Epsilon)
             {
                 return 0F;
             }

--- a/src/ImageSharp/Drawing/Processors/DrawPathProcessor.cs
+++ b/src/ImageSharp/Drawing/Processors/DrawPathProcessor.cs
@@ -9,7 +9,6 @@ namespace ImageSharp.Drawing.Processors
     using System.Linq;
     using System.Numerics;
     using System.Threading.Tasks;
-    using Common;
     using ImageSharp.Processors;
     using Paths;
     using Pens;

--- a/src/ImageSharp/Drawing/Processors/DrawPathProcessor.cs
+++ b/src/ImageSharp/Drawing/Processors/DrawPathProcessor.cs
@@ -9,7 +9,7 @@ namespace ImageSharp.Drawing.Processors
     using System.Linq;
     using System.Numerics;
     using System.Threading.Tasks;
-
+    using Common;
     using ImageSharp.Processors;
     using Paths;
     using Pens;
@@ -27,7 +27,6 @@ namespace ImageSharp.Drawing.Processors
     {
         private const float AntialiasFactor = 1f;
         private const int PaddingFactor = 1; // needs to been the same or greater than AntialiasFactor
-        private const float Epsilon = 0.001f;
 
         private readonly IPen<TColor> pen;
         private readonly IPath[] paths;
@@ -138,7 +137,7 @@ namespace ImageSharp.Drawing.Processors
 
                         var opacity = this.Opacity(color.DistanceFromElement);
 
-                        if (opacity > Epsilon)
+                        if (opacity > Constants.Epsilon)
                         {
                             int offsetColorX = x - minX;
 

--- a/src/ImageSharp/Drawing/Processors/FillShapeProcessor.cs
+++ b/src/ImageSharp/Drawing/Processors/FillShapeProcessor.cs
@@ -8,6 +8,7 @@ namespace ImageSharp.Drawing.Processors
     using System;
     using System.Numerics;
     using System.Threading.Tasks;
+    using Common;
     using Drawing;
     using ImageSharp.Processors;
     using Shapes;
@@ -21,8 +22,6 @@ namespace ImageSharp.Drawing.Processors
     public class FillShapeProcessor<TColor> : ImageFilteringProcessor<TColor>
         where TColor : struct, IPackedPixel, IEquatable<TColor>
     {
-        private const float Epsilon = 0.001f;
-
         private const float AntialiasFactor = 1f;
         private const int DrawPadding = 1;
         private readonly IBrush<TColor> fillColor;
@@ -95,7 +94,7 @@ namespace ImageSharp.Drawing.Processors
                         float dist = this.poly.Distance(currentPoint);
                         float opacity = this.Opacity(dist);
 
-                        if (opacity > Epsilon)
+                        if (opacity > Constants.Epsilon)
                         {
                             Vector4 backgroundVector = sourcePixels[offsetX, offsetY].ToVector4();
                             Vector4 sourceVector = applicator.GetColor(currentPoint).ToVector4();

--- a/src/ImageSharp/Drawing/Processors/FillShapeProcessor.cs
+++ b/src/ImageSharp/Drawing/Processors/FillShapeProcessor.cs
@@ -8,7 +8,6 @@ namespace ImageSharp.Drawing.Processors
     using System;
     using System.Numerics;
     using System.Threading.Tasks;
-    using Common;
     using Drawing;
     using ImageSharp.Processors;
     using Shapes;

--- a/src/ImageSharp/Filters/Processors/Effects/BackgroundColorProcessor.cs
+++ b/src/ImageSharp/Filters/Processors/Effects/BackgroundColorProcessor.cs
@@ -8,6 +8,7 @@ namespace ImageSharp.Processors
     using System;
     using System.Numerics;
     using System.Threading.Tasks;
+    using Common;
 
     /// <summary>
     /// Sets the background color of the image.
@@ -16,11 +17,6 @@ namespace ImageSharp.Processors
     public class BackgroundColorProcessor<TColor> : ImageFilteringProcessor<TColor>
         where TColor : struct, IPackedPixel, IEquatable<TColor>
     {
-        /// <summary>
-        /// The epsilon for comparing floating point numbers.
-        /// </summary>
-        private const float Epsilon = 0.001f;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="BackgroundColorProcessor{TColor}"/> class.
         /// </summary>
@@ -82,7 +78,7 @@ namespace ImageSharp.Processors
                                 color = Vector4BlendTransforms.PremultipliedLerp(backgroundColor, color, .5F);
                             }
 
-                            if (Math.Abs(a) < Epsilon)
+                            if (Math.Abs(a) < Constants.Epsilon)
                             {
                                 color = backgroundColor;
                             }

--- a/src/ImageSharp/Filters/Processors/Effects/BackgroundColorProcessor.cs
+++ b/src/ImageSharp/Filters/Processors/Effects/BackgroundColorProcessor.cs
@@ -8,7 +8,6 @@ namespace ImageSharp.Processors
     using System;
     using System.Numerics;
     using System.Threading.Tasks;
-    using Common;
 
     /// <summary>
     /// Sets the background color of the image.

--- a/src/ImageSharp/Filters/Processors/Transforms/RotateProcessor.cs
+++ b/src/ImageSharp/Filters/Processors/Transforms/RotateProcessor.cs
@@ -8,6 +8,7 @@ namespace ImageSharp.Processors
     using System;
     using System.Numerics;
     using System.Threading.Tasks;
+    using Common;
 
     /// <summary>
     /// Provides methods that allow the rotating of images.
@@ -70,9 +71,7 @@ namespace ImageSharp.Processors
         /// <inheritdoc/>
         protected override void BeforeApply(ImageBase<TColor> source, Rectangle sourceRectangle)
         {
-            const float Epsilon = .0001F;
-
-            if (Math.Abs(this.Angle) < Epsilon || Math.Abs(this.Angle - 90) < Epsilon || Math.Abs(this.Angle - 180) < Epsilon || Math.Abs(this.Angle - 270) < Epsilon)
+            if (Math.Abs(this.Angle) < Constants.Epsilon || Math.Abs(this.Angle - 90) < Constants.Epsilon || Math.Abs(this.Angle - 180) < Constants.Epsilon || Math.Abs(this.Angle - 270) < Constants.Epsilon)
             {
                 return;
             }
@@ -91,26 +90,25 @@ namespace ImageSharp.Processors
         /// <returns>The <see cref="bool"/></returns>
         private bool OptimizedApply(ImageBase<TColor> source)
         {
-            const float Epsilon = .0001F;
-            if (Math.Abs(this.Angle) < Epsilon)
+            if (Math.Abs(this.Angle) < Constants.Epsilon)
             {
                 // No need to do anything so return.
                 return true;
             }
 
-            if (Math.Abs(this.Angle - 90) < Epsilon)
+            if (Math.Abs(this.Angle - 90) < Constants.Epsilon)
             {
                 this.Rotate90(source);
                 return true;
             }
 
-            if (Math.Abs(this.Angle - 180) < Epsilon)
+            if (Math.Abs(this.Angle - 180) < Constants.Epsilon)
             {
                 this.Rotate180(source);
                 return true;
             }
 
-            if (Math.Abs(this.Angle - 270) < Epsilon)
+            if (Math.Abs(this.Angle - 270) < Constants.Epsilon)
             {
                 this.Rotate270(source);
                 return true;

--- a/src/ImageSharp/Filters/Processors/Transforms/RotateProcessor.cs
+++ b/src/ImageSharp/Filters/Processors/Transforms/RotateProcessor.cs
@@ -8,7 +8,6 @@ namespace ImageSharp.Processors
     using System;
     using System.Numerics;
     using System.Threading.Tasks;
-    using Common;
 
     /// <summary>
     /// Provides methods that allow the rotating of images.

--- a/src/ImageSharp/Quantizers/Wu/WuQuantizer.cs
+++ b/src/ImageSharp/Quantizers/Wu/WuQuantizer.cs
@@ -9,6 +9,7 @@ namespace ImageSharp.Quantizers
     using System.Buffers;
     using System.Numerics;
     using System.Threading.Tasks;
+    using Common;
 
     /// <summary>
     /// An implementation of Wu's color quantizer with alpha channel.
@@ -33,11 +34,6 @@ namespace ImageSharp.Quantizers
     public sealed class WuQuantizer<TColor> : IQuantizer<TColor>
         where TColor : struct, IPackedPixel, IEquatable<TColor>
     {
-        /// <summary>
-        /// The epsilon for comparing floating point numbers.
-        /// </summary>
-        private const float Epsilon = 1e-5F;
-
         /// <summary>
         /// The index bits.
         /// </summary>
@@ -542,7 +538,7 @@ namespace ImageSharp.Quantizers
 
                 double temp;
 
-                if (Math.Abs(halfW) < Epsilon)
+                if (Math.Abs(halfW) < Constants.Epsilon)
                 {
                     continue;
                 }
@@ -555,7 +551,7 @@ namespace ImageSharp.Quantizers
                 halfA = wholeA - halfA;
                 halfW = wholeW - halfW;
 
-                if (Math.Abs(halfW) < Epsilon)
+                if (Math.Abs(halfW) < Constants.Epsilon)
                 {
                     continue;
                 }
@@ -762,7 +758,7 @@ namespace ImageSharp.Quantizers
 
                 double weight = Volume(cube[k], this.vwt);
 
-                if (Math.Abs(weight) > Epsilon)
+                if (Math.Abs(weight) > Constants.Epsilon)
                 {
                     float r = (float)(Volume(cube[k], this.vmr) / weight);
                     float g = (float)(Volume(cube[k], this.vmg) / weight);

--- a/src/ImageSharp/Quantizers/Wu/WuQuantizer.cs
+++ b/src/ImageSharp/Quantizers/Wu/WuQuantizer.cs
@@ -9,7 +9,6 @@ namespace ImageSharp.Quantizers
     using System.Buffers;
     using System.Numerics;
     using System.Threading.Tasks;
-    using Common;
 
     /// <summary>
     /// An implementation of Wu's color quantizer with alpha channel.

--- a/tests/ImageSharp.Tests/Common/ConstantsTests.cs
+++ b/tests/ImageSharp.Tests/Common/ConstantsTests.cs
@@ -1,0 +1,19 @@
+﻿// <copyright file="ConstantsTests.cs" company="James Jackson-South">
+// Copyright (c) James Jackson-South and contributors.
+// Licensed under the Apache License, Version 2.0.
+// </copyright>
+
+namespace ImageSharp.Tests.Common
+{
+    using ImageSharp.Common;
+    using Xunit;
+
+    public class ConstantsTests
+    {
+        [Fact]
+        public void Epsilon()
+        {
+            Assert.Equal(Constants.Epsilon, 0.001f);
+        }
+    }
+}

--- a/tests/ImageSharp.Tests/Common/ConstantsTests.cs
+++ b/tests/ImageSharp.Tests/Common/ConstantsTests.cs
@@ -5,7 +5,6 @@
 
 namespace ImageSharp.Tests.Common
 {
-    using ImageSharp.Common;
     using Xunit;
 
     public class ConstantsTests


### PR DESCRIPTION
I noticed we had a bunch of `private const float Epsilon = 0.001F;` duplicated throughout the code, and I see no reason why that shouldn't be in a common place.

I put it in the `Common` namespace, not sure how you feel about that. I fixed ColorSpaces and Transforms to use it, but there are a few more which I can fix if you guys think this is worth doing 😄 

Also added a test to protect the value, if that is accidentally changed we could be in quite some trouble.