### PR TITLE
Replace ToBytes()

### DIFF
--- a/src/ImageSharp/Colors/Color.cs
+++ b/src/ImageSharp/Colors/Color.cs
@@ -273,35 +273,37 @@ namespace ImageSharp
         }
 
         /// <inheritdoc/>
-        public void ToBytes(byte[] bytes, int startIndex, ComponentOrder componentOrder)
+        public void ToXyzBytes(byte[] bytes, int startIndex)
         {
-            switch (componentOrder)
-            {
-                case ComponentOrder.ZYX:
-                    bytes[startIndex] = this.B;
-                    bytes[startIndex + 1] = this.G;
-                    bytes[startIndex + 2] = this.R;
-                    break;
-                case ComponentOrder.ZYXW:
-                    bytes[startIndex] = this.B;
-                    bytes[startIndex + 1] = this.G;
-                    bytes[startIndex + 2] = this.R;
-                    bytes[startIndex + 3] = this.A;
-                    break;
-                case ComponentOrder.XYZ:
-                    bytes[startIndex] = this.R;
-                    bytes[startIndex + 1] = this.G;
-                    bytes[startIndex + 2] = this.B;
-                    break;
-                case ComponentOrder.XYZW:
-                    bytes[startIndex] = this.R;
-                    bytes[startIndex + 1] = this.G;
-                    bytes[startIndex + 2] = this.B;
-                    bytes[startIndex + 3] = this.A;
-                    break;
-                default:
-                    throw new NotSupportedException();
-            }
+            bytes[startIndex] = this.R;
+            bytes[startIndex + 1] = this.G;
+            bytes[startIndex + 2] = this.B;
+        }
+
+        /// <inheritdoc/>
+        public void ToXyzwBytes(byte[] bytes, int startIndex)
+        {
+            bytes[startIndex] = this.R;
+            bytes[startIndex + 1] = this.G;
+            bytes[startIndex + 2] = this.B;
+            bytes[startIndex + 3] = this.A;
+        }
+
+        /// <inheritdoc/>
+        public void ToZyxBytes(byte[] bytes, int startIndex)
+        {
+            bytes[startIndex] = this.B;
+            bytes[startIndex + 1] = this.G;
+            bytes[startIndex + 2] = this.R;
+        }
+
+        /// <inheritdoc/>
+        public void ToZyxwBytes(byte[] bytes, int startIndex)
+        {
+            bytes[startIndex] = this.B;
+            bytes[startIndex + 1] = this.G;
+            bytes[startIndex + 2] = this.R;
+            bytes[startIndex + 3] = this.A;
         }
 
         /// <inheritdoc/>

--- a/src/ImageSharp/Colors/ComponentOrder.cs
+++ b/src/ImageSharp/Colors/ComponentOrder.cs
@@ -13,21 +13,21 @@ namespace ImageSharp
         /// <summary>
         /// Z-> Y-> X order. Equivalent to B-> G-> R in <see cref="Color"/>
         /// </summary>
-        ZYX,
+        Zyx,
 
         /// <summary>
         /// Z-> Y-> X-> W order. Equivalent to B-> G-> R-> A in <see cref="Color"/>
         /// </summary>
-        ZYXW,
+        Zyxw,
 
         /// <summary>
         /// X-> Y-> Z order. Equivalent to R-> G-> B in <see cref="Color"/>
         /// </summary>
-        XYZ,
+        Xyz,
 
         /// <summary>
         /// X-> Y-> Z-> W order. Equivalent to R-> G-> B-> A in <see cref="Color"/>
         /// </summary>
-        XYZW,
+        Xyzw,
     }
 }

--- a/src/ImageSharp/Colors/PackedPixel/Alpha8.cs
+++ b/src/ImageSharp/Colors/PackedPixel/Alpha8.cs
@@ -74,35 +74,37 @@ namespace ImageSharp
         }
 
         /// <inheritdoc />
-        public void ToBytes(byte[] bytes, int startIndex, ComponentOrder componentOrder)
+        public void ToXyzBytes(byte[] bytes, int startIndex)
         {
-            switch (componentOrder)
-            {
-                case ComponentOrder.ZYX:
-                    bytes[startIndex] = 0;
-                    bytes[startIndex + 1] = 0;
-                    bytes[startIndex + 2] = 0;
-                    break;
-                case ComponentOrder.ZYXW:
-                    bytes[startIndex] = 0;
-                    bytes[startIndex + 1] = 0;
-                    bytes[startIndex + 2] = 0;
-                    bytes[startIndex + 3] = this.PackedValue;
-                    break;
-                case ComponentOrder.XYZ:
-                    bytes[startIndex] = 0;
-                    bytes[startIndex + 1] = 0;
-                    bytes[startIndex + 2] = 0;
-                    break;
-                case ComponentOrder.XYZW:
-                    bytes[startIndex] = 0;
-                    bytes[startIndex + 1] = 0;
-                    bytes[startIndex + 2] = 0;
-                    bytes[startIndex + 3] = this.PackedValue;
-                    break;
-                default:
-                    throw new NotSupportedException();
-            }
+            bytes[startIndex] = 0;
+            bytes[startIndex + 1] = 0;
+            bytes[startIndex + 2] = 0;
+        }
+
+        /// <inheritdoc />
+        public void ToXyzwBytes(byte[] bytes, int startIndex)
+        {
+            bytes[startIndex] = 0;
+            bytes[startIndex + 1] = 0;
+            bytes[startIndex + 2] = 0;
+            bytes[startIndex + 3] = this.PackedValue;
+        }
+
+        /// <inheritdoc />
+        public void ToZyxBytes(byte[] bytes, int startIndex)
+        {
+            bytes[startIndex] = 0;
+            bytes[startIndex + 1] = 0;
+            bytes[startIndex + 2] = 0;
+        }
+
+        /// <inheritdoc />
+        public void ToZyxwBytes(byte[] bytes, int startIndex)
+        {
+            bytes[startIndex] = 0;
+            bytes[startIndex + 1] = 0;
+            bytes[startIndex + 2] = 0;
+            bytes[startIndex + 3] = this.PackedValue;
         }
 
         /// <summary>

--- a/src/ImageSharp/Colors/PackedPixel/Argb.cs
+++ b/src/ImageSharp/Colors/PackedPixel/Argb.cs
@@ -220,36 +220,38 @@ namespace ImageSharp
             this.PackedValue = Pack(x, y, z, w);
         }
 
-        /// <inheritdoc/>
-        public void ToBytes(byte[] bytes, int startIndex, ComponentOrder componentOrder)
+        /// <inheritdoc />
+        public void ToXyzBytes(byte[] bytes, int startIndex)
         {
-            switch (componentOrder)
-            {
-                case ComponentOrder.ZYX:
-                    bytes[startIndex] = this.B;
-                    bytes[startIndex + 1] = this.G;
-                    bytes[startIndex + 2] = this.R;
-                    break;
-                case ComponentOrder.ZYXW:
-                    bytes[startIndex] = this.B;
-                    bytes[startIndex + 1] = this.G;
-                    bytes[startIndex + 2] = this.R;
-                    bytes[startIndex + 3] = this.A;
-                    break;
-                case ComponentOrder.XYZ:
-                    bytes[startIndex] = this.R;
-                    bytes[startIndex + 1] = this.G;
-                    bytes[startIndex + 2] = this.B;
-                    break;
-                case ComponentOrder.XYZW:
-                    bytes[startIndex] = this.R;
-                    bytes[startIndex + 1] = this.G;
-                    bytes[startIndex + 2] = this.B;
-                    bytes[startIndex + 3] = this.A;
-                    break;
-                default:
-                    throw new NotSupportedException();
-            }
+            bytes[startIndex] = this.R;
+            bytes[startIndex + 1] = this.G;
+            bytes[startIndex + 2] = this.B;
+        }
+
+        /// <inheritdoc />
+        public void ToXyzwBytes(byte[] bytes, int startIndex)
+        {
+            bytes[startIndex] = this.R;
+            bytes[startIndex + 1] = this.G;
+            bytes[startIndex + 2] = this.B;
+            bytes[startIndex + 3] = this.A;
+        }
+
+        /// <inheritdoc />
+        public void ToZyxBytes(byte[] bytes, int startIndex)
+        {
+            bytes[startIndex] = this.B;
+            bytes[startIndex + 1] = this.G;
+            bytes[startIndex + 2] = this.R;
+        }
+
+        /// <inheritdoc />
+        public void ToZyxwBytes(byte[] bytes, int startIndex)
+        {
+            bytes[startIndex] = this.B;
+            bytes[startIndex + 1] = this.G;
+            bytes[startIndex + 2] = this.R;
+            bytes[startIndex + 3] = this.A;
         }
 
         /// <inheritdoc/>

--- a/src/ImageSharp/Colors/PackedPixel/Bgr565.cs
+++ b/src/ImageSharp/Colors/PackedPixel/Bgr565.cs
@@ -96,37 +96,41 @@ namespace ImageSharp
         }
 
         /// <inheritdoc />
-        public void ToBytes(byte[] bytes, int startIndex, ComponentOrder componentOrder)
+        public void ToXyzBytes(byte[] bytes, int startIndex)
         {
             Vector4 vector = this.ToVector4() * 255F;
+            bytes[startIndex] = (byte)(float)Math.Round(vector.X);
+            bytes[startIndex + 1] = (byte)(float)Math.Round(vector.Y);
+            bytes[startIndex + 2] = (byte)(float)Math.Round(vector.Z);
+        }
 
-            switch (componentOrder)
-            {
-                case ComponentOrder.ZYX:
-                    bytes[startIndex] = (byte)(float)Math.Round(vector.Z);
-                    bytes[startIndex + 1] = (byte)(float)Math.Round(vector.Y);
-                    bytes[startIndex + 2] = (byte)(float)Math.Round(vector.X);
-                    break;
-                case ComponentOrder.ZYXW:
-                    bytes[startIndex] = (byte)(float)Math.Round(vector.Z);
-                    bytes[startIndex + 1] = (byte)(float)Math.Round(vector.Y);
-                    bytes[startIndex + 2] = (byte)(float)Math.Round(vector.X);
-                    bytes[startIndex + 3] = (byte)(float)Math.Round(vector.W);
-                    break;
-                case ComponentOrder.XYZ:
-                    bytes[startIndex] = (byte)(float)Math.Round(vector.X);
-                    bytes[startIndex + 1] = (byte)(float)Math.Round(vector.Y);
-                    bytes[startIndex + 2] = (byte)(float)Math.Round(vector.Z);
-                    break;
-                case ComponentOrder.XYZW:
-                    bytes[startIndex] = (byte)(float)Math.Round(vector.X);
-                    bytes[startIndex + 1] = (byte)(float)Math.Round(vector.Y);
-                    bytes[startIndex + 2] = (byte)(float)Math.Round(vector.Z);
-                    bytes[startIndex + 3] = (byte)(float)Math.Round(vector.W);
-                    break;
-                default:
-                    throw new NotSupportedException();
-            }
+        /// <inheritdoc />
+        public void ToXyzwBytes(byte[] bytes, int startIndex)
+        {
+            Vector4 vector = this.ToVector4() * 255F;
+            bytes[startIndex] = (byte)(float)Math.Round(vector.X);
+            bytes[startIndex + 1] = (byte)(float)Math.Round(vector.Y);
+            bytes[startIndex + 2] = (byte)(float)Math.Round(vector.Z);
+            bytes[startIndex + 3] = (byte)(float)Math.Round(vector.W);
+        }
+
+        /// <inheritdoc />
+        public void ToZyxBytes(byte[] bytes, int startIndex)
+        {
+            Vector4 vector = this.ToVector4() * 255F;
+            bytes[startIndex] = (byte)(float)Math.Round(vector.Z);
+            bytes[startIndex + 1] = (byte)(float)Math.Round(vector.Y);
+            bytes[startIndex + 2] = (byte)(float)Math.Round(vector.X);
+        }
+
+        /// <inheritdoc />
+        public void ToZyxwBytes(byte[] bytes, int startIndex)
+        {
+            Vector4 vector = this.ToVector4() * 255F;
+            bytes[startIndex] = (byte)(float)Math.Round(vector.Z);
+            bytes[startIndex + 1] = (byte)(float)Math.Round(vector.Y);
+            bytes[startIndex + 2] = (byte)(float)Math.Round(vector.X);
+            bytes[startIndex + 3] = (byte)(float)Math.Round(vector.W);
         }
 
         /// <inheritdoc />

--- a/src/ImageSharp/Colors/PackedPixel/Bgra4444.cs
+++ b/src/ImageSharp/Colors/PackedPixel/Bgra4444.cs
@@ -88,37 +88,41 @@ namespace ImageSharp
         }
 
         /// <inheritdoc />
-        public void ToBytes(byte[] bytes, int startIndex, ComponentOrder componentOrder)
+        public void ToXyzBytes(byte[] bytes, int startIndex)
         {
             Vector4 vector = this.ToVector4() * 255F;
+            bytes[startIndex] = (byte)vector.X;
+            bytes[startIndex + 1] = (byte)vector.Y;
+            bytes[startIndex + 2] = (byte)vector.Z;
+        }
 
-            switch (componentOrder)
-            {
-                case ComponentOrder.ZYX:
-                    bytes[startIndex] = (byte)vector.Z;
-                    bytes[startIndex + 1] = (byte)vector.Y;
-                    bytes[startIndex + 2] = (byte)vector.X;
-                    break;
-                case ComponentOrder.ZYXW:
-                    bytes[startIndex] = (byte)vector.Z;
-                    bytes[startIndex + 1] = (byte)vector.Y;
-                    bytes[startIndex + 2] = (byte)vector.X;
-                    bytes[startIndex + 3] = (byte)vector.W;
-                    break;
-                case ComponentOrder.XYZ:
-                    bytes[startIndex] = (byte)vector.X;
-                    bytes[startIndex + 1] = (byte)vector.Y;
-                    bytes[startIndex + 2] = (byte)vector.Z;
-                    break;
-                case ComponentOrder.XYZW:
-                    bytes[startIndex] = (byte)vector.X;
-                    bytes[startIndex + 1] = (byte)vector.Y;
-                    bytes[startIndex + 2] = (byte)vector.Z;
-                    bytes[startIndex + 3] = (byte)vector.W;
-                    break;
-                default:
-                    throw new NotSupportedException();
-            }
+        /// <inheritdoc />
+        public void ToXyzwBytes(byte[] bytes, int startIndex)
+        {
+            Vector4 vector = this.ToVector4() * 255F;
+            bytes[startIndex] = (byte)vector.X;
+            bytes[startIndex + 1] = (byte)vector.Y;
+            bytes[startIndex + 2] = (byte)vector.Z;
+            bytes[startIndex + 3] = (byte)vector.W;
+        }
+
+        /// <inheritdoc />
+        public void ToZyxBytes(byte[] bytes, int startIndex)
+        {
+            Vector4 vector = this.ToVector4() * 255F;
+            bytes[startIndex] = (byte)vector.Z;
+            bytes[startIndex + 1] = (byte)vector.Y;
+            bytes[startIndex + 2] = (byte)vector.X;
+        }
+
+        /// <inheritdoc />
+        public void ToZyxwBytes(byte[] bytes, int startIndex)
+        {
+            Vector4 vector = this.ToVector4() * 255F;
+            bytes[startIndex] = (byte)vector.Z;
+            bytes[startIndex + 1] = (byte)vector.Y;
+            bytes[startIndex + 2] = (byte)vector.X;
+            bytes[startIndex + 3] = (byte)vector.W;
         }
 
         /// <inheritdoc />

--- a/src/ImageSharp/Colors/PackedPixel/Bgra5551.cs
+++ b/src/ImageSharp/Colors/PackedPixel/Bgra5551.cs
@@ -88,37 +88,41 @@ namespace ImageSharp
         }
 
         /// <inheritdoc />
-        public void ToBytes(byte[] bytes, int startIndex, ComponentOrder componentOrder)
+        public void ToXyzBytes(byte[] bytes, int startIndex)
         {
             Vector4 vector = this.ToVector4() * 255F;
+            bytes[startIndex] = (byte)vector.X;
+            bytes[startIndex + 1] = (byte)vector.Y;
+            bytes[startIndex + 2] = (byte)vector.Z;
+        }
 
-            switch (componentOrder)
-            {
-                case ComponentOrder.ZYX:
-                    bytes[startIndex] = (byte)vector.Z;
-                    bytes[startIndex + 1] = (byte)vector.Y;
-                    bytes[startIndex + 2] = (byte)vector.X;
-                    break;
-                case ComponentOrder.ZYXW:
-                    bytes[startIndex] = (byte)vector.Z;
-                    bytes[startIndex + 1] = (byte)vector.Y;
-                    bytes[startIndex + 2] = (byte)vector.X;
-                    bytes[startIndex + 3] = (byte)vector.W;
-                    break;
-                case ComponentOrder.XYZ:
-                    bytes[startIndex] = (byte)vector.X;
-                    bytes[startIndex + 1] = (byte)vector.Y;
-                    bytes[startIndex + 2] = (byte)vector.Z;
-                    break;
-                case ComponentOrder.XYZW:
-                    bytes[startIndex] = (byte)vector.X;
-                    bytes[startIndex + 1] = (byte)vector.Y;
-                    bytes[startIndex + 2] = (byte)vector.Z;
-                    bytes[startIndex + 3] = (byte)vector.W;
-                    break;
-                default:
-                    throw new NotSupportedException();
-            }
+        /// <inheritdoc />
+        public void ToXyzwBytes(byte[] bytes, int startIndex)
+        {
+            Vector4 vector = this.ToVector4() * 255F;
+            bytes[startIndex] = (byte)vector.X;
+            bytes[startIndex + 1] = (byte)vector.Y;
+            bytes[startIndex + 2] = (byte)vector.Z;
+            bytes[startIndex + 3] = (byte)vector.W;
+        }
+
+        /// <inheritdoc />
+        public void ToZyxBytes(byte[] bytes, int startIndex)
+        {
+            Vector4 vector = this.ToVector4() * 255F;
+            bytes[startIndex] = (byte)vector.Z;
+            bytes[startIndex + 1] = (byte)vector.Y;
+            bytes[startIndex + 2] = (byte)vector.X;
+        }
+
+        /// <inheritdoc />
+        public void ToZyxwBytes(byte[] bytes, int startIndex)
+        {
+            Vector4 vector = this.ToVector4() * 255F;
+            bytes[startIndex] = (byte)vector.Z;
+            bytes[startIndex + 1] = (byte)vector.Y;
+            bytes[startIndex + 2] = (byte)vector.X;
+            bytes[startIndex + 3] = (byte)vector.W;
         }
 
         /// <inheritdoc />

--- a/src/ImageSharp/Colors/PackedPixel/Byte4.cs
+++ b/src/ImageSharp/Colors/PackedPixel/Byte4.cs
@@ -95,37 +95,41 @@ namespace ImageSharp
         }
 
         /// <inheritdoc />
-        public void ToBytes(byte[] bytes, int startIndex, ComponentOrder componentOrder)
+        public void ToXyzBytes(byte[] bytes, int startIndex)
         {
             Vector4 vector = this.ToVector4();
+            bytes[startIndex] = (byte)vector.X;
+            bytes[startIndex + 1] = (byte)vector.Y;
+            bytes[startIndex + 2] = (byte)vector.Z;
+        }
 
-            switch (componentOrder)
-            {
-                case ComponentOrder.ZYX:
-                    bytes[startIndex] = (byte)vector.Z;
-                    bytes[startIndex + 1] = (byte)vector.Y;
-                    bytes[startIndex + 2] = (byte)vector.X;
-                    break;
-                case ComponentOrder.ZYXW:
-                    bytes[startIndex] = (byte)vector.Z;
-                    bytes[startIndex + 1] = (byte)vector.Y;
-                    bytes[startIndex + 2] = (byte)vector.X;
-                    bytes[startIndex + 3] = (byte)vector.W;
-                    break;
-                case ComponentOrder.XYZ:
-                    bytes[startIndex] = (byte)vector.X;
-                    bytes[startIndex + 1] = (byte)vector.Y;
-                    bytes[startIndex + 2] = (byte)vector.Z;
-                    break;
-                case ComponentOrder.XYZW:
-                    bytes[startIndex] = (byte)vector.X;
-                    bytes[startIndex + 1] = (byte)vector.Y;
-                    bytes[startIndex + 2] = (byte)vector.Z;
-                    bytes[startIndex + 3] = (byte)vector.W;
-                    break;
-                default:
-                    throw new NotSupportedException();
-            }
+        /// <inheritdoc />
+        public void ToXyzwBytes(byte[] bytes, int startIndex)
+        {
+            Vector4 vector = this.ToVector4();
+            bytes[startIndex] = (byte)vector.X;
+            bytes[startIndex + 1] = (byte)vector.Y;
+            bytes[startIndex + 2] = (byte)vector.Z;
+            bytes[startIndex + 3] = (byte)vector.W;
+        }
+
+        /// <inheritdoc />
+        public void ToZyxBytes(byte[] bytes, int startIndex)
+        {
+            Vector4 vector = this.ToVector4();
+            bytes[startIndex] = (byte)vector.Z;
+            bytes[startIndex + 1] = (byte)vector.Y;
+            bytes[startIndex + 2] = (byte)vector.X;
+        }
+
+        /// <inheritdoc />
+        public void ToZyxwBytes(byte[] bytes, int startIndex)
+        {
+            Vector4 vector = this.ToVector4();
+            bytes[startIndex] = (byte)vector.Z;
+            bytes[startIndex + 1] = (byte)vector.Y;
+            bytes[startIndex + 2] = (byte)vector.X;
+            bytes[startIndex + 3] = (byte)vector.W;
         }
 
         /// <inheritdoc />

--- a/src/ImageSharp/Colors/PackedPixel/HalfSingle.cs
+++ b/src/ImageSharp/Colors/PackedPixel/HalfSingle.cs
@@ -97,40 +97,57 @@ namespace ImageSharp
         }
 
         /// <inheritdoc />
-        public void ToBytes(byte[] bytes, int startIndex, ComponentOrder componentOrder)
+        public void ToXyzBytes(byte[] bytes, int startIndex)
         {
             Vector4 vector = this.ToVector4();
             vector *= MaxBytes;
             vector += Half;
             vector = Vector4.Clamp(vector, Vector4.Zero, MaxBytes);
 
-            switch (componentOrder)
-            {
-                case ComponentOrder.ZYX:
-                    bytes[startIndex] = (byte)vector.Z;
-                    bytes[startIndex + 1] = (byte)vector.Y;
-                    bytes[startIndex + 2] = (byte)vector.X;
-                    break;
-                case ComponentOrder.ZYXW:
-                    bytes[startIndex] = (byte)vector.Z;
-                    bytes[startIndex + 1] = (byte)vector.Y;
-                    bytes[startIndex + 2] = (byte)vector.X;
-                    bytes[startIndex + 3] = (byte)vector.W;
-                    break;
-                case ComponentOrder.XYZ:
-                    bytes[startIndex] = (byte)vector.X;
-                    bytes[startIndex + 1] = (byte)vector.Y;
-                    bytes[startIndex + 2] = (byte)vector.Z;
-                    break;
-                case ComponentOrder.XYZW:
-                    bytes[startIndex] = (byte)vector.X;
-                    bytes[startIndex + 1] = (byte)vector.Y;
-                    bytes[startIndex + 2] = (byte)vector.Z;
-                    bytes[startIndex + 3] = (byte)vector.W;
-                    break;
-                default:
-                    throw new NotSupportedException();
-            }
+            bytes[startIndex] = (byte)vector.X;
+            bytes[startIndex + 1] = (byte)vector.Y;
+            bytes[startIndex + 2] = (byte)vector.Z;
+        }
+
+        /// <inheritdoc />
+        public void ToXyzwBytes(byte[] bytes, int startIndex)
+        {
+            Vector4 vector = this.ToVector4();
+            vector *= MaxBytes;
+            vector += Half;
+            vector = Vector4.Clamp(vector, Vector4.Zero, MaxBytes);
+
+            bytes[startIndex] = (byte)vector.X;
+            bytes[startIndex + 1] = (byte)vector.Y;
+            bytes[startIndex + 2] = (byte)vector.Z;
+            bytes[startIndex + 3] = (byte)vector.W;
+        }
+
+        /// <inheritdoc />
+        public void ToZyxBytes(byte[] bytes, int startIndex)
+        {
+            Vector4 vector = this.ToVector4();
+            vector *= MaxBytes;
+            vector += Half;
+            vector = Vector4.Clamp(vector, Vector4.Zero, MaxBytes);
+
+            bytes[startIndex] = (byte)vector.Z;
+            bytes[startIndex + 1] = (byte)vector.Y;
+            bytes[startIndex + 2] = (byte)vector.X;
+        }
+
+        /// <inheritdoc />
+        public void ToZyxwBytes(byte[] bytes, int startIndex)
+        {
+            Vector4 vector = this.ToVector4();
+            vector *= MaxBytes;
+            vector += Half;
+            vector = Vector4.Clamp(vector, Vector4.Zero, MaxBytes);
+
+            bytes[startIndex] = (byte)vector.Z;
+            bytes[startIndex + 1] = (byte)vector.Y;
+            bytes[startIndex + 2] = (byte)vector.X;
+            bytes[startIndex + 3] = (byte)vector.W;
         }
 
         /// <inheritdoc />

--- a/src/ImageSharp/Colors/PackedPixel/HalfVector2.cs
+++ b/src/ImageSharp/Colors/PackedPixel/HalfVector2.cs
@@ -111,40 +111,57 @@ namespace ImageSharp
         }
 
         /// <inheritdoc />
-        public void ToBytes(byte[] bytes, int startIndex, ComponentOrder componentOrder)
+        public void ToXyzBytes(byte[] bytes, int startIndex)
         {
             Vector4 vector = this.ToVector4();
             vector *= MaxBytes;
             vector += Half;
             vector = Vector4.Clamp(vector, Vector4.Zero, MaxBytes);
 
-            switch (componentOrder)
-            {
-                case ComponentOrder.ZYX:
-                    bytes[startIndex] = (byte)vector.Z;
-                    bytes[startIndex + 1] = (byte)vector.Y;
-                    bytes[startIndex + 2] = (byte)vector.X;
-                    break;
-                case ComponentOrder.ZYXW:
-                    bytes[startIndex] = (byte)vector.Z;
-                    bytes[startIndex + 1] = (byte)vector.Y;
-                    bytes[startIndex + 2] = (byte)vector.X;
-                    bytes[startIndex + 3] = (byte)vector.W;
-                    break;
-                case ComponentOrder.XYZ:
-                    bytes[startIndex] = (byte)vector.X;
-                    bytes[startIndex + 1] = (byte)vector.Y;
-                    bytes[startIndex + 2] = (byte)vector.Z;
-                    break;
-                case ComponentOrder.XYZW:
-                    bytes[startIndex] = (byte)vector.X;
-                    bytes[startIndex + 1] = (byte)vector.Y;
-                    bytes[startIndex + 2] = (byte)vector.Z;
-                    bytes[startIndex + 3] = (byte)vector.W;
-                    break;
-                default:
-                    throw new NotSupportedException();
-            }
+            bytes[startIndex] = (byte)vector.X;
+            bytes[startIndex + 1] = (byte)vector.Y;
+            bytes[startIndex + 2] = (byte)vector.Z;
+        }
+
+        /// <inheritdoc />
+        public void ToXyzwBytes(byte[] bytes, int startIndex)
+        {
+            Vector4 vector = this.ToVector4();
+            vector *= MaxBytes;
+            vector += Half;
+            vector = Vector4.Clamp(vector, Vector4.Zero, MaxBytes);
+
+            bytes[startIndex] = (byte)vector.X;
+            bytes[startIndex + 1] = (byte)vector.Y;
+            bytes[startIndex + 2] = (byte)vector.Z;
+            bytes[startIndex + 3] = (byte)vector.W;
+        }
+
+        /// <inheritdoc />
+        public void ToZyxBytes(byte[] bytes, int startIndex)
+        {
+            Vector4 vector = this.ToVector4();
+            vector *= MaxBytes;
+            vector += Half;
+            vector = Vector4.Clamp(vector, Vector4.Zero, MaxBytes);
+
+            bytes[startIndex] = (byte)vector.Z;
+            bytes[startIndex + 1] = (byte)vector.Y;
+            bytes[startIndex + 2] = (byte)vector.X;
+        }
+
+        /// <inheritdoc />
+        public void ToZyxwBytes(byte[] bytes, int startIndex)
+        {
+            Vector4 vector = this.ToVector4();
+            vector *= MaxBytes;
+            vector += Half;
+            vector = Vector4.Clamp(vector, Vector4.Zero, MaxBytes);
+
+            bytes[startIndex] = (byte)vector.Z;
+            bytes[startIndex + 1] = (byte)vector.Y;
+            bytes[startIndex + 2] = (byte)vector.X;
+            bytes[startIndex + 3] = (byte)vector.W;
         }
 
         /// <inheritdoc />

--- a/src/ImageSharp/Colors/PackedPixel/HalfVector4.cs
+++ b/src/ImageSharp/Colors/PackedPixel/HalfVector4.cs
@@ -105,40 +105,57 @@ namespace ImageSharp
         }
 
         /// <inheritdoc />
-        public void ToBytes(byte[] bytes, int startIndex, ComponentOrder componentOrder)
+        public void ToXyzBytes(byte[] bytes, int startIndex)
         {
             Vector4 vector = this.ToVector4();
             vector *= MaxBytes;
             vector += Half;
             vector = Vector4.Clamp(vector, Vector4.Zero, MaxBytes);
 
-            switch (componentOrder)
-            {
-                case ComponentOrder.ZYX:
-                    bytes[startIndex] = (byte)vector.Z;
-                    bytes[startIndex + 1] = (byte)vector.Y;
-                    bytes[startIndex + 2] = (byte)vector.X;
-                    break;
-                case ComponentOrder.ZYXW:
-                    bytes[startIndex] = (byte)vector.Z;
-                    bytes[startIndex + 1] = (byte)vector.Y;
-                    bytes[startIndex + 2] = (byte)vector.X;
-                    bytes[startIndex + 3] = (byte)vector.W;
-                    break;
-                case ComponentOrder.XYZ:
-                    bytes[startIndex] = (byte)vector.X;
-                    bytes[startIndex + 1] = (byte)vector.Y;
-                    bytes[startIndex + 2] = (byte)vector.Z;
-                    break;
-                case ComponentOrder.XYZW:
-                    bytes[startIndex] = (byte)vector.X;
-                    bytes[startIndex + 1] = (byte)vector.Y;
-                    bytes[startIndex + 2] = (byte)vector.Z;
-                    bytes[startIndex + 3] = (byte)vector.W;
-                    break;
-                default:
-                    throw new NotSupportedException();
-            }
+            bytes[startIndex] = (byte)vector.X;
+            bytes[startIndex + 1] = (byte)vector.Y;
+            bytes[startIndex + 2] = (byte)vector.Z;
+        }
+
+        /// <inheritdoc />
+        public void ToXyzwBytes(byte[] bytes, int startIndex)
+        {
+            Vector4 vector = this.ToVector4();
+            vector *= MaxBytes;
+            vector += Half;
+            vector = Vector4.Clamp(vector, Vector4.Zero, MaxBytes);
+
+            bytes[startIndex] = (byte)vector.X;
+            bytes[startIndex + 1] = (byte)vector.Y;
+            bytes[startIndex + 2] = (byte)vector.Z;
+            bytes[startIndex + 3] = (byte)vector.W;
+        }
+
+        /// <inheritdoc />
+        public void ToZyxBytes(byte[] bytes, int startIndex)
+        {
+            Vector4 vector = this.ToVector4();
+            vector *= MaxBytes;
+            vector += Half;
+            vector = Vector4.Clamp(vector, Vector4.Zero, MaxBytes);
+
+            bytes[startIndex] = (byte)vector.Z;
+            bytes[startIndex + 1] = (byte)vector.Y;
+            bytes[startIndex + 2] = (byte)vector.X;
+        }
+
+        /// <inheritdoc />
+        public void ToZyxwBytes(byte[] bytes, int startIndex)
+        {
+            Vector4 vector = this.ToVector4();
+            vector *= MaxBytes;
+            vector += Half;
+            vector = Vector4.Clamp(vector, Vector4.Zero, MaxBytes);
+
+            bytes[startIndex] = (byte)vector.Z;
+            bytes[startIndex + 1] = (byte)vector.Y;
+            bytes[startIndex + 2] = (byte)vector.X;
+            bytes[startIndex + 3] = (byte)vector.W;
         }
 
         /// <inheritdoc />

--- a/src/ImageSharp/Colors/PackedPixel/IPackedBytes.cs
+++ b/src/ImageSharp/Colors/PackedPixel/IPackedBytes.cs
@@ -12,7 +12,7 @@ namespace ImageSharp
     public interface IPackedBytes
     {
         /// <summary>
-        /// Gets the packed representation from the gives bytes.
+        /// Sets the packed representation from the given byte array.
         /// </summary>
         /// <param name="x">The x-component.</param>
         /// <param name="y">The y-component.</param>
@@ -21,11 +21,35 @@ namespace ImageSharp
         void PackFromBytes(byte x, byte y, byte z, byte w);
 
         /// <summary>
-        /// Sets the packed representation into the gives bytes.
+        /// Expands the packed representation into a given byte array.
+        /// Output is expanded to X-> Y-> Z order. Equivalent to R-> G-> B in <see cref="Color"/>
         /// </summary>
         /// <param name="bytes">The bytes to set the color in.</param>
         /// <param name="startIndex">The starting index of the <paramref name="bytes"/>.</param>
-        /// <param name="componentOrder">The order of the components.</param>
-        void ToBytes(byte[] bytes, int startIndex, ComponentOrder componentOrder);
+        void ToXyzBytes(byte[] bytes, int startIndex);
+
+        /// <summary>
+        /// Expands the packed representation into a given byte array.
+        /// Output is expanded to X-> Y-> Z-> W order. Equivalent to R-> G-> B-> A in <see cref="Color"/>
+        /// </summary>
+        /// <param name="bytes">The bytes to set the color in.</param>
+        /// <param name="startIndex">The starting index of the <paramref name="bytes"/>.</param>
+        void ToXyzwBytes(byte[] bytes, int startIndex);
+
+        /// <summary>
+        /// Expands the packed representation into a given byte array.
+        /// Output is expanded to Z-> Y-> X order. Equivalent to B-> G-> R in <see cref="Color"/>
+        /// </summary>
+        /// <param name="bytes">The bytes to set the color in.</param>
+        /// <param name="startIndex">The starting index of the <paramref name="bytes"/>.</param>
+        void ToZyxBytes(byte[] bytes, int startIndex);
+
+        /// <summary>
+        /// Expands the packed representation into a given byte array.
+        /// Output is expanded to Z-> Y-> X-> W order. Equivalent to B-> G-> R-> A in <see cref="Color"/>
+        /// </summary>
+        /// <param name="bytes">The bytes to set the color in.</param>
+        /// <param name="startIndex">The starting index of the <paramref name="bytes"/>.</param>
+        void ToZyxwBytes(byte[] bytes, int startIndex);
     }
 }

--- a/src/ImageSharp/Colors/PackedPixel/NormalizedByte2.cs
+++ b/src/ImageSharp/Colors/PackedPixel/NormalizedByte2.cs
@@ -120,7 +120,7 @@ namespace ImageSharp
         }
 
         /// <inheritdoc />
-        public void ToBytes(byte[] bytes, int startIndex, ComponentOrder componentOrder)
+        public void ToXyzBytes(byte[] bytes, int startIndex)
         {
             Vector4 vector = this.ToVector4();
             vector *= Half;
@@ -129,33 +129,56 @@ namespace ImageSharp
             vector += Round;
             vector = Vector4.Clamp(vector, Vector4.Zero, MaxBytes);
 
-            switch (componentOrder)
-            {
-                case ComponentOrder.ZYX:
-                    bytes[startIndex] = 0;
-                    bytes[startIndex + 1] = (byte)vector.Y;
-                    bytes[startIndex + 2] = (byte)vector.X;
-                    break;
-                case ComponentOrder.ZYXW:
-                    bytes[startIndex] = 0;
-                    bytes[startIndex + 1] = (byte)vector.Y;
-                    bytes[startIndex + 2] = (byte)vector.X;
-                    bytes[startIndex + 3] = 255;
-                    break;
-                case ComponentOrder.XYZ:
-                    bytes[startIndex] = (byte)vector.X;
-                    bytes[startIndex + 1] = (byte)vector.Y;
-                    bytes[startIndex + 2] = 0;
-                    break;
-                case ComponentOrder.XYZW:
-                    bytes[startIndex] = (byte)vector.X;
-                    bytes[startIndex + 1] = (byte)vector.Y;
-                    bytes[startIndex + 2] = 0;
-                    bytes[startIndex + 3] = 255;
-                    break;
-                default:
-                    throw new NotSupportedException();
-            }
+            bytes[startIndex] = (byte)vector.X;
+            bytes[startIndex + 1] = (byte)vector.Y;
+            bytes[startIndex + 2] = 0;
+        }
+
+        /// <inheritdoc />
+        public void ToXyzwBytes(byte[] bytes, int startIndex)
+        {
+            Vector4 vector = this.ToVector4();
+            vector *= Half;
+            vector += Round;
+            vector += Half;
+            vector += Round;
+            vector = Vector4.Clamp(vector, Vector4.Zero, MaxBytes);
+
+            bytes[startIndex] = (byte)vector.X;
+            bytes[startIndex + 1] = (byte)vector.Y;
+            bytes[startIndex + 2] = 0;
+            bytes[startIndex + 3] = 255;
+        }
+
+        /// <inheritdoc />
+        public void ToZyxBytes(byte[] bytes, int startIndex)
+        {
+            Vector4 vector = this.ToVector4();
+            vector *= Half;
+            vector += Round;
+            vector += Half;
+            vector += Round;
+            vector = Vector4.Clamp(vector, Vector4.Zero, MaxBytes);
+
+            bytes[startIndex] = 0;
+            bytes[startIndex + 1] = (byte)vector.Y;
+            bytes[startIndex + 2] = (byte)vector.X;
+        }
+
+        /// <inheritdoc />
+        public void ToZyxwBytes(byte[] bytes, int startIndex)
+        {
+            Vector4 vector = this.ToVector4();
+            vector *= Half;
+            vector += Round;
+            vector += Half;
+            vector += Round;
+            vector = Vector4.Clamp(vector, Vector4.Zero, MaxBytes);
+
+            bytes[startIndex] = 0;
+            bytes[startIndex + 1] = (byte)vector.Y;
+            bytes[startIndex + 2] = (byte)vector.X;
+            bytes[startIndex + 3] = 255;
         }
 
         /// <inheritdoc />

--- a/src/ImageSharp/Colors/PackedPixel/NormalizedByte4.cs
+++ b/src/ImageSharp/Colors/PackedPixel/NormalizedByte4.cs
@@ -114,7 +114,7 @@ namespace ImageSharp
         }
 
         /// <inheritdoc />
-        public void ToBytes(byte[] bytes, int startIndex, ComponentOrder componentOrder)
+        public void ToXyzBytes(byte[] bytes, int startIndex)
         {
             Vector4 vector = this.ToVector4();
             vector *= Half;
@@ -123,33 +123,56 @@ namespace ImageSharp
             vector += Round;
             vector = Vector4.Clamp(vector, Vector4.Zero, MaxBytes);
 
-            switch (componentOrder)
-            {
-                case ComponentOrder.ZYX:
-                    bytes[startIndex] = (byte)vector.Z;
-                    bytes[startIndex + 1] = (byte)vector.Y;
-                    bytes[startIndex + 2] = (byte)vector.X;
-                    break;
-                case ComponentOrder.ZYXW:
-                    bytes[startIndex] = (byte)vector.Z;
-                    bytes[startIndex + 1] = (byte)vector.Y;
-                    bytes[startIndex + 2] = (byte)vector.X;
-                    bytes[startIndex + 3] = (byte)vector.W;
-                    break;
-                case ComponentOrder.XYZ:
-                    bytes[startIndex] = (byte)vector.X;
-                    bytes[startIndex + 1] = (byte)vector.Y;
-                    bytes[startIndex + 2] = (byte)vector.Z;
-                    break;
-                case ComponentOrder.XYZW:
-                    bytes[startIndex] = (byte)vector.X;
-                    bytes[startIndex + 1] = (byte)vector.Y;
-                    bytes[startIndex + 2] = (byte)vector.Z;
-                    bytes[startIndex + 3] = (byte)vector.W;
-                    break;
-                default:
-                    throw new NotSupportedException();
-            }
+            bytes[startIndex] = (byte)vector.X;
+            bytes[startIndex + 1] = (byte)vector.Y;
+            bytes[startIndex + 2] = (byte)vector.Z;
+        }
+
+        /// <inheritdoc />
+        public void ToXyzwBytes(byte[] bytes, int startIndex)
+        {
+            Vector4 vector = this.ToVector4();
+            vector *= Half;
+            vector += Round;
+            vector += Half;
+            vector += Round;
+            vector = Vector4.Clamp(vector, Vector4.Zero, MaxBytes);
+
+            bytes[startIndex] = (byte)vector.X;
+            bytes[startIndex + 1] = (byte)vector.Y;
+            bytes[startIndex + 2] = (byte)vector.Z;
+            bytes[startIndex + 3] = (byte)vector.W;
+        }
+
+        /// <inheritdoc />
+        public void ToZyxBytes(byte[] bytes, int startIndex)
+        {
+            Vector4 vector = this.ToVector4();
+            vector *= Half;
+            vector += Round;
+            vector += Half;
+            vector += Round;
+            vector = Vector4.Clamp(vector, Vector4.Zero, MaxBytes);
+
+            bytes[startIndex] = (byte)vector.Z;
+            bytes[startIndex + 1] = (byte)vector.Y;
+            bytes[startIndex + 2] = (byte)vector.X;
+        }
+
+        /// <inheritdoc />
+        public void ToZyxwBytes(byte[] bytes, int startIndex)
+        {
+            Vector4 vector = this.ToVector4();
+            vector *= Half;
+            vector += Round;
+            vector += Half;
+            vector += Round;
+            vector = Vector4.Clamp(vector, Vector4.Zero, MaxBytes);
+
+            bytes[startIndex] = (byte)vector.Z;
+            bytes[startIndex + 1] = (byte)vector.Y;
+            bytes[startIndex + 2] = (byte)vector.X;
+            bytes[startIndex + 3] = (byte)vector.W;
         }
 
         /// <inheritdoc />

--- a/src/ImageSharp/Colors/PackedPixel/NormalizedShort2.cs
+++ b/src/ImageSharp/Colors/PackedPixel/NormalizedShort2.cs
@@ -108,7 +108,7 @@ namespace ImageSharp
         }
 
         /// <inheritdoc />
-        public void ToBytes(byte[] bytes, int startIndex, ComponentOrder componentOrder)
+        public void ToXyzBytes(byte[] bytes, int startIndex)
         {
             Vector4 vector = this.ToVector4();
             vector *= Half;
@@ -117,33 +117,56 @@ namespace ImageSharp
             vector += Round;
             vector = Vector4.Clamp(vector, Vector4.Zero, MaxBytes);
 
-            switch (componentOrder)
-            {
-                case ComponentOrder.ZYX:
-                    bytes[startIndex] = 0;
-                    bytes[startIndex + 1] = (byte)(float)Math.Round(vector.Y);
-                    bytes[startIndex + 2] = (byte)(float)Math.Round(vector.X);
-                    break;
-                case ComponentOrder.ZYXW:
-                    bytes[startIndex] = 0;
-                    bytes[startIndex + 1] = (byte)(float)Math.Round(vector.Y);
-                    bytes[startIndex + 2] = (byte)(float)Math.Round(vector.X);
-                    bytes[startIndex + 3] = 255;
-                    break;
-                case ComponentOrder.XYZ:
-                    bytes[startIndex] = (byte)(float)Math.Round(vector.X);
-                    bytes[startIndex + 1] = (byte)(float)Math.Round(vector.Y);
-                    bytes[startIndex + 2] = 0;
-                    break;
-                case ComponentOrder.XYZW:
-                    bytes[startIndex] = (byte)(float)Math.Round(vector.X);
-                    bytes[startIndex + 1] = (byte)(float)Math.Round(vector.Y);
-                    bytes[startIndex + 2] = 0;
-                    bytes[startIndex + 3] = 255;
-                    break;
-                default:
-                    throw new NotSupportedException();
-            }
+            bytes[startIndex] = (byte)(float)Math.Round(vector.X);
+            bytes[startIndex + 1] = (byte)(float)Math.Round(vector.Y);
+            bytes[startIndex + 2] = 0;
+        }
+
+        /// <inheritdoc />
+        public void ToXyzwBytes(byte[] bytes, int startIndex)
+        {
+            Vector4 vector = this.ToVector4();
+            vector *= Half;
+            vector += Round;
+            vector += Half;
+            vector += Round;
+            vector = Vector4.Clamp(vector, Vector4.Zero, MaxBytes);
+
+            bytes[startIndex] = (byte)(float)Math.Round(vector.X);
+            bytes[startIndex + 1] = (byte)(float)Math.Round(vector.Y);
+            bytes[startIndex + 2] = 0;
+            bytes[startIndex + 3] = 255;
+        }
+
+        /// <inheritdoc />
+        public void ToZyxBytes(byte[] bytes, int startIndex)
+        {
+            Vector4 vector = this.ToVector4();
+            vector *= Half;
+            vector += Round;
+            vector += Half;
+            vector += Round;
+            vector = Vector4.Clamp(vector, Vector4.Zero, MaxBytes);
+
+            bytes[startIndex] = 0;
+            bytes[startIndex + 1] = (byte)(float)Math.Round(vector.Y);
+            bytes[startIndex + 2] = (byte)(float)Math.Round(vector.X);
+        }
+
+        /// <inheritdoc />
+        public void ToZyxwBytes(byte[] bytes, int startIndex)
+        {
+            Vector4 vector = this.ToVector4();
+            vector *= Half;
+            vector += Round;
+            vector += Half;
+            vector += Round;
+            vector = Vector4.Clamp(vector, Vector4.Zero, MaxBytes);
+
+            bytes[startIndex] = 0;
+            bytes[startIndex + 1] = (byte)(float)Math.Round(vector.Y);
+            bytes[startIndex + 2] = (byte)(float)Math.Round(vector.X);
+            bytes[startIndex + 3] = 255;
         }
 
         /// <summary>

--- a/src/ImageSharp/Colors/PackedPixel/NormalizedShort4.cs
+++ b/src/ImageSharp/Colors/PackedPixel/NormalizedShort4.cs
@@ -116,7 +116,7 @@ namespace ImageSharp
         }
 
         /// <inheritdoc />
-        public void ToBytes(byte[] bytes, int startIndex, ComponentOrder componentOrder)
+        public void ToXyzBytes(byte[] bytes, int startIndex)
         {
             Vector4 vector = this.ToVector4();
             vector *= Half;
@@ -125,33 +125,56 @@ namespace ImageSharp
             vector += Round;
             vector = Vector4.Clamp(vector, Vector4.Zero, MaxBytes);
 
-            switch (componentOrder)
-            {
-                case ComponentOrder.ZYX:
-                    bytes[startIndex] = (byte)(float)Math.Round(vector.Z);
-                    bytes[startIndex + 1] = (byte)(float)Math.Round(vector.Y);
-                    bytes[startIndex + 2] = (byte)(float)Math.Round(vector.X);
-                    break;
-                case ComponentOrder.ZYXW:
-                    bytes[startIndex] = (byte)(float)Math.Round(vector.Z);
-                    bytes[startIndex + 1] = (byte)(float)Math.Round(vector.Y);
-                    bytes[startIndex + 2] = (byte)(float)Math.Round(vector.X);
-                    bytes[startIndex + 3] = (byte)(float)Math.Round(vector.W);
-                    break;
-                case ComponentOrder.XYZ:
-                    bytes[startIndex] = (byte)(float)Math.Round(vector.X);
-                    bytes[startIndex + 1] = (byte)(float)Math.Round(vector.Y);
-                    bytes[startIndex + 2] = (byte)(float)Math.Round(vector.Z);
-                    break;
-                case ComponentOrder.XYZW:
-                    bytes[startIndex] = (byte)(float)Math.Round(vector.X);
-                    bytes[startIndex + 1] = (byte)(float)Math.Round(vector.Y);
-                    bytes[startIndex + 2] = (byte)(float)Math.Round(vector.Z);
-                    bytes[startIndex + 3] = (byte)(float)Math.Round(vector.W);
-                    break;
-                default:
-                    throw new NotSupportedException();
-            }
+            bytes[startIndex] = (byte)(float)Math.Round(vector.X);
+            bytes[startIndex + 1] = (byte)(float)Math.Round(vector.Y);
+            bytes[startIndex + 2] = (byte)(float)Math.Round(vector.Z);
+        }
+
+        /// <inheritdoc />
+        public void ToXyzwBytes(byte[] bytes, int startIndex)
+        {
+            Vector4 vector = this.ToVector4();
+            vector *= Half;
+            vector += Round;
+            vector += Half;
+            vector += Round;
+            vector = Vector4.Clamp(vector, Vector4.Zero, MaxBytes);
+
+            bytes[startIndex] = (byte)(float)Math.Round(vector.X);
+            bytes[startIndex + 1] = (byte)(float)Math.Round(vector.Y);
+            bytes[startIndex + 2] = (byte)(float)Math.Round(vector.Z);
+            bytes[startIndex + 3] = (byte)(float)Math.Round(vector.W);
+        }
+
+        /// <inheritdoc />
+        public void ToZyxBytes(byte[] bytes, int startIndex)
+        {
+            Vector4 vector = this.ToVector4();
+            vector *= Half;
+            vector += Round;
+            vector += Half;
+            vector += Round;
+            vector = Vector4.Clamp(vector, Vector4.Zero, MaxBytes);
+
+            bytes[startIndex] = (byte)(float)Math.Round(vector.Z);
+            bytes[startIndex + 1] = (byte)(float)Math.Round(vector.Y);
+            bytes[startIndex + 2] = (byte)(float)Math.Round(vector.X);
+        }
+
+        /// <inheritdoc />
+        public void ToZyxwBytes(byte[] bytes, int startIndex)
+        {
+            Vector4 vector = this.ToVector4();
+            vector *= Half;
+            vector += Round;
+            vector += Half;
+            vector += Round;
+            vector = Vector4.Clamp(vector, Vector4.Zero, MaxBytes);
+
+            bytes[startIndex] = (byte)(float)Math.Round(vector.Z);
+            bytes[startIndex + 1] = (byte)(float)Math.Round(vector.Y);
+            bytes[startIndex + 2] = (byte)(float)Math.Round(vector.X);
+            bytes[startIndex + 3] = (byte)(float)Math.Round(vector.W);
         }
 
         /// <inheritdoc />

--- a/src/ImageSharp/Colors/PackedPixel/Rg32.cs
+++ b/src/ImageSharp/Colors/PackedPixel/Rg32.cs
@@ -100,37 +100,45 @@ namespace ImageSharp
         }
 
         /// <inheritdoc />
-        public void ToBytes(byte[] bytes, int startIndex, ComponentOrder componentOrder)
+        public void ToXyzBytes(byte[] bytes, int startIndex)
         {
             Vector4 vector = this.ToVector4() * 255F;
 
-            switch (componentOrder)
-            {
-                case ComponentOrder.ZYX:
-                    bytes[startIndex] = (byte)vector.Z;
-                    bytes[startIndex + 1] = (byte)vector.Y;
-                    bytes[startIndex + 2] = (byte)vector.X;
-                    break;
-                case ComponentOrder.ZYXW:
-                    bytes[startIndex] = (byte)vector.Z;
-                    bytes[startIndex + 1] = (byte)vector.Y;
-                    bytes[startIndex + 2] = (byte)vector.X;
-                    bytes[startIndex + 3] = (byte)vector.W;
-                    break;
-                case ComponentOrder.XYZ:
-                    bytes[startIndex] = (byte)vector.X;
-                    bytes[startIndex + 1] = (byte)vector.Y;
-                    bytes[startIndex + 2] = (byte)vector.Z;
-                    break;
-                case ComponentOrder.XYZW:
-                    bytes[startIndex] = (byte)vector.X;
-                    bytes[startIndex + 1] = (byte)vector.Y;
-                    bytes[startIndex + 2] = (byte)vector.Z;
-                    bytes[startIndex + 3] = (byte)vector.W;
-                    break;
-                default:
-                    throw new NotSupportedException();
-            }
+            bytes[startIndex] = (byte)vector.X;
+            bytes[startIndex + 1] = (byte)vector.Y;
+            bytes[startIndex + 2] = (byte)vector.Z;
+        }
+
+        /// <inheritdoc />
+        public void ToXyzwBytes(byte[] bytes, int startIndex)
+        {
+            Vector4 vector = this.ToVector4() * 255F;
+
+            bytes[startIndex] = (byte)vector.X;
+            bytes[startIndex + 1] = (byte)vector.Y;
+            bytes[startIndex + 2] = (byte)vector.Z;
+            bytes[startIndex + 3] = (byte)vector.W;
+        }
+
+        /// <inheritdoc />
+        public void ToZyxBytes(byte[] bytes, int startIndex)
+        {
+            Vector4 vector = this.ToVector4() * 255F;
+
+            bytes[startIndex] = (byte)vector.Z;
+            bytes[startIndex + 1] = (byte)vector.Y;
+            bytes[startIndex + 2] = (byte)vector.X;
+        }
+
+        /// <inheritdoc />
+        public void ToZyxwBytes(byte[] bytes, int startIndex)
+        {
+            Vector4 vector = this.ToVector4() * 255F;
+
+            bytes[startIndex] = (byte)vector.Z;
+            bytes[startIndex + 1] = (byte)vector.Y;
+            bytes[startIndex + 2] = (byte)vector.X;
+            bytes[startIndex + 3] = (byte)vector.W;
         }
 
         /// <inheritdoc />

--- a/src/ImageSharp/Colors/PackedPixel/Rgba1010102.cs
+++ b/src/ImageSharp/Colors/PackedPixel/Rgba1010102.cs
@@ -95,37 +95,45 @@ namespace ImageSharp
         }
 
         /// <inheritdoc />
-        public void ToBytes(byte[] bytes, int startIndex, ComponentOrder componentOrder)
+        public void ToXyzBytes(byte[] bytes, int startIndex)
         {
             Vector4 vector = this.ToVector4() * 255F;
 
-            switch (componentOrder)
-            {
-                case ComponentOrder.ZYX:
-                    bytes[startIndex] = (byte)(float)Math.Round(vector.Z);
-                    bytes[startIndex + 1] = (byte)(float)Math.Round(vector.Y);
-                    bytes[startIndex + 2] = (byte)(float)Math.Round(vector.X);
-                    break;
-                case ComponentOrder.ZYXW:
-                    bytes[startIndex] = (byte)(float)Math.Round(vector.Z);
-                    bytes[startIndex + 1] = (byte)(float)Math.Round(vector.Y);
-                    bytes[startIndex + 2] = (byte)(float)Math.Round(vector.X);
-                    bytes[startIndex + 3] = (byte)(float)Math.Round(vector.W);
-                    break;
-                case ComponentOrder.XYZ:
-                    bytes[startIndex] = (byte)(float)Math.Round(vector.X);
-                    bytes[startIndex + 1] = (byte)(float)Math.Round(vector.Y);
-                    bytes[startIndex + 2] = (byte)(float)Math.Round(vector.Z);
-                    break;
-                case ComponentOrder.XYZW:
-                    bytes[startIndex] = (byte)(float)Math.Round(vector.X);
-                    bytes[startIndex + 1] = (byte)(float)Math.Round(vector.Y);
-                    bytes[startIndex + 2] = (byte)(float)Math.Round(vector.Z);
-                    bytes[startIndex + 3] = (byte)(float)Math.Round(vector.W);
-                    break;
-                default:
-                    throw new NotSupportedException();
-            }
+            bytes[startIndex] = (byte)(float)Math.Round(vector.X);
+            bytes[startIndex + 1] = (byte)(float)Math.Round(vector.Y);
+            bytes[startIndex + 2] = (byte)(float)Math.Round(vector.Z);
+        }
+
+        /// <inheritdoc />
+        public void ToXyzwBytes(byte[] bytes, int startIndex)
+        {
+            Vector4 vector = this.ToVector4() * 255F;
+
+            bytes[startIndex] = (byte)(float)Math.Round(vector.X);
+            bytes[startIndex + 1] = (byte)(float)Math.Round(vector.Y);
+            bytes[startIndex + 2] = (byte)(float)Math.Round(vector.Z);
+            bytes[startIndex + 3] = (byte)(float)Math.Round(vector.W);
+        }
+
+        /// <inheritdoc />
+        public void ToZyxBytes(byte[] bytes, int startIndex)
+        {
+            Vector4 vector = this.ToVector4() * 255F;
+
+            bytes[startIndex] = (byte)(float)Math.Round(vector.Z);
+            bytes[startIndex + 1] = (byte)(float)Math.Round(vector.Y);
+            bytes[startIndex + 2] = (byte)(float)Math.Round(vector.X);
+        }
+
+        /// <inheritdoc />
+        public void ToZyxwBytes(byte[] bytes, int startIndex)
+        {
+            Vector4 vector = this.ToVector4() * 255F;
+
+            bytes[startIndex] = (byte)(float)Math.Round(vector.Z);
+            bytes[startIndex + 1] = (byte)(float)Math.Round(vector.Y);
+            bytes[startIndex + 2] = (byte)(float)Math.Round(vector.X);
+            bytes[startIndex + 3] = (byte)(float)Math.Round(vector.W);
         }
 
         /// <inheritdoc />

--- a/src/ImageSharp/Colors/PackedPixel/Rgba64.cs
+++ b/src/ImageSharp/Colors/PackedPixel/Rgba64.cs
@@ -94,37 +94,45 @@ namespace ImageSharp
         }
 
         /// <inheritdoc />
-        public void ToBytes(byte[] bytes, int startIndex, ComponentOrder componentOrder)
+        public void ToXyzBytes(byte[] bytes, int startIndex)
         {
             Vector4 vector = this.ToVector4() * 255F;
 
-            switch (componentOrder)
-            {
-                case ComponentOrder.ZYX:
-                    bytes[startIndex] = (byte)(float)Math.Round(vector.Z);
-                    bytes[startIndex + 1] = (byte)(float)Math.Round(vector.Y);
-                    bytes[startIndex + 2] = (byte)(float)Math.Round(vector.X);
-                    break;
-                case ComponentOrder.ZYXW:
-                    bytes[startIndex] = (byte)(float)Math.Round(vector.Z);
-                    bytes[startIndex + 1] = (byte)(float)Math.Round(vector.Y);
-                    bytes[startIndex + 2] = (byte)(float)Math.Round(vector.X);
-                    bytes[startIndex + 3] = (byte)(float)Math.Round(vector.W);
-                    break;
-                case ComponentOrder.XYZ:
-                    bytes[startIndex] = (byte)(float)Math.Round(vector.X);
-                    bytes[startIndex + 1] = (byte)(float)Math.Round(vector.Y);
-                    bytes[startIndex + 2] = (byte)(float)Math.Round(vector.Z);
-                    break;
-                case ComponentOrder.XYZW:
-                    bytes[startIndex] = (byte)(float)Math.Round(vector.X);
-                    bytes[startIndex + 1] = (byte)(float)Math.Round(vector.Y);
-                    bytes[startIndex + 2] = (byte)(float)Math.Round(vector.Z);
-                    bytes[startIndex + 3] = (byte)(float)Math.Round(vector.W);
-                    break;
-                default:
-                    throw new NotSupportedException();
-            }
+            bytes[startIndex] = (byte)(float)Math.Round(vector.X);
+            bytes[startIndex + 1] = (byte)(float)Math.Round(vector.Y);
+            bytes[startIndex + 2] = (byte)(float)Math.Round(vector.Z);
+        }
+
+        /// <inheritdoc />
+        public void ToXyzwBytes(byte[] bytes, int startIndex)
+        {
+            Vector4 vector = this.ToVector4() * 255F;
+
+            bytes[startIndex] = (byte)(float)Math.Round(vector.X);
+            bytes[startIndex + 1] = (byte)(float)Math.Round(vector.Y);
+            bytes[startIndex + 2] = (byte)(float)Math.Round(vector.Z);
+            bytes[startIndex + 3] = (byte)(float)Math.Round(vector.W);
+        }
+
+        /// <inheritdoc />
+        public void ToZyxBytes(byte[] bytes, int startIndex)
+        {
+            Vector4 vector = this.ToVector4() * 255F;
+
+            bytes[startIndex] = (byte)(float)Math.Round(vector.Z);
+            bytes[startIndex + 1] = (byte)(float)Math.Round(vector.Y);
+            bytes[startIndex + 2] = (byte)(float)Math.Round(vector.X);
+        }
+
+        /// <inheritdoc />
+        public void ToZyxwBytes(byte[] bytes, int startIndex)
+        {
+            Vector4 vector = this.ToVector4() * 255F;
+
+            bytes[startIndex] = (byte)(float)Math.Round(vector.Z);
+            bytes[startIndex + 1] = (byte)(float)Math.Round(vector.Y);
+            bytes[startIndex + 2] = (byte)(float)Math.Round(vector.X);
+            bytes[startIndex + 3] = (byte)(float)Math.Round(vector.W);
         }
 
         /// <inheritdoc />

--- a/src/ImageSharp/Colors/PackedPixel/Short2.cs
+++ b/src/ImageSharp/Colors/PackedPixel/Short2.cs
@@ -106,7 +106,7 @@ namespace ImageSharp
         }
 
         /// <inheritdoc />
-        public void ToBytes(byte[] bytes, int startIndex, ComponentOrder componentOrder)
+        public void ToXyzBytes(byte[] bytes, int startIndex)
         {
             Vector2 vector = this.ToVector2();
             vector /= 65534;
@@ -115,33 +115,56 @@ namespace ImageSharp
             vector += Round;
             vector = Vector2.Clamp(vector, Vector2.Zero, MaxBytes);
 
-            switch (componentOrder)
-            {
-                case ComponentOrder.ZYX:
-                    bytes[startIndex] = 0;
-                    bytes[startIndex + 1] = (byte)(float)Math.Round(vector.Y);
-                    bytes[startIndex + 2] = (byte)(float)Math.Round(vector.X);
-                    break;
-                case ComponentOrder.ZYXW:
-                    bytes[startIndex] = 0;
-                    bytes[startIndex + 1] = (byte)(float)Math.Round(vector.Y);
-                    bytes[startIndex + 2] = (byte)(float)Math.Round(vector.X);
-                    bytes[startIndex + 3] = 255;
-                    break;
-                case ComponentOrder.XYZ:
-                    bytes[startIndex] = (byte)(float)Math.Round(vector.X);
-                    bytes[startIndex + 1] = (byte)(float)Math.Round(vector.Y);
-                    bytes[startIndex + 2] = 0;
-                    break;
-                case ComponentOrder.XYZW:
-                    bytes[startIndex] = (byte)(float)Math.Round(vector.X);
-                    bytes[startIndex + 1] = (byte)(float)Math.Round(vector.Y);
-                    bytes[startIndex + 2] = 0;
-                    bytes[startIndex + 3] = 255;
-                    break;
-                default:
-                    throw new NotSupportedException();
-            }
+            bytes[startIndex] = (byte)(float)Math.Round(vector.X);
+            bytes[startIndex + 1] = (byte)(float)Math.Round(vector.Y);
+            bytes[startIndex + 2] = 0;
+        }
+
+        /// <inheritdoc />
+        public void ToXyzwBytes(byte[] bytes, int startIndex)
+        {
+            Vector2 vector = this.ToVector2();
+            vector /= 65534;
+            vector *= 255;
+            vector += Half;
+            vector += Round;
+            vector = Vector2.Clamp(vector, Vector2.Zero, MaxBytes);
+
+            bytes[startIndex] = (byte)(float)Math.Round(vector.X);
+            bytes[startIndex + 1] = (byte)(float)Math.Round(vector.Y);
+            bytes[startIndex + 2] = 0;
+            bytes[startIndex + 3] = 255;
+        }
+
+        /// <inheritdoc />
+        public void ToZyxBytes(byte[] bytes, int startIndex)
+        {
+            Vector2 vector = this.ToVector2();
+            vector /= 65534;
+            vector *= 255;
+            vector += Half;
+            vector += Round;
+            vector = Vector2.Clamp(vector, Vector2.Zero, MaxBytes);
+
+            bytes[startIndex] = 0;
+            bytes[startIndex + 1] = (byte)(float)Math.Round(vector.Y);
+            bytes[startIndex + 2] = (byte)(float)Math.Round(vector.X);
+        }
+
+        /// <inheritdoc />
+        public void ToZyxwBytes(byte[] bytes, int startIndex)
+        {
+            Vector2 vector = this.ToVector2();
+            vector /= 65534;
+            vector *= 255;
+            vector += Half;
+            vector += Round;
+            vector = Vector2.Clamp(vector, Vector2.Zero, MaxBytes);
+
+            bytes[startIndex] = 0;
+            bytes[startIndex + 1] = (byte)(float)Math.Round(vector.Y);
+            bytes[startIndex + 2] = (byte)(float)Math.Round(vector.X);
+            bytes[startIndex + 3] = 255;
         }
 
         /// <summary>

--- a/src/ImageSharp/Colors/PackedPixel/Short4.cs
+++ b/src/ImageSharp/Colors/PackedPixel/Short4.cs
@@ -112,7 +112,7 @@ namespace ImageSharp
         }
 
         /// <inheritdoc />
-        public void ToBytes(byte[] bytes, int startIndex, ComponentOrder componentOrder)
+        public void ToXyzBytes(byte[] bytes, int startIndex)
         {
             Vector4 vector = this.ToVector4();
             vector /= 65534;
@@ -121,50 +121,65 @@ namespace ImageSharp
             vector += Round;
             vector = Vector4.Clamp(vector, Vector4.Zero, MaxBytes);
 
-            switch (componentOrder)
-            {
-                case ComponentOrder.ZYX:
-                    bytes[startIndex] = (byte)(float)Math.Round(vector.Z);
-                    bytes[startIndex + 1] = (byte)(float)Math.Round(vector.Y);
-                    bytes[startIndex + 2] = (byte)(float)Math.Round(vector.X);
-                    break;
-                case ComponentOrder.ZYXW:
-                    bytes[startIndex] = (byte)(float)Math.Round(vector.Z);
-                    bytes[startIndex + 1] = (byte)(float)Math.Round(vector.Y);
-                    bytes[startIndex + 2] = (byte)(float)Math.Round(vector.X);
-                    bytes[startIndex + 3] = (byte)(float)Math.Round(vector.W);
-                    break;
-                case ComponentOrder.XYZ:
-                    bytes[startIndex] = (byte)(float)Math.Round(vector.X);
-                    bytes[startIndex + 1] = (byte)(float)Math.Round(vector.Y);
-                    bytes[startIndex + 2] = (byte)(float)Math.Round(vector.Z);
-                    break;
-                case ComponentOrder.XYZW:
-                    bytes[startIndex] = (byte)(float)Math.Round(vector.X);
-                    bytes[startIndex + 1] = (byte)(float)Math.Round(vector.Y);
-                    bytes[startIndex + 2] = (byte)(float)Math.Round(vector.Z);
-                    bytes[startIndex + 3] = (byte)(float)Math.Round(vector.W);
-                    break;
-                default:
-                    throw new NotSupportedException();
-            }
+            bytes[startIndex] = (byte)(float)Math.Round(vector.X);
+            bytes[startIndex + 1] = (byte)(float)Math.Round(vector.Y);
+            bytes[startIndex + 2] = (byte)(float)Math.Round(vector.Z);
         }
 
-        /// <summary>
-        /// Returns a value that indicates whether the current instance is equal to a specified object.
-        /// </summary>
-        /// <param name="obj">The object with which to make the comparison.</param>
-        /// <returns>true if the current instance is equal to the specified object; false otherwise.</returns>
+        /// <inheritdoc />
+        public void ToXyzwBytes(byte[] bytes, int startIndex)
+        {
+            Vector4 vector = this.ToVector4();
+            vector /= 65534;
+            vector *= 255;
+            vector += Half;
+            vector += Round;
+            vector = Vector4.Clamp(vector, Vector4.Zero, MaxBytes);
+
+            bytes[startIndex] = (byte)(float)Math.Round(vector.X);
+            bytes[startIndex + 1] = (byte)(float)Math.Round(vector.Y);
+            bytes[startIndex + 2] = (byte)(float)Math.Round(vector.Z);
+            bytes[startIndex + 3] = (byte)(float)Math.Round(vector.W);
+        }
+
+        /// <inheritdoc />
+        public void ToZyxBytes(byte[] bytes, int startIndex)
+        {
+            Vector4 vector = this.ToVector4();
+            vector /= 65534;
+            vector *= 255;
+            vector += Half;
+            vector += Round;
+            vector = Vector4.Clamp(vector, Vector4.Zero, MaxBytes);
+
+            bytes[startIndex] = (byte)(float)Math.Round(vector.Z);
+            bytes[startIndex + 1] = (byte)(float)Math.Round(vector.Y);
+            bytes[startIndex + 2] = (byte)(float)Math.Round(vector.X);
+        }
+
+        /// <inheritdoc />
+        public void ToZyxwBytes(byte[] bytes, int startIndex)
+        {
+            Vector4 vector = this.ToVector4();
+            vector /= 65534;
+            vector *= 255;
+            vector += Half;
+            vector += Round;
+            vector = Vector4.Clamp(vector, Vector4.Zero, MaxBytes);
+
+            bytes[startIndex] = (byte)(float)Math.Round(vector.Z);
+            bytes[startIndex + 1] = (byte)(float)Math.Round(vector.Y);
+            bytes[startIndex + 2] = (byte)(float)Math.Round(vector.X);
+            bytes[startIndex + 3] = (byte)(float)Math.Round(vector.W);
+        }
+
+        /// <inheritdoc />
         public override bool Equals(object obj)
         {
             return (obj is Short4) && this == (Short4)obj;
         }
 
-        /// <summary>
-        /// Returns a value that indicates whether the current instance is equal to a specified object.
-        /// </summary>
-        /// <param name="other">The object with which to make the comparison.</param>
-        /// <returns>true if the current instance is equal to the specified object; false otherwise.</returns>
+        /// <inheritdoc />
         public bool Equals(Short4 other)
         {
             return this == other;

--- a/src/ImageSharp/Formats/Bmp/BmpDecoderCore.cs
+++ b/src/ImageSharp/Formats/Bmp/BmpDecoderCore.cs
@@ -275,7 +275,7 @@ namespace ImageSharp.Formats
             const int ComponentCount = 2;
 
             TColor color = default(TColor);
-            using (PixelArea<TColor> row = new PixelArea<TColor>(width, ComponentOrder.XYZ))
+            using (PixelArea<TColor> row = new PixelArea<TColor>(width, ComponentOrder.Xyz))
             {
                 for (int y = 0; y < height; y++)
                 {
@@ -312,7 +312,7 @@ namespace ImageSharp.Formats
             where TColor : struct, IPackedPixel, IEquatable<TColor>
         {
             int padding = CalculatePadding(width, 3);
-            using (PixelArea<TColor> row = new PixelArea<TColor>(width, ComponentOrder.ZYX, padding))
+            using (PixelArea<TColor> row = new PixelArea<TColor>(width, ComponentOrder.Zyx, padding))
             {
                 for (int y = 0; y < height; y++)
                 {
@@ -336,7 +336,7 @@ namespace ImageSharp.Formats
             where TColor : struct, IPackedPixel, IEquatable<TColor>
         {
             int padding = CalculatePadding(width, 4);
-            using (PixelArea<TColor> row = new PixelArea<TColor>(width, ComponentOrder.ZYXW, padding))
+            using (PixelArea<TColor> row = new PixelArea<TColor>(width, ComponentOrder.Zyxw, padding))
             {
                 for (int y = 0; y < height; y++)
                 {

--- a/src/ImageSharp/Formats/Bmp/BmpEncoderCore.cs
+++ b/src/ImageSharp/Formats/Bmp/BmpEncoderCore.cs
@@ -150,7 +150,7 @@ namespace ImageSharp.Formats
         private void Write32Bit<TColor>(EndianBinaryWriter writer, PixelAccessor<TColor> pixels)
             where TColor : struct, IPackedPixel, IEquatable<TColor>
                     {
-            using (PixelArea<TColor> row = new PixelArea<TColor>(pixels.Width, ComponentOrder.ZYXW, this.padding))
+            using (PixelArea<TColor> row = new PixelArea<TColor>(pixels.Width, ComponentOrder.Zyxw, this.padding))
             {
                 for (int y = pixels.Height - 1; y >= 0; y--)
                 {
@@ -169,7 +169,7 @@ namespace ImageSharp.Formats
         private void Write24Bit<TColor>(EndianBinaryWriter writer, PixelAccessor<TColor> pixels)
             where TColor : struct, IPackedPixel, IEquatable<TColor>
                     {
-            using (PixelArea<TColor> row = new PixelArea<TColor>(pixels.Width, ComponentOrder.ZYX, this.padding))
+            using (PixelArea<TColor> row = new PixelArea<TColor>(pixels.Width, ComponentOrder.Zyx, this.padding))
             {
                 for (int y = pixels.Height - 1; y >= 0; y--)
                 {

--- a/src/ImageSharp/Formats/Gif/GifDecoderCore.cs
+++ b/src/ImageSharp/Formats/Gif/GifDecoderCore.cs
@@ -451,7 +451,7 @@ namespace ImageSharp.Formats
             }
             else
             {
-                using (PixelArea<TColor> emptyRow = new PixelArea<TColor>(this.restoreArea.Value.Width, ComponentOrder.XYZW))
+                using (PixelArea<TColor> emptyRow = new PixelArea<TColor>(this.restoreArea.Value.Width, ComponentOrder.Xyzw))
                 {
                     using (PixelAccessor<TColor> pixelAccessor = frame.Lock())
                     {

--- a/src/ImageSharp/Formats/Gif/GifEncoderCore.cs
+++ b/src/ImageSharp/Formats/Gif/GifEncoderCore.cs
@@ -129,10 +129,10 @@ namespace ImageSharp.Formats
             bool hasEmpty = false;
 
             // Some images may have more than one quantized pixel returned with an alpha value of zero
-            // (No idea why?!) so we should always ignore if we have empty pixels present.
+            // so we should always ignore if we have empty pixels present.
             for (int i = 0; i < quantized.Palette.Length; i++)
             {
-                quantized.Palette[i].ToBytes(this.buffer, 0, ComponentOrder.XYZW);
+                quantized.Palette[i].ToXyzwBytes(this.buffer, 0);
 
                 if (!hasEmpty)
                 {
@@ -318,7 +318,7 @@ namespace ImageSharp.Formats
                 for (int i = 0; i < pixelCount; i++)
                 {
                     int offset = i * 3;
-                    image.Palette[i].ToBytes(this.buffer, 0, ComponentOrder.XYZ);
+                    image.Palette[i].ToXyzBytes(this.buffer, 0);
                     colorTable[offset] = this.buffer[0];
                     colorTable[offset + 1] = this.buffer[1];
                     colorTable[offset + 2] = this.buffer[2];

--- a/src/ImageSharp/Formats/Jpg/JpegEncoderCore.cs
+++ b/src/ImageSharp/Formats/Jpg/JpegEncoderCore.cs
@@ -436,7 +436,7 @@ namespace ImageSharp.Formats
             // ReSharper disable once InconsistentNaming
             float prevDCY = 0, prevDCCb = 0, prevDCCr = 0;
 
-            using (PixelArea<TColor> rgbBytes = new PixelArea<TColor>(8, 8, ComponentOrder.XYZ, true))
+            using (PixelArea<TColor> rgbBytes = new PixelArea<TColor>(8, 8, ComponentOrder.Xyz, true))
             {
                 for (int y = 0; y < pixels.Height; y += 8)
                 {
@@ -805,7 +805,7 @@ namespace ImageSharp.Formats
             // ReSharper disable once InconsistentNaming
             float prevDCY = 0, prevDCCb = 0, prevDCCr = 0;
 
-            using (PixelArea<TColor> rgbBytes = new PixelArea<TColor>(8, 8, ComponentOrder.XYZ, true))
+            using (PixelArea<TColor> rgbBytes = new PixelArea<TColor>(8, 8, ComponentOrder.Xyz, true))
             {
                 for (int y = 0; y < pixels.Height; y += 16)
                 {

--- a/src/ImageSharp/Formats/Png/PngEncoderCore.cs
+++ b/src/ImageSharp/Formats/Png/PngEncoderCore.cs
@@ -286,7 +286,7 @@ namespace ImageSharp.Formats
                 // Convert the color to YCbCr and store the luminance
                 // Optionally store the original color alpha.
                 int offset = x * this.bytesPerPixel;
-                pixels[x, row].ToBytes(this.chunkTypeBuffer, 0, ComponentOrder.XYZW);
+                pixels[x, row].ToXyzwBytes(this.chunkTypeBuffer, 0);
                 byte luminance = (byte)((0.299F * this.chunkTypeBuffer[0]) + (0.587F * this.chunkTypeBuffer[1]) + (0.114F * this.chunkTypeBuffer[2]));
 
                 for (int i = 0; i < this.bytesPerPixel; i++)
@@ -314,7 +314,7 @@ namespace ImageSharp.Formats
             where TColor : struct, IPackedPixel, IEquatable<TColor>
         {
             // We can use the optimized PixelAccessor here and copy the bytes in unmanaged memory.
-            using (PixelArea<TColor> pixelRow = new PixelArea<TColor>(this.width, rawScanline, this.bytesPerPixel == 4 ? ComponentOrder.XYZW : ComponentOrder.XYZ))
+            using (PixelArea<TColor> pixelRow = new PixelArea<TColor>(this.width, rawScanline, this.bytesPerPixel == 4 ? ComponentOrder.Xyzw : ComponentOrder.Xyz))
             {
                 pixels.CopyTo(pixelRow, row);
             }
@@ -507,7 +507,7 @@ namespace ImageSharp.Formats
                 for (int i = 0; i < pixelCount; i++)
                 {
                     int offset = i * 3;
-                    palette[i].ToBytes(bytes, 0, ComponentOrder.XYZW);
+                    palette[i].ToXyzwBytes(bytes, 0);
 
                     int alpha = bytes[3];
 

--- a/src/ImageSharp/Image/PixelAccessor{TColor}.cs
+++ b/src/ImageSharp/Image/PixelAccessor{TColor}.cs
@@ -189,17 +189,17 @@ namespace ImageSharp
             this.CheckDimensions(width, height);
             switch (area.ComponentOrder)
             {
-                case ComponentOrder.ZYX:
-                    this.CopyFromZYX(area, targetY, targetX, width, height);
+                case ComponentOrder.Zyx:
+                    this.CopyFromZyx(area, targetY, targetX, width, height);
                     break;
-                case ComponentOrder.ZYXW:
-                    this.CopyFromZYXW(area, targetY, targetX, width, height);
+                case ComponentOrder.Zyxw:
+                    this.CopyFromZyxw(area, targetY, targetX, width, height);
                     break;
-                case ComponentOrder.XYZ:
-                    this.CopyFromXYZ(area, targetY, targetX, width, height);
+                case ComponentOrder.Xyz:
+                    this.CopyFromXyz(area, targetY, targetX, width, height);
                     break;
-                case ComponentOrder.XYZW:
-                    this.CopyFromXYZW(area, targetY, targetX, width, height);
+                case ComponentOrder.Xyzw:
+                    this.CopyFromXyzw(area, targetY, targetX, width, height);
                     break;
                 default:
                     throw new NotSupportedException();
@@ -223,17 +223,17 @@ namespace ImageSharp
             this.CheckDimensions(width, height);
             switch (area.ComponentOrder)
             {
-                case ComponentOrder.ZYX:
-                    this.CopyToZYX(area, sourceY, sourceX, width, height);
+                case ComponentOrder.Zyx:
+                    this.CopyToZyx(area, sourceY, sourceX, width, height);
                     break;
-                case ComponentOrder.ZYXW:
-                    this.CopyToZYXW(area, sourceY, sourceX, width, height);
+                case ComponentOrder.Zyxw:
+                    this.CopyToZyxw(area, sourceY, sourceX, width, height);
                     break;
-                case ComponentOrder.XYZ:
-                    this.CopyToXYZ(area, sourceY, sourceX, width, height);
+                case ComponentOrder.Xyz:
+                    this.CopyToXyz(area, sourceY, sourceX, width, height);
                     break;
-                case ComponentOrder.XYZW:
-                    this.CopyToXYZW(area, sourceY, sourceX, width, height);
+                case ComponentOrder.Xyzw:
+                    this.CopyToXyzw(area, sourceY, sourceX, width, height);
                     break;
                 default:
                     throw new NotSupportedException();
@@ -278,14 +278,14 @@ namespace ImageSharp
         }
 
         /// <summary>
-        /// Copies from an area in <see cref="ComponentOrder.ZYX"/> format.
+        /// Copies from an area in <see cref="ComponentOrder.Zyx"/> format.
         /// </summary>
         /// <param name="area">The area.</param>
         /// <param name="targetY">The target row index.</param>
         /// <param name="targetX">The target column index.</param>
         /// <param name="width">The width.</param>
         /// <param name="height">The height.</param>
-        protected virtual void CopyFromZYX(PixelArea<TColor> area, int targetY, int targetX, int width, int height)
+        protected virtual void CopyFromZyx(PixelArea<TColor> area, int targetY, int targetX, int width, int height)
         {
             TColor packed = default(TColor);
             int size = Unsafe.SizeOf<TColor>();
@@ -307,14 +307,14 @@ namespace ImageSharp
         }
 
         /// <summary>
-        /// Copies from an area in <see cref="ComponentOrder.ZYXW"/> format.
+        /// Copies from an area in <see cref="ComponentOrder.Zyxw"/> format.
         /// </summary>
         /// <param name="area">The area.</param>
         /// <param name="targetY">The target row index.</param>
         /// <param name="targetX">The target column index.</param>
         /// <param name="width">The width.</param>
         /// <param name="height">The height.</param>
-        protected virtual void CopyFromZYXW(PixelArea<TColor> area, int targetY, int targetX, int width, int height)
+        protected virtual void CopyFromZyxw(PixelArea<TColor> area, int targetY, int targetX, int width, int height)
         {
             TColor packed = default(TColor);
             int size = Unsafe.SizeOf<TColor>();
@@ -336,14 +336,14 @@ namespace ImageSharp
         }
 
         /// <summary>
-        /// Copies from an area in <see cref="ComponentOrder.XYZ"/> format.
+        /// Copies from an area in <see cref="ComponentOrder.Xyz"/> format.
         /// </summary>
         /// <param name="area">The area.</param>
         /// <param name="targetY">The target row index.</param>
         /// <param name="targetX">The target column index.</param>
         /// <param name="width">The width.</param>
         /// <param name="height">The height.</param>
-        protected virtual void CopyFromXYZ(PixelArea<TColor> area, int targetY, int targetX, int width, int height)
+        protected virtual void CopyFromXyz(PixelArea<TColor> area, int targetY, int targetX, int width, int height)
         {
             TColor packed = default(TColor);
             int size = Unsafe.SizeOf<TColor>();
@@ -365,14 +365,14 @@ namespace ImageSharp
         }
 
         /// <summary>
-        /// Copies from an area in <see cref="ComponentOrder.XYZW"/> format.
+        /// Copies from an area in <see cref="ComponentOrder.Xyzw"/> format.
         /// </summary>
         /// <param name="area">The area.</param>
         /// <param name="targetY">The target row index.</param>
         /// <param name="targetX">The target column index.</param>
         /// <param name="width">The width.</param>
         /// <param name="height">The height.</param>
-        protected virtual void CopyFromXYZW(PixelArea<TColor> area, int targetY, int targetX, int width, int height)
+        protected virtual void CopyFromXyzw(PixelArea<TColor> area, int targetY, int targetX, int width, int height)
         {
             TColor packed = default(TColor);
             int size = Unsafe.SizeOf<TColor>();
@@ -394,84 +394,84 @@ namespace ImageSharp
         }
 
         /// <summary>
-        /// Copies to an area in <see cref="ComponentOrder.ZYX"/> format.
+        /// Copies to an area in <see cref="ComponentOrder.Zyx"/> format.
         /// </summary>
         /// <param name="area">The row.</param>
         /// <param name="sourceY">The source row index.</param>
         /// <param name="sourceX">The source column index.</param>
         /// <param name="width">The width.</param>
         /// <param name="height">The height.</param>
-        protected virtual void CopyToZYX(PixelArea<TColor> area, int sourceY, int sourceX, int width, int height)
+        protected virtual void CopyToZyx(PixelArea<TColor> area, int sourceY, int sourceX, int width, int height)
         {
             for (int y = 0; y < height; y++)
             {
                 int offset = y * area.RowStride;
                 for (int x = 0; x < width; x++)
                 {
-                    this[sourceX + x, sourceY + y].ToBytes(area.Bytes, offset, ComponentOrder.ZYX);
+                    this[sourceX + x, sourceY + y].ToZyxBytes(area.Bytes, offset);
                     offset += 3;
                 }
             }
         }
 
         /// <summary>
-        /// Copies to an area in <see cref="ComponentOrder.ZYXW"/> format.
+        /// Copies to an area in <see cref="ComponentOrder.Zyxw"/> format.
         /// </summary>
         /// <param name="area">The row.</param>
         /// <param name="sourceY">The source row index.</param>
         /// <param name="sourceX">The source column index.</param>
         /// <param name="width">The width.</param>
         /// <param name="height">The height.</param>
-        protected virtual void CopyToZYXW(PixelArea<TColor> area, int sourceY, int sourceX, int width, int height)
+        protected virtual void CopyToZyxw(PixelArea<TColor> area, int sourceY, int sourceX, int width, int height)
         {
             for (int y = 0; y < height; y++)
             {
                 int offset = y * area.RowStride;
                 for (int x = 0; x < width; x++)
                 {
-                    this[sourceX + x, sourceY + y].ToBytes(area.Bytes, offset, ComponentOrder.ZYXW);
+                    this[sourceX + x, sourceY + y].ToZyxwBytes(area.Bytes, offset);
                     offset += 4;
                 }
             }
         }
 
         /// <summary>
-        /// Copies to an area in <see cref="ComponentOrder.XYZ"/> format.
+        /// Copies to an area in <see cref="ComponentOrder.Xyz"/> format.
         /// </summary>
         /// <param name="area">The row.</param>
         /// <param name="sourceY">The source row index.</param>
         /// <param name="sourceX">The source column index.</param>
         /// <param name="width">The width.</param>
         /// <param name="height">The height.</param>
-        protected virtual void CopyToXYZ(PixelArea<TColor> area, int sourceY, int sourceX, int width, int height)
+        protected virtual void CopyToXyz(PixelArea<TColor> area, int sourceY, int sourceX, int width, int height)
         {
             for (int y = 0; y < height; y++)
             {
                 int offset = y * area.RowStride;
                 for (int x = 0; x < width; x++)
                 {
-                    this[sourceX + x, sourceY + y].ToBytes(area.Bytes, offset, ComponentOrder.XYZ);
+                    this[sourceX + x, sourceY + y].ToXyzBytes(area.Bytes, offset);
                     offset += 3;
                 }
             }
         }
 
         /// <summary>
-        /// Copies to an area in <see cref="ComponentOrder.XYZW"/> format.
+        /// Copies to an area in <see cref="ComponentOrder.Xyzw"/> format.
         /// </summary>
         /// <param name="area">The row.</param>
         /// <param name="sourceY">The source row index.</param>
         /// <param name="sourceX">The source column index.</param>
         /// <param name="width">The width.</param>
         /// <param name="height">The height.</param>
-        protected virtual void CopyToXYZW(PixelArea<TColor> area, int sourceY, int sourceX, int width, int height)
+        protected virtual void CopyToXyzw(PixelArea<TColor> area, int sourceY, int sourceX, int width, int height)
         {
             for (int y = 0; y < height; y++)
             {
                 int offset = y * area.RowStride;
                 for (int x = 0; x < width; x++)
                 {
-                    this[sourceX + x, sourceY + y].ToBytes(area.Bytes, offset, ComponentOrder.XYZW);
+                    this[sourceX + x, sourceY + y].ToXyzwBytes(area.Bytes, offset);
                     offset += 4;
                 }
             }

--- a/src/ImageSharp/Image/PixelArea{TColor}.cs
+++ b/src/ImageSharp/Image/PixelArea{TColor}.cs
@@ -252,11 +252,11 @@ namespace ImageSharp
         {
             switch (componentOrder)
             {
-                case ComponentOrder.ZYX:
-                case ComponentOrder.XYZ:
+                case ComponentOrder.Zyx:
+                case ComponentOrder.Xyz:
                     return 3;
-                case ComponentOrder.ZYXW:
-                case ComponentOrder.XYZW:
+                case ComponentOrder.Zyxw:
+                case ComponentOrder.Xyzw:
                     return 4;
             }
 

--- a/src/ImageSharp/PixelAccessor.cs
+++ b/src/ImageSharp/PixelAccessor.cs
@@ -22,7 +22,7 @@ namespace ImageSharp
         }
 
         /// <inheritdoc />
-        protected override void CopyFromXYZW(PixelArea<Color> area, int targetY, int targetX, int width, int height)
+        protected override void CopyFromXyzw(PixelArea<Color> area, int targetY, int targetX, int width, int height)
         {
             uint byteCount = (uint)width * 4;
 
@@ -36,7 +36,7 @@ namespace ImageSharp
         }
 
         /// <inheritdoc />
-        protected override void CopyFromXYZ(PixelArea<Color> area, int targetY, int targetX, int width, int height)
+        protected override void CopyFromXyz(PixelArea<Color> area, int targetY, int targetX, int width, int height)
         {
             for (int y = 0; y < height; y++)
             {
@@ -54,7 +54,7 @@ namespace ImageSharp
         }
 
         /// <inheritdoc />
-        protected override void CopyFromZYX(PixelArea<Color> area, int targetY, int targetX, int width, int height)
+        protected override void CopyFromZyx(PixelArea<Color> area, int targetY, int targetX, int width, int height)
         {
             for (int y = 0; y < height; y++)
             {
@@ -72,7 +72,7 @@ namespace ImageSharp
         }
 
         /// <inheritdoc />
-        protected override void CopyFromZYXW(PixelArea<Color> area, int targetY, int targetX, int width, int height)
+        protected override void CopyFromZyxw(PixelArea<Color> area, int targetY, int targetX, int width, int height)
         {
             for (int y = 0; y < height; y++)
             {
@@ -90,7 +90,7 @@ namespace ImageSharp
         }
 
         /// <inheritdoc />
-        protected override void CopyToZYX(PixelArea<Color> area, int sourceY, int sourceX, int width, int height)
+        protected override void CopyToZyx(PixelArea<Color> area, int sourceY, int sourceX, int width, int height)
         {
             for (int y = 0; y < height; y++)
             {
@@ -110,7 +110,7 @@ namespace ImageSharp
         }
 
         /// <inheritdoc />
-        protected override unsafe void CopyToXYZ(PixelArea<Color> area, int sourceY, int sourceX, int width, int height)
+        protected override void CopyToXyz(PixelArea<Color> area, int sourceY, int sourceX, int width, int height)
         {
             for (int y = 0; y < height; y++)
             {
@@ -130,7 +130,7 @@ namespace ImageSharp
         }
 
         /// <inheritdoc />
-        protected override void CopyToZYXW(PixelArea<Color> area, int sourceY, int sourceX, int width, int height)
+        protected override void CopyToZyxw(PixelArea<Color> area, int sourceY, int sourceX, int width, int height)
         {
             for (int y = 0; y < height; y++)
             {

--- a/src/ImageSharp/Quantizers/Octree/OctreeQuantizer.cs
+++ b/src/ImageSharp/Quantizers/Octree/OctreeQuantizer.cs
@@ -112,6 +112,7 @@ namespace ImageSharp.Quantizers
             /// <summary>
             /// Mask used when getting the appropriate pixels for a given node
             /// </summary>
+            // ReSharper disable once StaticMemberInGenericType
             private static readonly int[] Mask = { 0x100, 0x80, 0x40, 0x20, 0x10, 0x08, 0x04, 0x02, 0x01 };
 
             /// <summary>
@@ -375,7 +376,7 @@ namespace ImageSharp.Quantizers
                     {
                         // Go to the next level down in the tree
                         int shift = 7 - level;
-                        pixel.ToBytes(buffer, 0, ComponentOrder.XYZW);
+                        pixel.ToXyzwBytes(buffer, 0);
 
                         int index = ((buffer[3] & Mask[0]) >> (shift - 3)) |
                                     ((buffer[2] & Mask[level + 1]) >> (shift - 2)) |
@@ -479,7 +480,7 @@ namespace ImageSharp.Quantizers
                     if (!this.leaf)
                     {
                         int shift = 7 - level;
-                        pixel.ToBytes(buffer, 0, ComponentOrder.XYZW);
+                        pixel.ToXyzwBytes(buffer, 0);
 
                         int pixelIndex = ((buffer[3] & Mask[0]) >> (shift - 3)) |
                                          ((buffer[2] & Mask[level + 1]) >> (shift - 2)) |
@@ -506,7 +507,7 @@ namespace ImageSharp.Quantizers
                 /// <param name="buffer">The buffer array.</param>
                 public void Increment(TColor pixel, byte[] buffer)
                 {
-                    pixel.ToBytes(buffer, 0, ComponentOrder.XYZW);
+                    pixel.ToXyzwBytes(buffer, 0);
                     this.pixelCount++;
                     this.red += buffer[0];
                     this.green += buffer[1];

--- a/src/ImageSharp/Quantizers/Palette/PaletteQuantizer.cs
+++ b/src/ImageSharp/Quantizers/Palette/PaletteQuantizer.cs
@@ -49,7 +49,7 @@ namespace ImageSharp.Quantizers
 
                 for (int i = 0; i < constants.Length; i++)
                 {
-                    constants[i].ToBytes(this.pixelBuffer, 0, ComponentOrder.XYZW);
+                    constants[i].ToXyzwBytes(this.pixelBuffer, 0);
                     TColor packed = default(TColor);
                     packed.PackFromBytes(this.pixelBuffer[0], this.pixelBuffer[1], this.pixelBuffer[2], this.pixelBuffer[3]);
                     safe[i] = packed;

--- a/src/ImageSharp/Quantizers/Wu/WuQuantizer.cs
+++ b/src/ImageSharp/Quantizers/Wu/WuQuantizer.cs
@@ -340,7 +340,7 @@ namespace ImageSharp.Quantizers
                 for (int x = 0; x < pixels.Width; x++)
                 {
                     // Colors are expected in r->g->b->a format
-                    pixels[x, y].ToBytes(this.rgbaBuffer, 0, ComponentOrder.XYZW);
+                    pixels[x, y].ToXyzwBytes(this.rgbaBuffer, 0);
 
                     byte r = this.rgbaBuffer[0];
                     byte g = this.rgbaBuffer[1];
@@ -785,7 +785,7 @@ namespace ImageSharp.Quantizers
                     for (int x = 0; x < width; x++)
                     {
                         // Expected order r->g->b->a
-                        imagePixels[x, y].ToBytes(rgba, 0, ComponentOrder.XYZW);
+                        imagePixels[x, y].ToXyzwBytes(rgba, 0);
 
                         int r = rgba[0] >> (8 - IndexBits);
                         int g = rgba[1] >> (8 - IndexBits);

--- a/tests/ImageSharp.Tests/Colors/PackedPixelTests.cs
+++ b/tests/ImageSharp.Tests/Colors/PackedPixelTests.cs
@@ -15,7 +15,7 @@ namespace ImageSharp.Tests.Colors
     /// </summary>
     /// <remarks>
     /// The "ToVector4" tests should now be covered in <see cref="ColorConstructorTests"/>
-    /// and at some point they can be safely removed from here. 
+    /// and at some point they can be safely removed from here.
     /// </remarks>
     public class PackedPixelTests
     {
@@ -47,16 +47,16 @@ namespace ImageSharp.Tests.Colors
             byte[] bgr = new byte[3];
             byte[] bgra = new byte[4];
 
-            new Alpha8(.5F).ToBytes(rgb, 0, ComponentOrder.XYZ);
+            new Alpha8(.5F).ToXyzBytes(rgb, 0);
             Assert.Equal(rgb, new byte[] { 0, 0, 0 });
 
-            new Alpha8(.5F).ToBytes(rgba, 0, ComponentOrder.XYZW);
+            new Alpha8(.5F).ToXyzwBytes(rgba, 0);
             Assert.Equal(rgba, new byte[] { 0, 0, 0, 128 });
 
-            new Alpha8(.5F).ToBytes(bgr, 0, ComponentOrder.ZYX);
+            new Alpha8(.5F).ToZyxBytes(bgr, 0);
             Assert.Equal(bgr, new byte[] { 0, 0, 0 });
 
-            new Alpha8(.5F).ToBytes(bgra, 0, ComponentOrder.ZYXW);
+            new Alpha8(.5F).ToZyxwBytes(bgra, 0);
             Assert.Equal(bgra, new byte[] { 0, 0, 0, 128 });
         }
 
@@ -92,16 +92,16 @@ namespace ImageSharp.Tests.Colors
             byte[] bgr = new byte[3];
             byte[] bgra = new byte[4];
 
-            argb.ToBytes(rgb, 0, ComponentOrder.XYZ);
+            argb.ToXyzBytes(rgb, 0);
             Assert.Equal(rgb, new byte[] { 0x1a, 0, 0x80 });
 
-            argb.ToBytes(rgba, 0, ComponentOrder.XYZW);
+            argb.ToXyzwBytes(rgba, 0);
             Assert.Equal(rgba, new byte[] { 0x1a, 0, 0x80, 0 });
 
-            argb.ToBytes(bgr, 0, ComponentOrder.ZYX);
+            argb.ToZyxBytes(bgr, 0);
             Assert.Equal(bgr, new byte[] { 0x80, 0, 0x1a });
 
-            argb.ToBytes(bgra, 0, ComponentOrder.ZYXW);
+            argb.ToZyxwBytes(bgra, 0);
             Assert.Equal(bgra, new byte[] { 0x80, 0, 0x1a, 0 });
         }
 
@@ -133,23 +133,22 @@ namespace ImageSharp.Tests.Colors
             float z = 0.5F;
             Assert.Equal(6160, new Bgr565(x, y, z).PackedValue);
 
-
             // Test ordering
             byte[] rgb = new byte[3];
             byte[] rgba = new byte[4];
             byte[] bgr = new byte[3];
             byte[] bgra = new byte[4];
 
-            new Bgr565(x, y, z).ToBytes(rgb, 0, ComponentOrder.XYZ);
+            new Bgr565(x, y, z).ToXyzBytes(rgb, 0);
             Assert.Equal(rgb, new byte[] { 25, 0, 132 });
 
-            new Bgr565(x, y, z).ToBytes(rgba, 0, ComponentOrder.XYZW);
+            new Bgr565(x, y, z).ToXyzwBytes(rgba, 0);
             Assert.Equal(rgba, new byte[] { 25, 0, 132, 255 });
 
-            new Bgr565(x, y, z).ToBytes(bgr, 0, ComponentOrder.ZYX);
+            new Bgr565(x, y, z).ToZyxBytes(bgr, 0);
             Assert.Equal(bgr, new byte[] { 132, 0, 25 });
 
-            new Bgr565(x, y, z).ToBytes(bgra, 0, ComponentOrder.ZYXW);
+            new Bgr565(x, y, z).ToZyxwBytes(bgra, 0);
             Assert.Equal(bgra, new byte[] { 132, 0, 25, 255 });
         }
 
@@ -190,16 +189,16 @@ namespace ImageSharp.Tests.Colors
             byte[] bgr = new byte[3];
             byte[] bgra = new byte[4];
 
-            new Bgra4444(x, y, z, w).ToBytes(rgb, 0, ComponentOrder.XYZ);
+            new Bgra4444(x, y, z, w).ToXyzBytes(rgb, 0);
             Assert.Equal(rgb, new byte[] { 34, 0, 136 });
 
-            new Bgra4444(x, y, z, w).ToBytes(rgba, 0, ComponentOrder.XYZW);
+            new Bgra4444(x, y, z, w).ToXyzwBytes(rgba, 0);
             Assert.Equal(rgba, new byte[] { 34, 0, 136, 0 });
 
-            new Bgra4444(x, y, z, w).ToBytes(bgr, 0, ComponentOrder.ZYX);
+            new Bgra4444(x, y, z, w).ToZyxBytes(bgr, 0);
             Assert.Equal(bgr, new byte[] { 136, 0, 34 });
 
-            new Bgra4444(x, y, z, w).ToBytes(bgra, 0, ComponentOrder.ZYXW);
+            new Bgra4444(x, y, z, w).ToZyxwBytes(bgra, 0);
             Assert.Equal(bgra, new byte[] { 136, 0, 34, 0 });
         }
 
@@ -236,16 +235,16 @@ namespace ImageSharp.Tests.Colors
             byte[] bgr = new byte[3];
             byte[] bgra = new byte[4];
 
-            new Bgra5551(x, y, z, w).ToBytes(rgb, 0, ComponentOrder.XYZ);
+            new Bgra5551(x, y, z, w).ToXyzBytes(rgb, 0);
             Assert.Equal(rgb, new byte[] { 24, 0, 131 });
 
-            new Bgra5551(x, y, z, w).ToBytes(rgba, 0, ComponentOrder.XYZW);
+            new Bgra5551(x, y, z, w).ToXyzwBytes(rgba, 0);
             Assert.Equal(rgba, new byte[] { 24, 0, 131, 0 });
 
-            new Bgra5551(x, y, z, w).ToBytes(bgr, 0, ComponentOrder.ZYX);
+            new Bgra5551(x, y, z, w).ToZyxBytes(bgr, 0);
             Assert.Equal(bgr, new byte[] { 131, 0, 24 });
 
-            new Bgra5551(x, y, z, w).ToBytes(bgra, 0, ComponentOrder.ZYXW);
+            new Bgra5551(x, y, z, w).ToZyxwBytes(bgra, 0);
             Assert.Equal(bgra, new byte[] { 131, 0, 24, 0 });
         }
 
@@ -287,21 +286,21 @@ namespace ImageSharp.Tests.Colors
             byte[] bgr = new byte[3];
             byte[] bgra = new byte[4];
 
-            new Byte4(x, y, z, w).ToBytes(rgb, 0, ComponentOrder.XYZ);
+            new Byte4(x, y, z, w).ToXyzBytes(rgb, 0);
             Assert.Equal(rgb, new byte[] { 128, 0, 0 });
 
-            new Byte4(x, y, z, w).ToBytes(rgba, 0, ComponentOrder.XYZW);
+            new Byte4(x, y, z, w).ToXyzwBytes(rgba, 0);
             Assert.Equal(rgba, new byte[] { 128, 0, 0, 0 });
 
-            new Byte4(x, y, z, w).ToBytes(bgr, 0, ComponentOrder.ZYX);
+            new Byte4(x, y, z, w).ToZyxBytes(bgr, 0);
             Assert.Equal(bgr, new byte[] { 0, 0, 128 });
 
-            new Byte4(x, y, z, w).ToBytes(bgra, 0, ComponentOrder.ZYXW);
+            new Byte4(x, y, z, w).ToZyxwBytes(bgra, 0);
             Assert.Equal(bgra, new byte[] { 0, 0, 128, 0 });
 
             Byte4 r = new Byte4();
             r.PackFromBytes(20, 38, 0, 255);
-            r.ToBytes(rgba, 0, ComponentOrder.XYZW);
+            r.ToXyzwBytes(rgba, 0);
             Assert.Equal(rgba, new byte[] { 20, 38, 0, 255 });
         }
 
@@ -326,16 +325,16 @@ namespace ImageSharp.Tests.Colors
             byte[] bgr = new byte[3];
             byte[] bgra = new byte[4];
 
-            new HalfSingle(x).ToBytes(rgb, 0, ComponentOrder.XYZ);
+            new HalfSingle(x).ToXyzBytes(rgb, 0);
             Assert.Equal(rgb, new byte[] { 128, 0, 0 });
 
-            new HalfSingle(x).ToBytes(rgba, 0, ComponentOrder.XYZW);
+            new HalfSingle(x).ToXyzwBytes(rgba, 0);
             Assert.Equal(rgba, new byte[] { 128, 0, 0, 255 });
 
-            new HalfSingle(x).ToBytes(bgr, 0, ComponentOrder.ZYX);
+            new HalfSingle(x).ToZyxBytes(bgr, 0);
             Assert.Equal(bgr, new byte[] { 0, 0, 128 });
 
-            new HalfSingle(x).ToBytes(bgra, 0, ComponentOrder.ZYXW);
+            new HalfSingle(x).ToZyxwBytes(bgra, 0);
             Assert.Equal(bgra, new byte[] { 0, 0, 128, 255 });
         }
 
@@ -363,16 +362,16 @@ namespace ImageSharp.Tests.Colors
             byte[] bgr = new byte[3];
             byte[] bgra = new byte[4];
 
-            new HalfVector2(x, y).ToBytes(rgb, 0, ComponentOrder.XYZ);
+            new HalfVector2(x, y).ToXyzBytes(rgb, 0);
             Assert.Equal(rgb, new byte[] { 128, 64, 0 });
 
-            new HalfVector2(x, y).ToBytes(rgba, 0, ComponentOrder.XYZW);
+            new HalfVector2(x, y).ToXyzwBytes(rgba, 0);
             Assert.Equal(rgba, new byte[] { 128, 64, 0, 255 });
 
-            new HalfVector2(x, y).ToBytes(bgr, 0, ComponentOrder.ZYX);
+            new HalfVector2(x, y).ToZyxBytes(bgr, 0);
             Assert.Equal(bgr, new byte[] { 0, 64, 128 });
 
-            new HalfVector2(x, y).ToBytes(bgra, 0, ComponentOrder.ZYXW);
+            new HalfVector2(x, y).ToZyxwBytes(bgra, 0);
             Assert.Equal(bgra, new byte[] { 0, 64, 128, 255 });
         }
 
@@ -409,16 +408,16 @@ namespace ImageSharp.Tests.Colors
             byte[] bgr = new byte[3];
             byte[] bgra = new byte[4];
 
-            new HalfVector4(x, y, z, w).ToBytes(rgb, 0, ComponentOrder.XYZ);
+            new HalfVector4(x, y, z, w).ToXyzBytes(rgb, 0);
             Assert.Equal(rgb, new byte[] { 64, 128, 191 });
 
-            new HalfVector4(x, y, z, w).ToBytes(rgba, 0, ComponentOrder.XYZW);
+            new HalfVector4(x, y, z, w).ToXyzwBytes(rgba, 0);
             Assert.Equal(rgba, new byte[] { 64, 128, 191, 255 });
 
-            new HalfVector4(x, y, z, w).ToBytes(bgr, 0, ComponentOrder.ZYX);
+            new HalfVector4(x, y, z, w).ToZyxBytes(bgr, 0);
             Assert.Equal(bgr, new byte[] { 191, 128, 64 });
 
-            new HalfVector4(x, y, z, w).ToBytes(bgra, 0, ComponentOrder.ZYXW);
+            new HalfVector4(x, y, z, w).ToZyxwBytes(bgra, 0);
             Assert.Equal(bgra, new byte[] { 191, 128, 64, 255 });
         }
 
@@ -454,16 +453,16 @@ namespace ImageSharp.Tests.Colors
             byte[] bgr = new byte[3];
             byte[] bgra = new byte[4];
 
-            new NormalizedByte2(x, y).ToBytes(rgb, 0, ComponentOrder.XYZ);
+            new NormalizedByte2(x, y).ToXyzBytes(rgb, 0);
             Assert.Equal(rgb, new byte[] { 141, 90, 0 });
 
-            new NormalizedByte2(x, y).ToBytes(rgba, 0, ComponentOrder.XYZW);
+            new NormalizedByte2(x, y).ToXyzwBytes(rgba, 0);
             Assert.Equal(rgba, new byte[] { 141, 90, 0, 255 });
 
-            new NormalizedByte2(x, y).ToBytes(bgr, 0, ComponentOrder.ZYX);
+            new NormalizedByte2(x, y).ToZyxBytes(bgr, 0);
             Assert.Equal(bgr, new byte[] { 0, 90, 141 });
 
-            new NormalizedByte2(x, y).ToBytes(bgra, 0, ComponentOrder.ZYXW);
+            new NormalizedByte2(x, y).ToZyxwBytes(bgra, 0);
             Assert.Equal(bgra, new byte[] { 0, 90, 141, 255 });
         }
 
@@ -499,26 +498,26 @@ namespace ImageSharp.Tests.Colors
             byte[] bgr = new byte[3];
             byte[] bgra = new byte[4];
 
-            new NormalizedByte4(x, y, z, w).ToBytes(rgb, 0, ComponentOrder.XYZ);
+            new NormalizedByte4(x, y, z, w).ToXyzBytes(rgb, 0);
             Assert.Equal(rgb, new byte[] { 141, 90, 192 });
 
-            new NormalizedByte4(x, y, z, w).ToBytes(rgba, 0, ComponentOrder.XYZW);
+            new NormalizedByte4(x, y, z, w).ToXyzwBytes(rgba, 0);
             Assert.Equal(rgba, new byte[] { 141, 90, 192, 39 });
 
-            new NormalizedByte4(x, y, z, w).ToBytes(bgr, 0, ComponentOrder.ZYX);
+            new NormalizedByte4(x, y, z, w).ToZyxBytes(bgr, 0);
             Assert.Equal(bgr, new byte[] { 192, 90, 141 });
 
-            new NormalizedByte4(x, y, z, w).ToBytes(bgra, 0, ComponentOrder.ZYXW);
+            new NormalizedByte4(x, y, z, w).ToZyxwBytes(bgra, 0);
             Assert.Equal(bgra, new byte[] { 192, 90, 141, 39 });
 
             // http://community.monogame.net/t/normalizedbyte4-texture2d-gives-different-results-from-xna/8012/8
             NormalizedByte4 r = new NormalizedByte4();
             r.PackFromBytes(9, 115, 202, 127);
-            r.ToBytes(rgba, 0, ComponentOrder.XYZW);
+            r.ToXyzwBytes(rgba, 0);
             Assert.Equal(rgba, new byte[] { 9, 115, 202, 127 });
 
             r.PackedValue = 0xff4af389;
-            r.ToBytes(rgba, 0, ComponentOrder.XYZW);
+            r.ToXyzwBytes(rgba, 0);
             Assert.Equal(rgba, new byte[] { 9, 115, 202, 127 });
         }
 
@@ -553,22 +552,22 @@ namespace ImageSharp.Tests.Colors
 
             NormalizedShort2 n = new NormalizedShort2();
             n.PackFromBytes(141, 90, 0, 0);
-            n.ToBytes(rgb, 0, ComponentOrder.XYZ);
+            n.ToXyzBytes(rgb, 0);
             Assert.Equal(rgb, new byte[] { 141, 90, 0 });
 
             // TODO: I don't think this can ever pass since the bytes are already truncated.
             // Assert.Equal(3650751693, n.PackedValue);
 
-            new NormalizedShort2(x, y).ToBytes(rgb, 0, ComponentOrder.XYZ);
+            new NormalizedShort2(x, y).ToXyzBytes(rgb, 0);
             Assert.Equal(rgb, new byte[] { 141, 90, 0 });
 
-            new NormalizedShort2(x, y).ToBytes(rgba, 0, ComponentOrder.XYZW);
+            new NormalizedShort2(x, y).ToXyzwBytes(rgba, 0);
             Assert.Equal(rgba, new byte[] { 141, 90, 0, 255 });
 
-            new NormalizedShort2(x, y).ToBytes(bgr, 0, ComponentOrder.ZYX);
+            new NormalizedShort2(x, y).ToZyxBytes(bgr, 0);
             Assert.Equal(bgr, new byte[] { 0, 90, 141 });
 
-            new NormalizedShort2(x, y).ToBytes(bgra, 0, ComponentOrder.ZYXW);
+            new NormalizedShort2(x, y).ToZyxwBytes(bgra, 0);
             Assert.Equal(bgra, new byte[] { 0, 90, 141, 255 });
         }
 
@@ -600,21 +599,21 @@ namespace ImageSharp.Tests.Colors
             byte[] bgr = new byte[3];
             byte[] bgra = new byte[4];
 
-            new NormalizedShort4(x, y, z, w).ToBytes(rgb, 0, ComponentOrder.XYZ);
+            new NormalizedShort4(x, y, z, w).ToXyzBytes(rgb, 0);
             Assert.Equal(rgb, new byte[] { 141, 90, 192 });
 
-            new NormalizedShort4(x, y, z, w).ToBytes(rgba, 0, ComponentOrder.XYZW);
+            new NormalizedShort4(x, y, z, w).ToXyzwBytes(rgba, 0);
             Assert.Equal(rgba, new byte[] { 141, 90, 192, 39 });
 
-            new NormalizedShort4(x, y, z, w).ToBytes(bgr, 0, ComponentOrder.ZYX);
+            new NormalizedShort4(x, y, z, w).ToZyxBytes(bgr, 0);
             Assert.Equal(bgr, new byte[] { 192, 90, 141 });
 
-            new NormalizedShort4(x, y, z, w).ToBytes(bgra, 0, ComponentOrder.ZYXW);
+            new NormalizedShort4(x, y, z, w).ToZyxwBytes(bgra, 0);
             Assert.Equal(bgra, new byte[] { 192, 90, 141, 39 });
 
             NormalizedShort4 r = new NormalizedShort4();
             r.PackFromBytes(9, 115, 202, 127);
-            r.ToBytes(rgba, 0, ComponentOrder.XYZW);
+            r.ToXyzwBytes(rgba, 0);
             Assert.Equal(rgba, new byte[] { 9, 115, 202, 127 });
         }
 
@@ -647,16 +646,16 @@ namespace ImageSharp.Tests.Colors
             byte[] bgr = new byte[3];
             byte[] bgra = new byte[4];
 
-            new Rg32(x, y).ToBytes(rgb, 0, ComponentOrder.XYZ);
+            new Rg32(x, y).ToXyzBytes(rgb, 0);
             Assert.Equal(rgb, new byte[] { 25, 0, 0 });
 
-            new Rg32(x, y).ToBytes(rgba, 0, ComponentOrder.XYZW);
+            new Rg32(x, y).ToXyzwBytes(rgba, 0);
             Assert.Equal(rgba, new byte[] { 25, 0, 0, 255 });
 
-            new Rg32(x, y).ToBytes(bgr, 0, ComponentOrder.ZYX);
+            new Rg32(x, y).ToZyxBytes(bgr, 0);
             Assert.Equal(bgr, new byte[] { 0, 0, 25 });
 
-            new Rg32(x, y).ToBytes(bgra, 0, ComponentOrder.ZYXW);
+            new Rg32(x, y).ToZyxwBytes(bgra, 0);
             Assert.Equal(bgra, new byte[] { 0, 0, 25, 255 });
         }
 
@@ -692,22 +691,22 @@ namespace ImageSharp.Tests.Colors
             byte[] bgr = new byte[3];
             byte[] bgra = new byte[4];
 
-            new Rgba1010102(x, y, z, w).ToBytes(rgb, 0, ComponentOrder.XYZ);
+            new Rgba1010102(x, y, z, w).ToXyzBytes(rgb, 0);
             Assert.Equal(rgb, new byte[] { 25, 0, 128 });
 
-            new Rgba1010102(x, y, z, w).ToBytes(rgba, 0, ComponentOrder.XYZW);
+            new Rgba1010102(x, y, z, w).ToXyzwBytes(rgba, 0);
             Assert.Equal(rgba, new byte[] { 25, 0, 128, 0 });
 
-            new Rgba1010102(x, y, z, w).ToBytes(bgr, 0, ComponentOrder.ZYX);
+            new Rgba1010102(x, y, z, w).ToZyxBytes(bgr, 0);
             Assert.Equal(bgr, new byte[] { 128, 0, 25 });
 
-            new Rgba1010102(x, y, z, w).ToBytes(bgra, 0, ComponentOrder.ZYXW);
+            new Rgba1010102(x, y, z, w).ToZyxwBytes(bgra, 0);
             Assert.Equal(bgra, new byte[] { 128, 0, 25, 0 });
 
             // Alpha component accuracy will be awful.
             Rgba1010102 r = new Rgba1010102();
             r.PackFromBytes(25, 0, 128, 0);
-            r.ToBytes(rgba, 0, ComponentOrder.XYZW);
+            r.ToXyzwBytes(rgba, 0);
             Assert.Equal(rgba, new byte[] { 25, 0, 128, 0 });
         }
 
@@ -741,21 +740,21 @@ namespace ImageSharp.Tests.Colors
             byte[] bgr = new byte[3];
             byte[] bgra = new byte[4];
 
-            new Rgba64(x, y, z, w).ToBytes(rgb, 0, ComponentOrder.XYZ);
+            new Rgba64(x, y, z, w).ToXyzBytes(rgb, 0);
             Assert.Equal(rgb, new byte[] { 20, 38, 76 });
 
-            new Rgba64(x, y, z, w).ToBytes(rgba, 0, ComponentOrder.XYZW);
+            new Rgba64(x, y, z, w).ToXyzwBytes(rgba, 0);
             Assert.Equal(rgba, new byte[] { 20, 38, 76, 115 });
 
-            new Rgba64(x, y, z, w).ToBytes(bgr, 0, ComponentOrder.ZYX);
+            new Rgba64(x, y, z, w).ToZyxBytes(bgr, 0);
             Assert.Equal(bgr, new byte[] { 76, 38, 20 });
 
-            new Rgba64(x, y, z, w).ToBytes(bgra, 0, ComponentOrder.ZYXW);
+            new Rgba64(x, y, z, w).ToZyxwBytes(bgra, 0);
             Assert.Equal(bgra, new byte[] { 76, 38, 20, 115 });
 
             Rgba64 r = new Rgba64();
             r.PackFromBytes(20, 38, 76, 115);
-            r.ToBytes(rgba, 0, ComponentOrder.XYZW);
+            r.ToXyzwBytes(rgba, 0);
             Assert.Equal(rgba, new byte[] { 20, 38, 76, 115 });
         }
 
@@ -796,21 +795,21 @@ namespace ImageSharp.Tests.Colors
             byte[] bgr = new byte[3];
             byte[] bgra = new byte[4];
 
-            new Short2(x, y).ToBytes(rgb, 0, ComponentOrder.XYZ);
+            new Short2(x, y).ToXyzBytes(rgb, 0);
             Assert.Equal(rgb, new byte[] { 128, 127, 0 });
 
-            new Short2(x, y).ToBytes(rgba, 0, ComponentOrder.XYZW);
+            new Short2(x, y).ToXyzwBytes(rgba, 0);
             Assert.Equal(rgba, new byte[] { 128, 127, 0, 255 });
 
-            new Short2(x, y).ToBytes(bgr, 0, ComponentOrder.ZYX);
+            new Short2(x, y).ToZyxBytes(bgr, 0);
             Assert.Equal(bgr, new byte[] { 0, 127, 128 });
 
-            new Short2(x, y).ToBytes(bgra, 0, ComponentOrder.ZYXW);
+            new Short2(x, y).ToZyxwBytes(bgra, 0);
             Assert.Equal(bgra, new byte[] { 0, 127, 128, 255 });
 
             Short2 r = new Short2();
             r.PackFromBytes(20, 38, 0, 255);
-            r.ToBytes(rgba, 0, ComponentOrder.XYZW);
+            r.ToXyzwBytes(rgba, 0);
             Assert.Equal(rgba, new byte[] { 20, 38, 0, 255 });
         }
 
@@ -853,21 +852,21 @@ namespace ImageSharp.Tests.Colors
             byte[] bgr = new byte[3];
             byte[] bgra = new byte[4];
 
-            new Short4(x, y, z, w).ToBytes(rgb, 0, ComponentOrder.XYZ);
+            new Short4(x, y, z, w).ToXyzBytes(rgb, 0);
             Assert.Equal(rgb, new byte[] { 172, 177, 243 });
 
-            new Short4(x, y, z, w).ToBytes(rgba, 0, ComponentOrder.XYZW);
+            new Short4(x, y, z, w).ToXyzwBytes(rgba, 0);
             Assert.Equal(rgba, new byte[] { 172, 177, 243, 128 });
 
-            new Short4(x, y, z, w).ToBytes(bgr, 0, ComponentOrder.ZYX);
+            new Short4(x, y, z, w).ToZyxBytes(bgr, 0);
             Assert.Equal(bgr, new byte[] { 243, 177, 172 });
 
-            new Short4(x, y, z, w).ToBytes(bgra, 0, ComponentOrder.ZYXW);
+            new Short4(x, y, z, w).ToZyxwBytes(bgra, 0);
             Assert.Equal(bgra, new byte[] { 243, 177, 172, 128 });
 
             Short4 r = new Short4();
             r.PackFromBytes(20, 38, 0, 255);
-            r.ToBytes(rgba, 0, ComponentOrder.XYZW);
+            r.ToXyzwBytes(rgba, 0);
             Assert.Equal(rgba, new byte[] { 20, 38, 0, 255 });
         }
 

--- a/tests/ImageSharp.Tests/Formats/Jpg/JpegTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/JpegTests.cs
@@ -146,7 +146,7 @@ namespace ImageSharp.Tests
         {
             var src = provider.GetImage();
 
-            PixelArea<TColor> area = new PixelArea<TColor>(8, 8, ComponentOrder.XYZ);
+            PixelArea<TColor> area = new PixelArea<TColor>(8, 8, ComponentOrder.Xyz);
             var dest = provider.Factory.CreateImage(8, 8);
 
             using (var s = src.Lock())
@@ -171,7 +171,7 @@ namespace ImageSharp.Tests
         {
             var src = provider.GetImage();
             
-            PixelArea<TColor> area = new PixelArea<TColor>(8, 8, ComponentOrder.XYZ);
+            PixelArea<TColor> area = new PixelArea<TColor>(8, 8, ComponentOrder.Xyz);
             var dest = provider.Factory.CreateImage(8, 8);
 
             using (var s = src.Lock())

--- a/tests/ImageSharp.Tests/Image/PixelAccessorTests.cs
+++ b/tests/ImageSharp.Tests/Image/PixelAccessorTests.cs
@@ -40,10 +40,10 @@ namespace ImageSharp.Tests
         }
 
         [Theory]
-        [WithMemberFactory(nameof(CreateTestImage), PixelTypes.All, ComponentOrder.XYZ)]
-        [WithMemberFactory(nameof(CreateTestImage), PixelTypes.All, ComponentOrder.ZYX)]
-        [WithMemberFactory(nameof(CreateTestImage), PixelTypes.All, ComponentOrder.XYZW)]
-        [WithMemberFactory(nameof(CreateTestImage), PixelTypes.All, ComponentOrder.ZYXW)]
+        [WithMemberFactory(nameof(CreateTestImage), PixelTypes.All, ComponentOrder.Xyz)]
+        [WithMemberFactory(nameof(CreateTestImage), PixelTypes.All, ComponentOrder.Zyx)]
+        [WithMemberFactory(nameof(CreateTestImage), PixelTypes.All, ComponentOrder.Xyzw)]
+        [WithMemberFactory(nameof(CreateTestImage), PixelTypes.All, ComponentOrder.Zyxw)]
         public void CopyTo_Then_CopyFrom_OnFullImageRect<TColor>(TestImageProvider<TColor> provider, ComponentOrder order)
             where TColor : struct, IPackedPixel, IEquatable<TColor>
         {
@@ -84,10 +84,10 @@ namespace ImageSharp.Tests
         }
 
         [Theory]
-        [WithBlankImages(16, 16, PixelTypes.All, ComponentOrder.XYZ)]
-        [WithBlankImages(16, 16, PixelTypes.All, ComponentOrder.ZYX)]
-        [WithBlankImages(16, 16, PixelTypes.All, ComponentOrder.XYZW)]
-        [WithBlankImages(16, 16, PixelTypes.All, ComponentOrder.ZYXW)]
+        [WithBlankImages(16, 16, PixelTypes.All, ComponentOrder.Xyz)]
+        [WithBlankImages(16, 16, PixelTypes.All, ComponentOrder.Zyx)]
+        [WithBlankImages(16, 16, PixelTypes.All, ComponentOrder.Xyzw)]
+        [WithBlankImages(16, 16, PixelTypes.All, ComponentOrder.Zyxw)]
         public void CopyTo_Then_CopyFrom_WithOffset<TColor>(TestImageProvider<TColor> provider, ComponentOrder order)
             where TColor : struct, IPackedPixel, IEquatable<TColor>
 
@@ -181,7 +181,7 @@ namespace ImageSharp.Tests
                 byte blue = 3;
                 byte alpha = 255;
 
-                using (PixelArea<TColor> row = new PixelArea<TColor>(1, ComponentOrder.ZYX))
+                using (PixelArea<TColor> row = new PixelArea<TColor>(1, ComponentOrder.Zyx))
                 {
                     row.Bytes[0] = blue;
                     row.Bytes[1] = green;
@@ -208,7 +208,7 @@ namespace ImageSharp.Tests
                 byte blue = 3;
                 byte alpha = 4;
 
-                using (PixelArea<TColor> row = new PixelArea<TColor>(1, ComponentOrder.ZYXW))
+                using (PixelArea<TColor> row = new PixelArea<TColor>(1, ComponentOrder.Zyxw))
                 {
                     row.Bytes[0] = blue;
                     row.Bytes[1] = green;
@@ -235,7 +235,7 @@ namespace ImageSharp.Tests
                 byte green = 2;
                 byte blue = 3;
 
-                using (PixelArea<TColor> row = new PixelArea<TColor>(1, ComponentOrder.ZYX))
+                using (PixelArea<TColor> row = new PixelArea<TColor>(1, ComponentOrder.Zyx))
                 {
                     pixels[0, 0] = (TColor)(object)new Color(red, green, blue);
 
@@ -258,7 +258,7 @@ namespace ImageSharp.Tests
                 byte blue = 3;
                 byte alpha = 4;
 
-                using (PixelArea<TColor> row = new PixelArea<TColor>(1, ComponentOrder.ZYXW))
+                using (PixelArea<TColor> row = new PixelArea<TColor>(1, ComponentOrder.Zyxw))
                 {
                     pixels[0, 0] = (TColor)(object)new Color(red, green, blue, alpha);
 

--- a/tests/ImageSharp.Tests/TestUtilities/TestUtilityExtensions.cs
+++ b/tests/ImageSharp.Tests/TestUtilities/TestUtilityExtensions.cs
@@ -21,7 +21,7 @@ namespace ImageSharp.Tests
         private static readonly Assembly ImageSharpAssembly = typeof(Color).GetTypeInfo().Assembly;
 
         private static readonly Dictionary<PixelTypes, Type> PixelTypes2ClrTypes = new Dictionary<PixelTypes, Type>();
-        
+
         private static readonly PixelTypes[] AllConcretePixelTypes = EnumHelper.GetSortedValues<PixelTypes>()
             .Except(new [] {PixelTypes.Undefined, PixelTypes.All })
             .ToArray();
@@ -53,7 +53,7 @@ namespace ImageSharp.Tests
 
             return intrfcType.GetGenericArguments().Single();
         }
-        
+
         public static bool HasFlag(this PixelTypes pixelTypes, PixelTypes flag) => (pixelTypes & flag) == flag;
 
         public static bool IsEquivalentTo<TColor>(this Image<TColor> a, Image<TColor> b, bool compareAlpha = true)
@@ -87,11 +87,11 @@ namespace ImageSharp.Tests
                             }
                             else
                             {
-                                ca.ToBytes(bytesA, 0, ComponentOrder.XYZ);
-                                cb.ToBytes(bytesB, 0, ComponentOrder.XYZ);
+                                ca.ToXyzBytes(bytesA, 0);
+                                cb.ToXyzBytes(bytesB, 0);
 
-                                if (bytesA[0] != bytesB[0] || 
-                                    bytesA[1] != bytesB[1] || 
+                                if (bytesA[0] != bytesB[0] ||
+                                    bytesA[1] != bytesB[1] ||
                                     bytesA[2] != bytesB[2])
                                 {
                                     return false;

--- a/tests/ImageSharp.Tests/TestUtilities/Tests/TestImageProviderTests.cs
+++ b/tests/ImageSharp.Tests/TestUtilities/Tests/TestImageProviderTests.cs
@@ -35,7 +35,7 @@ namespace ImageSharp.Tests
         [WithBlankImages(42, 666, PixelTypes.All, "hello")]
         public void Use_WithBlankImagesAttribute_WithAllPixelTypes<TColor>(
             TestImageProvider<TColor> provider,
-            string message) 
+            string message)
             where TColor : struct, IPackedPixel, IEquatable<TColor>
         {
             var img = provider.GetImage();
@@ -59,7 +59,7 @@ namespace ImageSharp.Tests
         [WithBlankImages(1, 1, PixelTypes.StandardImageClass)]
         [WithFile(TestImages.Bmp.F, PixelTypes.StandardImageClass)]
         public void PixelTypes_ColorWithDefaultImageClass_TriggersCreatingTheNonGenericDerivedImageClass<TColor>(
-            TestImageProvider<TColor> provider) 
+            TestImageProvider<TColor> provider)
             where TColor : struct, IPackedPixel, IEquatable<TColor>
         {
             var img = provider.GetImage();
@@ -112,7 +112,7 @@ namespace ImageSharp.Tests
                 {
                     for (int x = 0; x < pixels.Width; x++)
                     {
-                        pixels[x, y].ToBytes(colors, 0, ComponentOrder.XYZW);
+                        pixels[x, y].ToXyzwBytes(colors, 0);
 
                         Assert.Equal(colors[0], 255);
                         Assert.Equal(colors[1], 100);
@@ -129,7 +129,7 @@ namespace ImageSharp.Tests
         /// <typeparam name="TColor"></typeparam>
         /// <param name="factory"></param>
         /// <returns></returns>
-        public static Image<TColor> CreateTestImage<TColor>(GenericFactory<TColor> factory) 
+        public static Image<TColor> CreateTestImage<TColor>(GenericFactory<TColor> factory)
             where TColor : struct, IPackedPixel, IEquatable<TColor>
         {
             return factory.CreateImage(3, 3);


### PR DESCRIPTION
This replaces `IPackedPixel.ToBytes(bytes, offset, ComponentOrder)` with
explicit implementations. By doing this we remove the overhead of a
switch statement for all `IPackedPixel` implementations.

Benefits are also to be found within all the quantizer implementations. You can see the benefit here in the gif encoder.

### Before

Method |       Mean |    StdErr |    StdDev |     Median | Scaled | Scaled-StdDev | Allocated |
--------------------- |----------- |---------- |---------- |----------- |------- |-------------- |---------- |
'System.Drawing Gif' | 20.3101 ms | 0.2681 ms | 2.6680 ms | 18.9793 ms |   1.00 |          0.00 |   1.12 MB |
'ImageSharp Gif' | 87.6805 ms | 1.3263 ms | 5.1366 ms | 85.3397 ms |   4.38 |          0.57 |   2.74 MB |

### After
Method |       Mean |    StdErr |    StdDev | Scaled | Scaled-StdDev | Allocated |
--------------------- |----------- |---------- |---------- |------- |-------------- |---------- |
'System.Drawing Gif' | 20.0511 ms | 0.1959 ms | 0.8976 ms |   1.00 |          0.00 |   1.12 MB |
'ImageSharp Gif' | 83.4210 ms | 0.8518 ms | 3.1873 ms |   4.17 |          0.23 |   2.74 MB |

