### PR TITLE
Add a .NET 4.6.1 profile to use its System.Numerics.Vectors

### DIFF
--- a/src/ImageSharp.Drawing/project.json
+++ b/src/ImageSharp.Drawing/project.json
@@ -51,7 +51,6 @@
       "type": "build"
     },
     "System.Buffers": "4.0.0",
-    "System.Numerics.Vectors": "4.1.1",
     "System.Runtime.CompilerServices.Unsafe": "4.0.0"
   },
   "frameworks": {
@@ -63,6 +62,7 @@
         "System.IO": "4.1.0",
         "System.IO.Compression": "4.1.0",
         "System.Linq": "4.1.0",
+        "System.Numerics.Vectors": "4.1.1",
         "System.ObjectModel": "4.0.12",
         "System.Resources.ResourceManager": "4.0.1",
         "System.Runtime.Extensions": "4.1.0",
@@ -76,7 +76,21 @@
     },
     "net45": {
       "dependencies": {
-        "System.Runtime": "4.0.0"
+        "System.Numerics.Vectors": "4.1.1",
+        "System.Threading.Tasks.Parallel": "4.0.0"
+      },
+      "frameworkAssemblies": {
+        "System.Runtime": "4.0.0.0"
+      }
+    },
+    "net461": {
+      "dependencies": {
+        "System.Threading.Tasks.Parallel": "4.0.0"
+      },
+      "frameworkAssemblies": {
+        "System.Runtime": "4.0.20.0",
+        "System.Numerics": "4.0.0.0",
+        "System.Numerics.Vectors": "4.0.0.0"
       }
     }
   }

--- a/src/ImageSharp.Formats.Bmp/project.json
+++ b/src/ImageSharp.Formats.Bmp/project.json
@@ -47,7 +47,6 @@
       "type": "build"
     },
     "System.Buffers": "4.0.0",
-    "System.Numerics.Vectors": "4.1.1",
     "System.Runtime.CompilerServices.Unsafe": "4.0.0"
   },
   "frameworks": {
@@ -59,6 +58,7 @@
         "System.IO": "4.1.0",
         "System.IO.Compression": "4.1.0",
         "System.Linq": "4.1.0",
+        "System.Numerics.Vectors": "4.1.1",
         "System.ObjectModel": "4.0.12",
         "System.Resources.ResourceManager": "4.0.1",
         "System.Runtime.Extensions": "4.1.0",
@@ -72,9 +72,21 @@
     },
     "net45": {
       "dependencies": {
-        "System.Runtime": "4.0.0",
-        "System.IO": "4.0.0",
+        "System.Numerics.Vectors": "4.1.1",
         "System.Threading.Tasks.Parallel": "4.0.0"
+      },
+      "frameworkAssemblies": {
+        "System.Runtime": "4.0.0.0"
+      }
+    },
+    "net461": {
+      "dependencies": {
+        "System.Threading.Tasks.Parallel": "4.0.0"
+      },
+      "frameworkAssemblies": {
+        "System.Runtime": "4.0.20.0",
+        "System.Numerics": "4.0.0.0",
+        "System.Numerics.Vectors": "4.0.0.0"
       }
     }
   }

--- a/src/ImageSharp.Formats.Gif/project.json
+++ b/src/ImageSharp.Formats.Gif/project.json
@@ -47,7 +47,6 @@
       "type": "build"
     },
     "System.Buffers": "4.0.0",
-    "System.Numerics.Vectors": "4.1.1",
     "System.Runtime.CompilerServices.Unsafe": "4.0.0"
   },
   "frameworks": {
@@ -59,6 +58,7 @@
         "System.IO": "4.1.0",
         "System.IO.Compression": "4.1.0",
         "System.Linq": "4.1.0",
+        "System.Numerics.Vectors": "4.1.1",
         "System.ObjectModel": "4.0.12",
         "System.Resources.ResourceManager": "4.0.1",
         "System.Runtime.Extensions": "4.1.0",
@@ -72,9 +72,21 @@
     },
     "net45": {
       "dependencies": {
-        "System.Runtime": "4.0.0",
-        "System.IO": "4.0.0",
+        "System.Numerics.Vectors": "4.1.1",
         "System.Threading.Tasks.Parallel": "4.0.0"
+      },
+      "frameworkAssemblies": {
+        "System.Runtime": "4.0.0.0"
+      }
+    },
+    "net461": {
+      "dependencies": {
+        "System.Threading.Tasks.Parallel": "4.0.0"
+      },
+      "frameworkAssemblies": {
+        "System.Runtime": "4.0.20.0",
+        "System.Numerics": "4.0.0.0",
+        "System.Numerics.Vectors": "4.0.0.0"
       }
     }
   }

--- a/src/ImageSharp.Formats.Jpeg/project.json
+++ b/src/ImageSharp.Formats.Jpeg/project.json
@@ -47,7 +47,6 @@
       "type": "build"
     },
     "System.Buffers": "4.0.0",
-    "System.Numerics.Vectors": "4.1.1",
     "System.Runtime.CompilerServices.Unsafe": "4.0.0"
   },
   "frameworks": {
@@ -59,6 +58,7 @@
         "System.IO": "4.1.0",
         "System.IO.Compression": "4.1.0",
         "System.Linq": "4.1.0",
+        "System.Numerics.Vectors": "4.1.1",
         "System.ObjectModel": "4.0.12",
         "System.Resources.ResourceManager": "4.0.1",
         "System.Runtime.Extensions": "4.1.0",
@@ -72,9 +72,21 @@
     },
     "net45": {
       "dependencies": {
-        "System.Runtime": "4.0.0",
-        "System.IO": "4.0.0",
+        "System.Numerics.Vectors": "4.1.1",
         "System.Threading.Tasks.Parallel": "4.0.0"
+      },
+      "frameworkAssemblies": {
+        "System.Runtime": "4.0.0.0"
+      }
+    },
+    "net461": {
+      "dependencies": {
+        "System.Threading.Tasks.Parallel": "4.0.0"
+      },
+      "frameworkAssemblies": {
+        "System.Runtime": "4.0.20.0",
+        "System.Numerics": "4.0.0.0",
+        "System.Numerics.Vectors": "4.0.0.0"
       }
     }
   }

--- a/src/ImageSharp.Formats.Png/project.json
+++ b/src/ImageSharp.Formats.Png/project.json
@@ -47,7 +47,6 @@
       "type": "build"
     },
     "System.Buffers": "4.0.0",
-    "System.Numerics.Vectors": "4.1.1",
     "System.Runtime.CompilerServices.Unsafe": "4.0.0"
   },
   "frameworks": {
@@ -59,6 +58,7 @@
         "System.IO": "4.1.0",
         "System.IO.Compression": "4.1.0",
         "System.Linq": "4.1.0",
+        "System.Numerics.Vectors": "4.1.1",
         "System.ObjectModel": "4.0.12",
         "System.Resources.ResourceManager": "4.0.1",
         "System.Runtime.Extensions": "4.1.0",
@@ -72,9 +72,21 @@
     },
     "net45": {
       "dependencies": {
-        "System.Runtime": "4.0.0",
-        "System.IO": "4.0.0",
+        "System.Numerics.Vectors": "4.1.1",
         "System.Threading.Tasks.Parallel": "4.0.0"
+      },
+      "frameworkAssemblies": {
+        "System.Runtime": "4.0.0.0"
+      }
+    },
+    "net461": {
+      "dependencies": {
+        "System.Threading.Tasks.Parallel": "4.0.0"
+      },
+      "frameworkAssemblies": {
+        "System.Runtime": "4.0.20.0",
+        "System.Numerics": "4.0.0.0",
+        "System.Numerics.Vectors": "4.0.0.0"
       }
     }
   }

--- a/src/ImageSharp.Processing/project.json
+++ b/src/ImageSharp.Processing/project.json
@@ -47,7 +47,6 @@
       "type": "build"
     },
     "System.Buffers": "4.0.0",
-    "System.Numerics.Vectors": "4.1.1",
     "System.Runtime.CompilerServices.Unsafe": "4.0.0"
   },
   "frameworks": {
@@ -59,6 +58,7 @@
         "System.IO": "4.1.0",
         "System.IO.Compression": "4.1.0",
         "System.Linq": "4.1.0",
+        "System.Numerics.Vectors": "4.1.1",
         "System.ObjectModel": "4.0.12",
         "System.Resources.ResourceManager": "4.0.1",
         "System.Runtime.Extensions": "4.1.0",
@@ -72,9 +72,21 @@
     },
     "net45": {
       "dependencies": {
-        "System.Runtime": "4.0.0",
-        "System.IO": "4.0.0",
+        "System.Numerics.Vectors": "4.1.1",
         "System.Threading.Tasks.Parallel": "4.0.0"
+      },
+      "frameworkAssemblies": {
+        "System.Runtime": "4.0.0.0"
+      }
+    },
+    "net461": {
+      "dependencies": {
+        "System.Threading.Tasks.Parallel": "4.0.0"
+      },
+      "frameworkAssemblies": {
+        "System.Runtime": "4.0.20.0",
+        "System.Numerics": "4.0.0.0",
+        "System.Numerics.Vectors": "4.0.0.0"
       }
     }
   }

--- a/src/ImageSharp/project.json
+++ b/src/ImageSharp/project.json
@@ -43,7 +43,6 @@
       "type": "build"
     },
     "System.Buffers": "4.0.0",
-    "System.Numerics.Vectors": "4.1.1",
     "System.Runtime.CompilerServices.Unsafe": "4.0.0"
   },
   "frameworks": {
@@ -55,6 +54,7 @@
         "System.IO": "4.1.0",
         "System.IO.Compression": "4.1.0",
         "System.Linq": "4.1.0",
+        "System.Numerics.Vectors": "4.1.1",
         "System.ObjectModel": "4.0.12",
         "System.Resources.ResourceManager": "4.0.1",
         "System.Runtime.Extensions": "4.1.0",
@@ -68,9 +68,21 @@
     },
     "net45": {
       "dependencies": {
-        "System.Runtime": "4.0.0",
-        "System.IO": "4.0.0",
+        "System.Numerics.Vectors": "4.1.1",
         "System.Threading.Tasks.Parallel": "4.0.0"
+      },
+      "frameworkAssemblies": {
+        "System.Runtime": "4.0.0.0"
+      }
+    },
+    "net461": {
+      "dependencies": {
+        "System.Threading.Tasks.Parallel": "4.0.0"
+      },
+      "frameworkAssemblies": {
+        "System.Runtime": "4.0.20.0",
+        "System.Numerics": "4.0.0.0",
+        "System.Numerics.Vectors": "4.0.0.0"
       }
     }
   }

--- a/tests/ImageSharp.Benchmarks/project.json
+++ b/tests/ImageSharp.Benchmarks/project.json
@@ -48,7 +48,7 @@
     "ImageSharp.Benchmarks": "ImageSharp.Benchmarks"
   },
   "frameworks": {
-    "net461": {
+    "net46": {
       "dependencies": {
       },
       "frameworkAssemblies": {


### PR DESCRIPTION
The downgrade from 4.6.1 to 4.6 in the benchmark is required to force
the System.Numerics.Vectors dependency to NuGet. The 4.6.1 version
does not contain the used generic vector type.

I have no idea if additional changes are required so that this profile ends up in the NuGet packages.

Closes #81