### PR TITLE
Make all images implement IDisposable

### DIFF
--- a/src/ImageSharp.Drawing/project.json
+++ b/src/ImageSharp.Drawing/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0-alpha1-*",
+  "version": "1.0.0-alpha2-*",
   "title": "ImageSharp.Drawing",
   "description": "A cross-platform library for the processing of image files; written in C#",
   "authors": [

--- a/src/ImageSharp.Formats.Bmp/BmpEncoderCore.cs
+++ b/src/ImageSharp.Formats.Bmp/BmpEncoderCore.cs
@@ -34,7 +34,7 @@ namespace ImageSharp.Formats
         /// <param name="bitsPerPixel">The <see cref="BmpBitsPerPixel"/></param>
         public void Encode<TColor>(ImageBase<TColor> image, Stream stream, BmpBitsPerPixel bitsPerPixel)
             where TColor : struct, IPackedPixel, IEquatable<TColor>
-                    {
+        {
             Guard.NotNull(image, nameof(image));
             Guard.NotNull(stream, nameof(stream));
 
@@ -119,23 +119,23 @@ namespace ImageSharp.Formats
         /// Writes the pixel data to the binary stream.
         /// </summary>
         /// <typeparam name="TColor">The pixel format.</typeparam>
-                /// <param name="writer">The <see cref="EndianBinaryWriter"/> containing the stream to write to.</param>
+        /// <param name="writer">The <see cref="EndianBinaryWriter"/> containing the stream to write to.</param>
         /// <param name="image">
         /// The <see cref="ImageBase{TColor}"/> containing pixel data.
         /// </param>
         private void WriteImage<TColor>(EndianBinaryWriter writer, ImageBase<TColor> image)
             where TColor : struct, IPackedPixel, IEquatable<TColor>
-                    {
+        {
             using (PixelAccessor<TColor> pixels = image.Lock())
             {
                 switch (this.bmpBitsPerPixel)
                 {
                     case BmpBitsPerPixel.Pixel32:
-                        this.Write32Bit<TColor>(writer, pixels);
+                        this.Write32Bit(writer, pixels);
                         break;
 
                     case BmpBitsPerPixel.Pixel24:
-                        this.Write24Bit<TColor>(writer, pixels);
+                        this.Write24Bit(writer, pixels);
                         break;
                 }
             }
@@ -145,11 +145,11 @@ namespace ImageSharp.Formats
         /// Writes the 32bit color palette to the stream.
         /// </summary>
         /// <typeparam name="TColor">The pixel format.</typeparam>
-                /// <param name="writer">The <see cref="EndianBinaryWriter"/> containing the stream to write to.</param>
+        /// <param name="writer">The <see cref="EndianBinaryWriter"/> containing the stream to write to.</param>
         /// <param name="pixels">The <see cref="PixelAccessor{TColor}"/> containing pixel data.</param>
         private void Write32Bit<TColor>(EndianBinaryWriter writer, PixelAccessor<TColor> pixels)
             where TColor : struct, IPackedPixel, IEquatable<TColor>
-                    {
+        {
             using (PixelArea<TColor> row = new PixelArea<TColor>(pixels.Width, ComponentOrder.Zyxw, this.padding))
             {
                 for (int y = pixels.Height - 1; y >= 0; y--)
@@ -164,11 +164,11 @@ namespace ImageSharp.Formats
         /// Writes the 24bit color palette to the stream.
         /// </summary>
         /// <typeparam name="TColor">The pixel format.</typeparam>
-                /// <param name="writer">The <see cref="EndianBinaryWriter"/> containing the stream to write to.</param>
+        /// <param name="writer">The <see cref="EndianBinaryWriter"/> containing the stream to write to.</param>
         /// <param name="pixels">The <see cref="PixelAccessor{TColor}"/> containing pixel data.</param>
         private void Write24Bit<TColor>(EndianBinaryWriter writer, PixelAccessor<TColor> pixels)
             where TColor : struct, IPackedPixel, IEquatable<TColor>
-                    {
+        {
             using (PixelArea<TColor> row = new PixelArea<TColor>(pixels.Width, ComponentOrder.Zyx, this.padding))
             {
                 for (int y = pixels.Height - 1; y >= 0; y--)

--- a/src/ImageSharp.Formats.Bmp/project.json
+++ b/src/ImageSharp.Formats.Bmp/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0-alpha1-*",
+  "version": "1.0.0-alpha2-*",
   "title": "ImageSharp.Formats.Bmp",
   "description": "A cross-platform library for the processing of image files; written in C#",
   "authors": [

--- a/src/ImageSharp.Formats.Gif/project.json
+++ b/src/ImageSharp.Formats.Gif/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0-alpha1-*",
+  "version": "1.0.0-alpha2-*",
   "title": "ImageSharp.Formats.Gif",
   "description": "A cross-platform library for the processing of image files; written in C#",
   "authors": [

--- a/src/ImageSharp.Formats.Jpeg/JpegDecoderCore.cs
+++ b/src/ImageSharp.Formats.Jpeg/JpegDecoderCore.cs
@@ -5,10 +5,8 @@
 namespace ImageSharp.Formats
 {
     using System;
-    using System.Buffers;
     using System.IO;
     using System.Runtime.CompilerServices;
-    using System.Runtime.InteropServices;
     using System.Threading.Tasks;
 
     using ImageSharp.Formats.Jpg;
@@ -586,7 +584,7 @@ namespace ImageSharp.Formats
                             byte yellow = this.ycbcrImage.CrChannel.Pixels[co + (x / scale)];
 
                             TColor packed = default(TColor);
-                            this.PackCmyk<TColor>(ref packed, cyan, magenta, yellow, x, y);
+                            this.PackCmyk(ref packed, cyan, magenta, yellow, x, y);
                             pixels[x, y] = packed;
                         }
                     });
@@ -744,7 +742,7 @@ namespace ImageSharp.Formats
                             byte cr = this.ycbcrImage.CrChannel.Pixels[co + (x / scale)];
 
                             TColor packed = default(TColor);
-                            this.PackYcck<TColor>(ref packed, yy, cb, cr, x, y);
+                            this.PackYcck(ref packed, yy, cb, cr, x, y);
                             pixels[x, y] = packed;
                         }
                     });
@@ -1037,7 +1035,7 @@ namespace ImageSharp.Formats
             }
 
             this.InputProcessor.ReadFull(this.Temp, 0, remaining);
-            this.RestartInterval = ((int)this.Temp[0] << 8) + (int)this.Temp[1];
+            this.RestartInterval = (this.Temp[0] << 8) + this.Temp[1];
         }
 
         /// <summary>

--- a/src/ImageSharp.Formats.Jpeg/JpegEncoderCore.cs
+++ b/src/ImageSharp.Formats.Jpeg/JpegEncoderCore.cs
@@ -8,7 +8,6 @@ namespace ImageSharp.Formats
     using System;
     using System.Buffers;
     using System.IO;
-    using System.Numerics;
     using System.Runtime.CompilerServices;
 
     using ImageSharp.Formats.Jpg;

--- a/src/ImageSharp.Formats.Jpeg/project.json
+++ b/src/ImageSharp.Formats.Jpeg/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0-alpha1-*",
+  "version": "1.0.0-alpha2-*",
   "title": "ImageSharp.Formats.Jpeg",
   "description": "A cross-platform library for the processing of image files; written in C#",
   "authors": [

--- a/src/ImageSharp.Formats.Png/project.json
+++ b/src/ImageSharp.Formats.Png/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0-alpha1-*",
+  "version": "1.0.0-alpha2-*",
   "title": "ImageSharp.Formats.Png",
   "description": "A cross-platform library for the processing of image files; written in C#",
   "authors": [

--- a/src/ImageSharp.Processing/Processors/Convolution/Convolution2DProcessor.cs
+++ b/src/ImageSharp.Processing/Processors/Convolution/Convolution2DProcessor.cs
@@ -54,9 +54,9 @@ namespace ImageSharp.Processing.Processors
             int maxY = endY - 1;
             int maxX = endX - 1;
 
-            TColor[] target = new TColor[source.Width * source.Height];
+            TColor[] target = PixelPool<TColor>.RentPixels(source.Width * source.Height);
             using (PixelAccessor<TColor> sourcePixels = source.Lock())
-            using (PixelAccessor<TColor> targetPixels = target.Lock<TColor>(source.Width, source.Height))
+            using (PixelAccessor<TColor> targetPixels = target.Lock(source.Width, source.Height))
             {
                 Parallel.For(
                 startY,

--- a/src/ImageSharp.Processing/Processors/Convolution/Convolution2PassProcessor.cs
+++ b/src/ImageSharp.Processing/Processors/Convolution/Convolution2PassProcessor.cs
@@ -45,19 +45,16 @@ namespace ImageSharp.Processing.Processors
             int width = source.Width;
             int height = source.Height;
 
-            TColor[] target = PixelPool<TColor>.RentPixels(width * height);
-            TColor[] firstPass = PixelPool<TColor>.RentPixels(width * height);
-
-            try
+            using (PixelAccessor<TColor> targetPixels = new PixelAccessor<TColor>(width, height))
             {
-                this.ApplyConvolution(width, height, firstPass, source.Pixels, sourceRectangle, kernelX);
-                this.ApplyConvolution(width, height, target, firstPass, sourceRectangle, kernelY);
+                using (PixelAccessor<TColor> firstPassPixels = new PixelAccessor<TColor>(width, height))
+                using (PixelAccessor<TColor> sourcePixels = source.Lock())
+                {
+                    this.ApplyConvolution(width, height, firstPassPixels, sourcePixels, sourceRectangle, kernelX);
+                    this.ApplyConvolution(width, height, targetPixels, firstPassPixels, sourceRectangle, kernelY);
+                }
 
-                source.SetPixels(width, height, target);
-            }
-            finally
-            {
-                PixelPool<TColor>.ReturnPixels(firstPass);
+                source.SwapPixelsBuffers(targetPixels);
             }
         }
 
@@ -67,13 +64,13 @@ namespace ImageSharp.Processing.Processors
         /// </summary>
         /// <param name="width">The image width.</param>
         /// <param name="height">The image height.</param>
-        /// <param name="target">The target pixels to apply the process to.</param>
-        /// <param name="source">The source pixels. Cannot be null.</param>
+        /// <param name="targetPixels">The target pixels to apply the process to.</param>
+        /// <param name="sourcePixels">The source pixels. Cannot be null.</param>
         /// <param name="sourceRectangle">
         /// The <see cref="Rectangle"/> structure that specifies the portion of the image object to draw.
         /// </param>
         /// <param name="kernel">The kernel operator.</param>
-        private void ApplyConvolution(int width, int height, TColor[] target, TColor[] source, Rectangle sourceRectangle, float[][] kernel)
+        private void ApplyConvolution(int width, int height, PixelAccessor<TColor> targetPixels, PixelAccessor<TColor> sourcePixels, Rectangle sourceRectangle, float[][] kernel)
         {
             int kernelHeight = kernel.Length;
             int kernelWidth = kernel[0].Length;
@@ -87,45 +84,41 @@ namespace ImageSharp.Processing.Processors
             int maxY = endY - 1;
             int maxX = endX - 1;
 
-            using (PixelAccessor<TColor> sourcePixels = source.Lock(width, height))
-            using (PixelAccessor<TColor> targetPixels = target.Lock(width, height))
+            Parallel.For(
+            startY,
+            endY,
+            this.ParallelOptions,
+            y =>
             {
-                Parallel.For(
-                startY,
-                endY,
-                this.ParallelOptions,
-                y =>
+                for (int x = startX; x < endX; x++)
                 {
-                    for (int x = startX; x < endX; x++)
+                    Vector4 destination = default(Vector4);
+
+                    // Apply each matrix multiplier to the color components for each pixel.
+                    for (int fy = 0; fy < kernelHeight; fy++)
                     {
-                        Vector4 destination = default(Vector4);
+                        int fyr = fy - radiusY;
+                        int offsetY = y + fyr;
 
-                        // Apply each matrix multiplier to the color components for each pixel.
-                        for (int fy = 0; fy < kernelHeight; fy++)
+                        offsetY = offsetY.Clamp(0, maxY);
+
+                        for (int fx = 0; fx < kernelWidth; fx++)
                         {
-                            int fyr = fy - radiusY;
-                            int offsetY = y + fyr;
+                            int fxr = fx - radiusX;
+                            int offsetX = x + fxr;
 
-                            offsetY = offsetY.Clamp(0, maxY);
+                            offsetX = offsetX.Clamp(0, maxX);
 
-                            for (int fx = 0; fx < kernelWidth; fx++)
-                            {
-                                int fxr = fx - radiusX;
-                                int offsetX = x + fxr;
-
-                                offsetX = offsetX.Clamp(0, maxX);
-
-                                Vector4 currentColor = sourcePixels[offsetX, offsetY].ToVector4();
-                                destination += kernel[fy][fx] * currentColor;
-                            }
+                            Vector4 currentColor = sourcePixels[offsetX, offsetY].ToVector4();
+                            destination += kernel[fy][fx] * currentColor;
                         }
-
-                        TColor packed = default(TColor);
-                        packed.PackFromVector4(destination);
-                        targetPixels[x, y] = packed;
                     }
-                });
-            }
+
+                    TColor packed = default(TColor);
+                    packed.PackFromVector4(destination);
+                    targetPixels[x, y] = packed;
+                }
+            });
         }
     }
 }

--- a/src/ImageSharp.Processing/Processors/Effects/OilPaintingProcessor.cs
+++ b/src/ImageSharp.Processing/Processors/Effects/OilPaintingProcessor.cs
@@ -67,9 +67,9 @@ namespace ImageSharp.Processing.Processors
                 startX = 0;
             }
 
-            TColor[] target = new TColor[source.Width * source.Height];
+            TColor[] target = PixelPool<TColor>.RentPixels(source.Width * source.Height);
             using (PixelAccessor<TColor> sourcePixels = source.Lock())
-            using (PixelAccessor<TColor> targetPixels = target.Lock<TColor>(source.Width, source.Height))
+            using (PixelAccessor<TColor> targetPixels = target.Lock(source.Width, source.Height))
             {
                 Parallel.For(
                     minY,

--- a/src/ImageSharp.Processing/Processors/Effects/PixelateProcessor.cs
+++ b/src/ImageSharp.Processing/Processors/Effects/PixelateProcessor.cs
@@ -63,51 +63,52 @@ namespace ImageSharp.Processing.Processors
 
             // Get the range on the y-plane to choose from.
             IEnumerable<int> range = EnumerableExtensions.SteppedRange(minY, i => i < maxY, size);
-            TColor[] target = PixelPool<TColor>.RentPixels(source.Width * source.Height);
 
-            using (PixelAccessor<TColor> sourcePixels = source.Lock())
-            using (PixelAccessor<TColor> targetPixels = target.Lock(source.Width, source.Height))
+            using (PixelAccessor<TColor> targetPixels = new PixelAccessor<TColor>(source.Width, source.Height))
             {
-                Parallel.ForEach(
-                    range,
-                    this.ParallelOptions,
-                    y =>
-                        {
-                            int offsetY = y - startY;
-                            int offsetPy = offset;
-
-                            for (int x = minX; x < maxX; x += size)
+                using (PixelAccessor<TColor> sourcePixels = source.Lock())
+                {
+                    Parallel.ForEach(
+                        range,
+                        this.ParallelOptions,
+                        y =>
                             {
-                                int offsetX = x - startX;
-                                int offsetPx = offset;
+                                int offsetY = y - startY;
+                                int offsetPy = offset;
 
-                                // Make sure that the offset is within the boundary of the image.
-                                while (offsetY + offsetPy >= maxY)
+                                for (int x = minX; x < maxX; x += size)
                                 {
-                                    offsetPy--;
-                                }
+                                    int offsetX = x - startX;
+                                    int offsetPx = offset;
 
-                                while (x + offsetPx >= maxX)
-                                {
-                                    offsetPx--;
-                                }
-
-                                // Get the pixel color in the centre of the soon to be pixelated area.
-                                // ReSharper disable AccessToDisposedClosure
-                                TColor pixel = sourcePixels[offsetX + offsetPx, offsetY + offsetPy];
-
-                                // For each pixel in the pixelate size, set it to the centre color.
-                                for (int l = offsetY; l < offsetY + size && l < maxY; l++)
-                                {
-                                    for (int k = offsetX; k < offsetX + size && k < maxX; k++)
+                                    // Make sure that the offset is within the boundary of the image.
+                                    while (offsetY + offsetPy >= maxY)
                                     {
-                                        targetPixels[k, l] = pixel;
+                                        offsetPy--;
+                                    }
+
+                                    while (x + offsetPx >= maxX)
+                                    {
+                                        offsetPx--;
+                                    }
+
+                                    // Get the pixel color in the centre of the soon to be pixelated area.
+                                    // ReSharper disable AccessToDisposedClosure
+                                    TColor pixel = sourcePixels[offsetX + offsetPx, offsetY + offsetPy];
+
+                                    // For each pixel in the pixelate size, set it to the centre color.
+                                    for (int l = offsetY; l < offsetY + size && l < maxY; l++)
+                                    {
+                                        for (int k = offsetX; k < offsetX + size && k < maxX; k++)
+                                        {
+                                            targetPixels[k, l] = pixel;
+                                        }
                                     }
                                 }
-                            }
-                        });
+                            });
 
-                source.SetPixels(source.Width, source.Height, target);
+                    source.SwapPixelsBuffers(targetPixels);
+                }
             }
         }
     }

--- a/src/ImageSharp.Processing/Processors/Effects/PixelateProcessor.cs
+++ b/src/ImageSharp.Processing/Processors/Effects/PixelateProcessor.cs
@@ -63,10 +63,10 @@ namespace ImageSharp.Processing.Processors
 
             // Get the range on the y-plane to choose from.
             IEnumerable<int> range = EnumerableExtensions.SteppedRange(minY, i => i < maxY, size);
-            TColor[] target = new TColor[source.Width * source.Height];
+            TColor[] target = PixelPool<TColor>.RentPixels(source.Width * source.Height);
 
             using (PixelAccessor<TColor> sourcePixels = source.Lock())
-            using (PixelAccessor<TColor> targetPixels = target.Lock<TColor>(source.Width, source.Height))
+            using (PixelAccessor<TColor> targetPixels = target.Lock(source.Width, source.Height))
             {
                 Parallel.ForEach(
                     range,

--- a/src/ImageSharp.Processing/Processors/Transforms/CompandingResizeProcessor.cs
+++ b/src/ImageSharp.Processing/Processors/Transforms/CompandingResizeProcessor.cs
@@ -66,103 +66,112 @@ namespace ImageSharp.Processing.Processors
             int minY = Math.Max(0, startY);
             int maxY = Math.Min(height, endY);
 
-            TColor[] target = new TColor[width * height];
+            TColor[] firstPass = null;
 
-            if (this.Sampler is NearestNeighborResampler)
+            try
             {
-                // Scaling factors
-                float widthFactor = sourceRectangle.Width / (float)this.ResizeRectangle.Width;
-                float heightFactor = sourceRectangle.Height / (float)this.ResizeRectangle.Height;
-
-                using (PixelAccessor<TColor> sourcePixels = source.Lock())
-                using (PixelAccessor<TColor> targetPixels = target.Lock<TColor>(width, height))
+                TColor[] target = PixelPool<TColor>.RentPixels(width * height);
+                if (this.Sampler is NearestNeighborResampler)
                 {
+                    // Scaling factors
+                    float widthFactor = sourceRectangle.Width / (float)this.ResizeRectangle.Width;
+                    float heightFactor = sourceRectangle.Height / (float)this.ResizeRectangle.Height;
+
+                    using (PixelAccessor<TColor> sourcePixels = source.Lock())
+                    using (PixelAccessor<TColor> targetPixels = target.Lock(width, height))
+                    {
+                        Parallel.For(
+                            minY,
+                            maxY,
+                            this.ParallelOptions,
+                            y =>
+                            {
+                                // Y coordinates of source points
+                                int originY = (int)((y - startY) * heightFactor);
+
+                                for (int x = minX; x < maxX; x++)
+                                {
+                                    // X coordinates of source points
+                                    targetPixels[x, y] = sourcePixels[(int)((x - startX) * widthFactor), originY];
+                                }
+                            });
+                    }
+
+                    // Break out now.
+                    source.SetPixels(width, height, target);
+                    return;
+                }
+
+                // Interpolate the image using the calculated weights.
+                // A 2-pass 1D algorithm appears to be faster than splitting a 1-pass 2D algorithm
+                // First process the columns. Since we are not using multiple threads startY and endY
+                // are the upper and lower bounds of the source rectangle.
+                firstPass = PixelPool<TColor>.RentPixels(width * source.Height);
+                using (PixelAccessor<TColor> sourcePixels = source.Lock())
+                using (PixelAccessor<TColor> firstPassPixels = firstPass.Lock(width, source.Height))
+                using (PixelAccessor<TColor> targetPixels = target.Lock(width, height))
+                {
+                    Parallel.For(
+                        0,
+                        sourceRectangle.Height,
+                        this.ParallelOptions,
+                        y =>
+                        {
+                            for (int x = minX; x < maxX; x++)
+                            {
+                                // Ensure offsets are normalised for cropping and padding.
+                                Weight[] horizontalValues = this.HorizontalWeights[x - startX].Values;
+
+                                // Destination color components
+                                Vector4 destination = Vector4.Zero;
+
+                                for (int i = 0; i < horizontalValues.Length; i++)
+                                {
+                                    Weight xw = horizontalValues[i];
+                                    destination += sourcePixels[xw.Index, y].ToVector4().Expand() * xw.Value;
+                                }
+
+                                TColor d = default(TColor);
+                                d.PackFromVector4(destination.Compress());
+                                firstPassPixels[x, y] = d;
+                            }
+                        });
+
+                    // Now process the rows.
                     Parallel.For(
                         minY,
                         maxY,
                         this.ParallelOptions,
                         y =>
                         {
-                            // Y coordinates of source points
-                            int originY = (int)((y - startY) * heightFactor);
+                            // Ensure offsets are normalised for cropping and padding.
+                            Weight[] verticalValues = this.VerticalWeights[y - startY].Values;
 
-                            for (int x = minX; x < maxX; x++)
+                            for (int x = 0; x < width; x++)
                             {
-                                // X coordinates of source points
-                                targetPixels[x, y] = sourcePixels[(int)((x - startX) * widthFactor), originY];
+                                // Destination color components
+                                Vector4 destination = Vector4.Zero;
+
+                                for (int i = 0; i < verticalValues.Length; i++)
+                                {
+                                    Weight yw = verticalValues[i];
+                                    destination += firstPassPixels[x, yw.Index].ToVector4().Expand() * yw.Value;
+                                }
+
+                                TColor d = default(TColor);
+                                d.PackFromVector4(destination.Compress());
+                                targetPixels[x, y] = d;
                             }
                         });
                 }
 
-                // Break out now.
                 source.SetPixels(width, height, target);
-                return;
             }
-
-            // Interpolate the image using the calculated weights.
-            // A 2-pass 1D algorithm appears to be faster than splitting a 1-pass 2D algorithm
-            // First process the columns. Since we are not using multiple threads startY and endY
-            // are the upper and lower bounds of the source rectangle.
-            TColor[] firstPass = new TColor[width * source.Height];
-            using (PixelAccessor<TColor> sourcePixels = source.Lock())
-            using (PixelAccessor<TColor> firstPassPixels = firstPass.Lock<TColor>(width, source.Height))
-            using (PixelAccessor<TColor> targetPixels = target.Lock<TColor>(width, height))
+            finally
             {
-                Parallel.For(
-                    0,
-                    sourceRectangle.Height,
-                    this.ParallelOptions,
-                    y =>
-                    {
-                        for (int x = minX; x < maxX; x++)
-                        {
-                            // Ensure offsets are normalised for cropping and padding.
-                            Weight[] horizontalValues = this.HorizontalWeights[x - startX].Values;
-
-                            // Destination color components
-                            Vector4 destination = Vector4.Zero;
-
-                            for (int i = 0; i < horizontalValues.Length; i++)
-                            {
-                                Weight xw = horizontalValues[i];
-                                destination += sourcePixels[xw.Index, y].ToVector4().Expand() * xw.Value;
-                            }
-
-                            TColor d = default(TColor);
-                            d.PackFromVector4(destination.Compress());
-                            firstPassPixels[x, y] = d;
-                        }
-                    });
-
-                // Now process the rows.
-                Parallel.For(
-                    minY,
-                    maxY,
-                    this.ParallelOptions,
-                    y =>
-                    {
-                        // Ensure offsets are normalised for cropping and padding.
-                        Weight[] verticalValues = this.VerticalWeights[y - startY].Values;
-
-                        for (int x = 0; x < width; x++)
-                        {
-                            // Destination color components
-                            Vector4 destination = Vector4.Zero;
-
-                            for (int i = 0; i < verticalValues.Length; i++)
-                            {
-                                Weight yw = verticalValues[i];
-                                destination += firstPassPixels[x, yw.Index].ToVector4().Expand() * yw.Value;
-                            }
-
-                            TColor d = default(TColor);
-                            d.PackFromVector4(destination.Compress());
-                            targetPixels[x, y] = d;
-                        }
-                    });
+                // We don't return target or source pixels as they are handled in the image itself.
+                PixelPool<TColor>.ReturnPixels(firstPass);
             }
-
-            source.SetPixels(width, height, target);
         }
     }
 }

--- a/src/ImageSharp.Processing/Processors/Transforms/CompandingResizeProcessor.cs
+++ b/src/ImageSharp.Processing/Processors/Transforms/CompandingResizeProcessor.cs
@@ -66,19 +66,15 @@ namespace ImageSharp.Processing.Processors
             int minY = Math.Max(0, startY);
             int maxY = Math.Min(height, endY);
 
-            TColor[] firstPass = null;
-
-            try
+            if (this.Sampler is NearestNeighborResampler)
             {
-                TColor[] target = PixelPool<TColor>.RentPixels(width * height);
-                if (this.Sampler is NearestNeighborResampler)
-                {
-                    // Scaling factors
-                    float widthFactor = sourceRectangle.Width / (float)this.ResizeRectangle.Width;
-                    float heightFactor = sourceRectangle.Height / (float)this.ResizeRectangle.Height;
+                // Scaling factors
+                float widthFactor = sourceRectangle.Width / (float)this.ResizeRectangle.Width;
+                float heightFactor = sourceRectangle.Height / (float)this.ResizeRectangle.Height;
 
+                using (PixelAccessor<TColor> targetPixels = new PixelAccessor<TColor>(width, height))
+                {
                     using (PixelAccessor<TColor> sourcePixels = source.Lock())
-                    using (PixelAccessor<TColor> targetPixels = target.Lock(width, height))
                     {
                         Parallel.For(
                             minY,
@@ -98,18 +94,19 @@ namespace ImageSharp.Processing.Processors
                     }
 
                     // Break out now.
-                    source.SetPixels(width, height, target);
+                    source.SwapPixelsBuffers(targetPixels);
                     return;
                 }
+            }
 
-                // Interpolate the image using the calculated weights.
-                // A 2-pass 1D algorithm appears to be faster than splitting a 1-pass 2D algorithm
-                // First process the columns. Since we are not using multiple threads startY and endY
-                // are the upper and lower bounds of the source rectangle.
-                firstPass = PixelPool<TColor>.RentPixels(width * source.Height);
+            // Interpolate the image using the calculated weights.
+            // A 2-pass 1D algorithm appears to be faster than splitting a 1-pass 2D algorithm
+            // First process the columns. Since we are not using multiple threads startY and endY
+            // are the upper and lower bounds of the source rectangle.
+            using (PixelAccessor<TColor> targetPixels = new PixelAccessor<TColor>(width, height))
+            {
                 using (PixelAccessor<TColor> sourcePixels = source.Lock())
-                using (PixelAccessor<TColor> firstPassPixels = firstPass.Lock(width, source.Height))
-                using (PixelAccessor<TColor> targetPixels = target.Lock(width, height))
+                using (PixelAccessor<TColor> firstPassPixels = new PixelAccessor<TColor>(width, source.Height))
                 {
                     Parallel.For(
                         0,
@@ -165,12 +162,7 @@ namespace ImageSharp.Processing.Processors
                         });
                 }
 
-                source.SetPixels(width, height, target);
-            }
-            finally
-            {
-                // We don't return target or source pixels as they are handled in the image itself.
-                PixelPool<TColor>.ReturnPixels(firstPass);
+                source.SwapPixelsBuffers(targetPixels);
             }
         }
     }

--- a/src/ImageSharp.Processing/Processors/Transforms/CropProcessor.cs
+++ b/src/ImageSharp.Processing/Processors/Transforms/CropProcessor.cs
@@ -42,10 +42,10 @@ namespace ImageSharp.Processing.Processors
             int minX = Math.Max(this.CropRectangle.X, sourceRectangle.X);
             int maxX = Math.Min(this.CropRectangle.Right, sourceRectangle.Right);
 
-            TColor[] target = new TColor[this.CropRectangle.Width * this.CropRectangle.Height];
+            TColor[] target = PixelPool<TColor>.RentPixels(this.CropRectangle.Width * this.CropRectangle.Height);
 
             using (PixelAccessor<TColor> sourcePixels = source.Lock())
-            using (PixelAccessor<TColor> targetPixels = target.Lock<TColor>(this.CropRectangle.Width, this.CropRectangle.Height))
+            using (PixelAccessor<TColor> targetPixels = target.Lock(this.CropRectangle.Width, this.CropRectangle.Height))
             {
                 Parallel.For(
                     minY,

--- a/src/ImageSharp.Processing/Processors/Transforms/EntropyCropProcessor.cs
+++ b/src/ImageSharp.Processing/Processors/Transforms/EntropyCropProcessor.cs
@@ -36,24 +36,24 @@ namespace ImageSharp.Processing.Processors
         /// <inheritdoc/>
         protected override void OnApply(ImageBase<TColor> source, Rectangle sourceRectangle)
         {
-            ImageBase<TColor> temp = new Image<TColor>(source.Width, source.Height);
-            temp.ClonePixels(source.Width, source.Height, source.Pixels);
-
-            // Detect the edges.
-            new SobelProcessor<TColor>().Apply(temp, sourceRectangle);
-
-            // Apply threshold binarization filter.
-            new BinaryThresholdProcessor<TColor>(this.Value).Apply(temp, sourceRectangle);
-
-            // Search for the first white pixels
-            Rectangle rectangle = ImageMaths.GetFilteredBoundingRectangle(temp, 0);
-
-            if (rectangle == sourceRectangle)
+            using (ImageBase<TColor> temp = new Image<TColor>(source))
             {
-                return;
-            }
+                // Detect the edges.
+                new SobelProcessor<TColor>().Apply(temp, sourceRectangle);
 
-            new CropProcessor<TColor>(rectangle).Apply(source, sourceRectangle);
+                // Apply threshold binarization filter.
+                new BinaryThresholdProcessor<TColor>(this.Value).Apply(temp, sourceRectangle);
+
+                // Search for the first white pixels
+                Rectangle rectangle = ImageMaths.GetFilteredBoundingRectangle(temp, 0);
+
+                if (rectangle == sourceRectangle)
+                {
+                    return;
+                }
+
+                new CropProcessor<TColor>(rectangle).Apply(source, sourceRectangle);
+            }
         }
     }
 }

--- a/src/ImageSharp.Processing/Processors/Transforms/FlipProcessor.cs
+++ b/src/ImageSharp.Processing/Processors/Transforms/FlipProcessor.cs
@@ -55,10 +55,10 @@ namespace ImageSharp.Processing.Processors
             int height = source.Height;
             int halfHeight = (int)Math.Ceiling(source.Height * .5F);
 
-            TColor[] target = new TColor[width * height];
+            TColor[] target = PixelPool<TColor>.RentPixels(width * height);
 
             using (PixelAccessor<TColor> sourcePixels = source.Lock())
-            using (PixelAccessor<TColor> targetPixels = target.Lock<TColor>(width, height))
+            using (PixelAccessor<TColor> targetPixels = target.Lock(width, height))
             {
                 Parallel.For(
                     0,
@@ -89,10 +89,10 @@ namespace ImageSharp.Processing.Processors
             int height = source.Height;
             int halfWidth = (int)Math.Ceiling(width * .5F);
 
-            TColor[] target = new TColor[width * height];
+            TColor[] target = PixelPool<TColor>.RentPixels(width * height);
 
             using (PixelAccessor<TColor> sourcePixels = source.Lock())
-            using (PixelAccessor<TColor> targetPixels = target.Lock<TColor>(width, height))
+            using (PixelAccessor<TColor> targetPixels = target.Lock(width, height))
             {
                 Parallel.For(
                     0,

--- a/src/ImageSharp.Processing/Processors/Transforms/FlipProcessor.cs
+++ b/src/ImageSharp.Processing/Processors/Transforms/FlipProcessor.cs
@@ -55,27 +55,27 @@ namespace ImageSharp.Processing.Processors
             int height = source.Height;
             int halfHeight = (int)Math.Ceiling(source.Height * .5F);
 
-            TColor[] target = PixelPool<TColor>.RentPixels(width * height);
-
-            using (PixelAccessor<TColor> sourcePixels = source.Lock())
-            using (PixelAccessor<TColor> targetPixels = target.Lock(width, height))
+            using (PixelAccessor<TColor> targetPixels = new PixelAccessor<TColor>(width, height))
             {
-                Parallel.For(
-                    0,
-                    halfHeight,
-                    this.ParallelOptions,
-                    y =>
-                        {
-                            for (int x = 0; x < width; x++)
+                using (PixelAccessor<TColor> sourcePixels = source.Lock())
+                {
+                    Parallel.For(
+                        0,
+                        halfHeight,
+                        this.ParallelOptions,
+                        y =>
                             {
-                                int newY = height - y - 1;
-                                targetPixels[x, y] = sourcePixels[x, newY];
-                                targetPixels[x, newY] = sourcePixels[x, y];
-                            }
-                        });
-            }
+                                for (int x = 0; x < width; x++)
+                                {
+                                    int newY = height - y - 1;
+                                    targetPixels[x, y] = sourcePixels[x, newY];
+                                    targetPixels[x, newY] = sourcePixels[x, y];
+                                }
+                            });
+                }
 
-            source.SetPixels(width, height, target);
+                source.SwapPixelsBuffers(targetPixels);
+            }
         }
 
         /// <summary>
@@ -89,27 +89,27 @@ namespace ImageSharp.Processing.Processors
             int height = source.Height;
             int halfWidth = (int)Math.Ceiling(width * .5F);
 
-            TColor[] target = PixelPool<TColor>.RentPixels(width * height);
-
-            using (PixelAccessor<TColor> sourcePixels = source.Lock())
-            using (PixelAccessor<TColor> targetPixels = target.Lock(width, height))
+            using (PixelAccessor<TColor> targetPixels = new PixelAccessor<TColor>(width, height))
             {
-                Parallel.For(
-                    0,
-                    height,
-                    this.ParallelOptions,
-                    y =>
-                        {
-                            for (int x = 0; x < halfWidth; x++)
+                using (PixelAccessor<TColor> sourcePixels = source.Lock())
+                {
+                    Parallel.For(
+                        0,
+                        height,
+                        this.ParallelOptions,
+                        y =>
                             {
-                                int newX = width - x - 1;
-                                targetPixels[x, y] = sourcePixels[newX, y];
-                                targetPixels[newX, y] = sourcePixels[x, y];
-                            }
-                        });
-            }
+                                for (int x = 0; x < halfWidth; x++)
+                                {
+                                    int newX = width - x - 1;
+                                    targetPixels[x, y] = sourcePixels[newX, y];
+                                    targetPixels[newX, y] = sourcePixels[x, y];
+                                }
+                            });
+                }
 
-            source.SetPixels(width, height, target);
+                source.SwapPixelsBuffers(targetPixels);
+            }
         }
     }
 }

--- a/src/ImageSharp.Processing/Processors/Transforms/ResizeProcessor.cs
+++ b/src/ImageSharp.Processing/Processors/Transforms/ResizeProcessor.cs
@@ -65,103 +65,112 @@ namespace ImageSharp.Processing.Processors
             int minY = Math.Max(0, startY);
             int maxY = Math.Min(height, endY);
 
-            TColor[] target = new TColor[width * height];
+            TColor[] firstPass = null;
 
-            if (this.Sampler is NearestNeighborResampler)
+            try
             {
-                // Scaling factors
-                float widthFactor = sourceRectangle.Width / (float)this.ResizeRectangle.Width;
-                float heightFactor = sourceRectangle.Height / (float)this.ResizeRectangle.Height;
-
-                using (PixelAccessor<TColor> sourcePixels = source.Lock())
-                using (PixelAccessor<TColor> targetPixels = target.Lock<TColor>(width, height))
+                TColor[] target = PixelPool<TColor>.RentPixels(width * height);
+                if (this.Sampler is NearestNeighborResampler)
                 {
+                    // Scaling factors
+                    float widthFactor = sourceRectangle.Width / (float)this.ResizeRectangle.Width;
+                    float heightFactor = sourceRectangle.Height / (float)this.ResizeRectangle.Height;
+
+                    using (PixelAccessor<TColor> sourcePixels = source.Lock())
+                    using (PixelAccessor<TColor> targetPixels = target.Lock(width, height))
+                    {
+                        Parallel.For(
+                            minY,
+                            maxY,
+                            this.ParallelOptions,
+                            y =>
+                            {
+                                // Y coordinates of source points
+                                int originY = (int)((y - startY) * heightFactor);
+
+                                for (int x = minX; x < maxX; x++)
+                                {
+                                    // X coordinates of source points
+                                    targetPixels[x, y] = sourcePixels[(int)((x - startX) * widthFactor), originY];
+                                }
+                            });
+                    }
+
+                    // Break out now.
+                    source.SetPixels(width, height, target);
+                    return;
+                }
+
+                // Interpolate the image using the calculated weights.
+                // A 2-pass 1D algorithm appears to be faster than splitting a 1-pass 2D algorithm
+                // First process the columns. Since we are not using multiple threads startY and endY
+                // are the upper and lower bounds of the source rectangle.
+                firstPass = PixelPool<TColor>.RentPixels(width * source.Height);
+                using (PixelAccessor<TColor> sourcePixels = source.Lock())
+                using (PixelAccessor<TColor> firstPassPixels = firstPass.Lock(width, source.Height))
+                using (PixelAccessor<TColor> targetPixels = target.Lock(width, height))
+                {
+                    Parallel.For(
+                        0,
+                        sourceRectangle.Height,
+                        this.ParallelOptions,
+                        y =>
+                        {
+                            for (int x = minX; x < maxX; x++)
+                            {
+                                // Ensure offsets are normalised for cropping and padding.
+                                Weight[] horizontalValues = this.HorizontalWeights[x - startX].Values;
+
+                                // Destination color components
+                                Vector4 destination = Vector4.Zero;
+
+                                for (int i = 0; i < horizontalValues.Length; i++)
+                                {
+                                    Weight xw = horizontalValues[i];
+                                    destination += sourcePixels[xw.Index, y].ToVector4() * xw.Value;
+                                }
+
+                                TColor d = default(TColor);
+                                d.PackFromVector4(destination);
+                                firstPassPixels[x, y] = d;
+                            }
+                        });
+
+                    // Now process the rows.
                     Parallel.For(
                         minY,
                         maxY,
                         this.ParallelOptions,
                         y =>
                         {
-                            // Y coordinates of source points
-                            int originY = (int)((y - startY) * heightFactor);
+                            // Ensure offsets are normalised for cropping and padding.
+                            Weight[] verticalValues = this.VerticalWeights[y - startY].Values;
 
-                            for (int x = minX; x < maxX; x++)
+                            for (int x = 0; x < width; x++)
                             {
-                                // X coordinates of source points
-                                targetPixels[x, y] = sourcePixels[(int)((x - startX) * widthFactor), originY];
+                                // Destination color components
+                                Vector4 destination = Vector4.Zero;
+
+                                for (int i = 0; i < verticalValues.Length; i++)
+                                {
+                                    Weight yw = verticalValues[i];
+                                    destination += firstPassPixels[x, yw.Index].ToVector4() * yw.Value;
+                                }
+
+                                TColor d = default(TColor);
+                                d.PackFromVector4(destination);
+                                targetPixels[x, y] = d;
                             }
                         });
                 }
 
-                // Break out now.
                 source.SetPixels(width, height, target);
-                return;
             }
-
-            // Interpolate the image using the calculated weights.
-            // A 2-pass 1D algorithm appears to be faster than splitting a 1-pass 2D algorithm
-            // First process the columns. Since we are not using multiple threads startY and endY
-            // are the upper and lower bounds of the source rectangle.
-            TColor[] firstPass = new TColor[width * source.Height];
-            using (PixelAccessor<TColor> sourcePixels = source.Lock())
-            using (PixelAccessor<TColor> firstPassPixels = firstPass.Lock<TColor>(width, source.Height))
-            using (PixelAccessor<TColor> targetPixels = target.Lock<TColor>(width, height))
+            finally
             {
-                Parallel.For(
-                    0,
-                    sourceRectangle.Height,
-                    this.ParallelOptions,
-                    y =>
-                    {
-                        for (int x = minX; x < maxX; x++)
-                        {
-                            // Ensure offsets are normalised for cropping and padding.
-                            Weight[] horizontalValues = this.HorizontalWeights[x - startX].Values;
-
-                            // Destination color components
-                            Vector4 destination = Vector4.Zero;
-
-                            for (int i = 0; i < horizontalValues.Length; i++)
-                            {
-                                Weight xw = horizontalValues[i];
-                                destination += sourcePixels[xw.Index, y].ToVector4() * xw.Value;
-                            }
-
-                            TColor d = default(TColor);
-                            d.PackFromVector4(destination);
-                            firstPassPixels[x, y] = d;
-                        }
-                    });
-
-                // Now process the rows.
-                Parallel.For(
-                    minY,
-                    maxY,
-                    this.ParallelOptions,
-                    y =>
-                    {
-                        // Ensure offsets are normalised for cropping and padding.
-                        Weight[] verticalValues = this.VerticalWeights[y - startY].Values;
-
-                        for (int x = 0; x < width; x++)
-                        {
-                            // Destination color components
-                            Vector4 destination = Vector4.Zero;
-
-                            for (int i = 0; i < verticalValues.Length; i++)
-                            {
-                                Weight yw = verticalValues[i];
-                                destination += firstPassPixels[x, yw.Index].ToVector4() * yw.Value;
-                            }
-
-                            TColor d = default(TColor);
-                            d.PackFromVector4(destination);
-                            targetPixels[x, y] = d;
-                        }
-                    });
+                // We don't return target or source pixels as they are handled in the image itself.
+                PixelPool<TColor>.ReturnPixels(firstPass);
             }
-
-            source.SetPixels(width, height, target);
         }
     }
 }

--- a/src/ImageSharp.Processing/Processors/Transforms/RotateProcessor.cs
+++ b/src/ImageSharp.Processing/Processors/Transforms/RotateProcessor.cs
@@ -42,10 +42,10 @@ namespace ImageSharp.Processing.Processors
             int height = this.CanvasRectangle.Height;
             int width = this.CanvasRectangle.Width;
             Matrix3x2 matrix = this.GetCenteredMatrix(source, this.processMatrix);
-            TColor[] target = new TColor[width * height];
+            TColor[] target = PixelPool<TColor>.RentPixels(width * height);
 
             using (PixelAccessor<TColor> sourcePixels = source.Lock())
-            using (PixelAccessor<TColor> targetPixels = target.Lock<TColor>(width, height))
+            using (PixelAccessor<TColor> targetPixels = target.Lock(width, height))
             {
                 Parallel.For(
                     0,
@@ -124,10 +124,10 @@ namespace ImageSharp.Processing.Processors
         {
             int width = source.Width;
             int height = source.Height;
-            TColor[] target = new TColor[width * height];
+            TColor[] target = PixelPool<TColor>.RentPixels(width * height);
 
             using (PixelAccessor<TColor> sourcePixels = source.Lock())
-            using (PixelAccessor<TColor> targetPixels = target.Lock<TColor>(height, width))
+            using (PixelAccessor<TColor> targetPixels = target.Lock(height, width))
             {
                 Parallel.For(
                     0,
@@ -156,10 +156,10 @@ namespace ImageSharp.Processing.Processors
         {
             int width = source.Width;
             int height = source.Height;
-            TColor[] target = new TColor[width * height];
+            TColor[] target = PixelPool<TColor>.RentPixels(width * height);
 
             using (PixelAccessor<TColor> sourcePixels = source.Lock())
-            using (PixelAccessor<TColor> targetPixels = target.Lock<TColor>(width, height))
+            using (PixelAccessor<TColor> targetPixels = target.Lock(width, height))
             {
                 Parallel.For(
                     0,
@@ -187,10 +187,10 @@ namespace ImageSharp.Processing.Processors
         {
             int width = source.Width;
             int height = source.Height;
-            TColor[] target = new TColor[width * height];
+            TColor[] target = PixelPool<TColor>.RentPixels(width * height);
 
             using (PixelAccessor<TColor> sourcePixels = source.Lock())
-            using (PixelAccessor<TColor> targetPixels = target.Lock<TColor>(height, width))
+            using (PixelAccessor<TColor> targetPixels = target.Lock(height, width))
             {
                 Parallel.For(
                     0,

--- a/src/ImageSharp.Processing/Processors/Transforms/RotateProcessor.cs
+++ b/src/ImageSharp.Processing/Processors/Transforms/RotateProcessor.cs
@@ -42,29 +42,30 @@ namespace ImageSharp.Processing.Processors
             int height = this.CanvasRectangle.Height;
             int width = this.CanvasRectangle.Width;
             Matrix3x2 matrix = this.GetCenteredMatrix(source, this.processMatrix);
-            TColor[] target = PixelPool<TColor>.RentPixels(width * height);
 
-            using (PixelAccessor<TColor> sourcePixels = source.Lock())
-            using (PixelAccessor<TColor> targetPixels = target.Lock(width, height))
+            using (PixelAccessor<TColor> targetPixels = new PixelAccessor<TColor>(width, height))
             {
-                Parallel.For(
-                    0,
-                    height,
-                    this.ParallelOptions,
-                    y =>
-                    {
-                        for (int x = 0; x < width; x++)
+                using (PixelAccessor<TColor> sourcePixels = source.Lock())
+                {
+                    Parallel.For(
+                        0,
+                        height,
+                        this.ParallelOptions,
+                        y =>
                         {
-                            Point transformedPoint = Point.Rotate(new Point(x, y), matrix);
-                            if (source.Bounds.Contains(transformedPoint.X, transformedPoint.Y))
+                            for (int x = 0; x < width; x++)
                             {
-                                targetPixels[x, y] = sourcePixels[transformedPoint.X, transformedPoint.Y];
+                                Point transformedPoint = Point.Rotate(new Point(x, y), matrix);
+                                if (source.Bounds.Contains(transformedPoint.X, transformedPoint.Y))
+                                {
+                                    targetPixels[x, y] = sourcePixels[transformedPoint.X, transformedPoint.Y];
+                                }
                             }
-                        }
-                    });
-            }
+                        });
+                }
 
-            source.SetPixels(width, height, target);
+                source.SwapPixelsBuffers(targetPixels);
+            }
         }
 
         /// <inheritdoc/>
@@ -124,28 +125,29 @@ namespace ImageSharp.Processing.Processors
         {
             int width = source.Width;
             int height = source.Height;
-            TColor[] target = PixelPool<TColor>.RentPixels(width * height);
 
-            using (PixelAccessor<TColor> sourcePixels = source.Lock())
-            using (PixelAccessor<TColor> targetPixels = target.Lock(height, width))
+            using (PixelAccessor<TColor> targetPixels = new PixelAccessor<TColor>(height, width))
             {
-                Parallel.For(
-                    0,
-                    height,
-                    this.ParallelOptions,
-                    y =>
-                    {
-                        for (int x = 0; x < width; x++)
+                using (PixelAccessor<TColor> sourcePixels = source.Lock())
+                {
+                    Parallel.For(
+                        0,
+                        height,
+                        this.ParallelOptions,
+                        y =>
                         {
-                            int newX = height - y - 1;
-                            newX = height - newX - 1;
-                            int newY = width - x - 1;
-                            targetPixels[newX, newY] = sourcePixels[x, y];
-                        }
-                    });
-            }
+                            for (int x = 0; x < width; x++)
+                            {
+                                int newX = height - y - 1;
+                                newX = height - newX - 1;
+                                int newY = width - x - 1;
+                                targetPixels[newX, newY] = sourcePixels[x, y];
+                            }
+                        });
+                }
 
-            source.SetPixels(height, width, target);
+                source.SwapPixelsBuffers(targetPixels);
+            }
         }
 
         /// <summary>
@@ -156,27 +158,28 @@ namespace ImageSharp.Processing.Processors
         {
             int width = source.Width;
             int height = source.Height;
-            TColor[] target = PixelPool<TColor>.RentPixels(width * height);
 
-            using (PixelAccessor<TColor> sourcePixels = source.Lock())
-            using (PixelAccessor<TColor> targetPixels = target.Lock(width, height))
+            using (PixelAccessor<TColor> targetPixels = new PixelAccessor<TColor>(width, height))
             {
-                Parallel.For(
-                    0,
-                    height,
-                    this.ParallelOptions,
-                    y =>
-                    {
-                        for (int x = 0; x < width; x++)
+                using (PixelAccessor<TColor> sourcePixels = source.Lock())
+                {
+                    Parallel.For(
+                        0,
+                        height,
+                        this.ParallelOptions,
+                        y =>
                         {
-                            int newX = width - x - 1;
-                            int newY = height - y - 1;
-                            targetPixels[newX, newY] = sourcePixels[x, y];
-                        }
-                    });
-            }
+                            for (int x = 0; x < width; x++)
+                            {
+                                int newX = width - x - 1;
+                                int newY = height - y - 1;
+                                targetPixels[newX, newY] = sourcePixels[x, y];
+                            }
+                        });
+                }
 
-            source.SetPixels(width, height, target);
+                source.SwapPixelsBuffers(targetPixels);
+            }
         }
 
         /// <summary>
@@ -187,26 +190,27 @@ namespace ImageSharp.Processing.Processors
         {
             int width = source.Width;
             int height = source.Height;
-            TColor[] target = PixelPool<TColor>.RentPixels(width * height);
 
-            using (PixelAccessor<TColor> sourcePixels = source.Lock())
-            using (PixelAccessor<TColor> targetPixels = target.Lock(height, width))
+            using (PixelAccessor<TColor> targetPixels = new PixelAccessor<TColor>(height, width))
             {
-                Parallel.For(
-                    0,
-                    height,
-                    this.ParallelOptions,
-                    y =>
-                    {
-                        for (int x = 0; x < width; x++)
+                using (PixelAccessor<TColor> sourcePixels = source.Lock())
+                {
+                    Parallel.For(
+                        0,
+                        height,
+                        this.ParallelOptions,
+                        y =>
                         {
-                            int newX = height - y - 1;
-                            targetPixels[newX, x] = sourcePixels[x, y];
-                        }
-                    });
-            }
+                            for (int x = 0; x < width; x++)
+                            {
+                                int newX = height - y - 1;
+                                targetPixels[newX, x] = sourcePixels[x, y];
+                            }
+                        });
+                }
 
-            source.SetPixels(height, width, target);
+                source.SwapPixelsBuffers(targetPixels);
+            }
         }
     }
 }

--- a/src/ImageSharp.Processing/Processors/Transforms/SkewProcessor.cs
+++ b/src/ImageSharp.Processing/Processors/Transforms/SkewProcessor.cs
@@ -42,10 +42,10 @@ namespace ImageSharp.Processing.Processors
             int height = this.CanvasRectangle.Height;
             int width = this.CanvasRectangle.Width;
             Matrix3x2 matrix = this.GetCenteredMatrix(source, this.processMatrix);
-            TColor[] target = new TColor[width * height];
+            TColor[] target = PixelPool<TColor>.RentPixels(width * height);
 
             using (PixelAccessor<TColor> sourcePixels = source.Lock())
-            using (PixelAccessor<TColor> targetPixels = target.Lock<TColor>(width, height))
+            using (PixelAccessor<TColor> targetPixels = target.Lock(width, height))
             {
                 Parallel.For(
                     0,

--- a/src/ImageSharp.Processing/Processors/Transforms/SkewProcessor.cs
+++ b/src/ImageSharp.Processing/Processors/Transforms/SkewProcessor.cs
@@ -42,29 +42,30 @@ namespace ImageSharp.Processing.Processors
             int height = this.CanvasRectangle.Height;
             int width = this.CanvasRectangle.Width;
             Matrix3x2 matrix = this.GetCenteredMatrix(source, this.processMatrix);
-            TColor[] target = PixelPool<TColor>.RentPixels(width * height);
 
-            using (PixelAccessor<TColor> sourcePixels = source.Lock())
-            using (PixelAccessor<TColor> targetPixels = target.Lock(width, height))
+            using (PixelAccessor<TColor> targetPixels = new PixelAccessor<TColor>(width, height))
             {
-                Parallel.For(
-                    0,
-                    height,
-                    this.ParallelOptions,
-                    y =>
-                        {
-                            for (int x = 0; x < width; x++)
+                using (PixelAccessor<TColor> sourcePixels = source.Lock())
+                {
+                    Parallel.For(
+                        0,
+                        height,
+                        this.ParallelOptions,
+                        y =>
                             {
-                                Point transformedPoint = Point.Skew(new Point(x, y), matrix);
-                                if (source.Bounds.Contains(transformedPoint.X, transformedPoint.Y))
+                                for (int x = 0; x < width; x++)
                                 {
-                                    targetPixels[x, y] = sourcePixels[transformedPoint.X, transformedPoint.Y];
+                                    Point transformedPoint = Point.Skew(new Point(x, y), matrix);
+                                    if (source.Bounds.Contains(transformedPoint.X, transformedPoint.Y))
+                                    {
+                                        targetPixels[x, y] = sourcePixels[transformedPoint.X, transformedPoint.Y];
+                                    }
                                 }
-                            }
-                        });
-            }
+                            });
+                }
 
-            source.SetPixels(width, height, target);
+                source.SwapPixelsBuffers(targetPixels);
+            }
         }
 
         /// <inheritdoc/>

--- a/src/ImageSharp.Processing/project.json
+++ b/src/ImageSharp.Processing/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0-alpha1-*",
+  "version": "1.0.0-alpha2-*",
   "title": "ImageSharp.Processing",
   "description": "A cross-platform library for the processing of image files; written in C#",
   "authors": [

--- a/src/ImageSharp.Processing/project.json
+++ b/src/ImageSharp.Processing/project.json
@@ -39,8 +39,7 @@
   },
   "dependencies": {
     "ImageSharp": {
-      "target": "project",
-      "version": "1.0.0-alpha1"
+      "target": "project"
     },
     "StyleCop.Analyzers": {
       "version": "1.1.0-beta001",

--- a/src/ImageSharp/Image/IImageBase{TColor}.cs
+++ b/src/ImageSharp/Image/IImageBase{TColor}.cs
@@ -32,35 +32,6 @@ namespace ImageSharp
         void InitPixels(int width, int height);
 
         /// <summary>
-        /// Sets the pixel array of the image to the given value.
-        /// </summary>
-        /// <param name="width">The new width of the image. Must be greater than zero.</param>
-        /// <param name="height">The new height of the image. Must be greater than zero.</param>
-        /// <param name="pixels">The array with pixels. Must be a multiple of the width and height.</param>
-        /// <exception cref="System.ArgumentOutOfRangeException">
-        /// Thrown if either <paramref name="width"/> or <paramref name="height"/> are less than or equal to 0.
-        /// </exception>
-        /// <exception cref="System.ArgumentException">
-        /// Thrown if the <paramref name="pixels"/> length is not equal to Width * Height.
-        /// </exception>
-        void SetPixels(int width, int height, TColor[] pixels);
-
-        /// <summary>
-        /// Sets the pixel array of the image to the given value, creating a copy of
-        /// the original pixels.
-        /// </summary>
-        /// <param name="width">The new width of the image. Must be greater than zero.</param>
-        /// <param name="height">The new height of the image. Must be greater than zero.</param>
-        /// <param name="pixels">The array with pixels. Must be a multiple of four times the width and height.</param>
-        /// <exception cref="System.ArgumentOutOfRangeException">
-        /// Thrown if either <paramref name="width"/> or <paramref name="height"/> are less than or equal to 0.
-        /// </exception>
-        /// <exception cref="System.ArgumentException">
-        /// Thrown if the <paramref name="pixels"/> length is not equal to Width * Height.
-        /// </exception>
-        void ClonePixels(int width, int height, TColor[] pixels);
-
-        /// <summary>
         /// Locks the image providing access to the pixels.
         /// <remarks>
         /// It is imperative that the accessor is correctly disposed off after use.

--- a/src/ImageSharp/Image/IImageBase{TColor}.cs
+++ b/src/ImageSharp/Image/IImageBase{TColor}.cs
@@ -11,11 +11,13 @@ namespace ImageSharp
     /// Encapsulates the basic properties and methods required to manipulate images in varying formats.
     /// </summary>
     /// <typeparam name="TColor">The pixel format.</typeparam>
-    public interface IImageBase<TColor> : IImageBase
+    public interface IImageBase<TColor> : IImageBase, IDisposable
         where TColor : struct, IPackedPixel, IEquatable<TColor>
     {
         /// <summary>
         /// Gets the pixels as an array of the given packed pixel format.
+        /// Important. Due to the nature in the way this is constructed do not rely on the length
+        /// of the array for calculations. Use Width * Height.
         /// </summary>
         TColor[] Pixels { get; }
 

--- a/src/ImageSharp/Image/ImageBase{TColor}.cs
+++ b/src/ImageSharp/Image/ImageBase{TColor}.cs
@@ -163,7 +163,7 @@ namespace ImageSharp
             int newWidth = pixelSource.Width;
             int newHeight = pixelSource.Height;
 
-            // push my memory into the accessor (which in turn unpins the old puffer ready for the images use)
+            // Push my memory into the accessor (which in turn unpins the old puffer ready for the images use)
             TColor[] newPixels = pixelSource.ReturnCurrentPixelsAndReplaceThemInternally(this.Width, this.Height, this.pixelBuffer, true);
             this.Width = newWidth;
             this.Height = newHeight;

--- a/src/ImageSharp/Image/ImageBase{TColor}.cs
+++ b/src/ImageSharp/Image/ImageBase{TColor}.cs
@@ -15,14 +15,9 @@ namespace ImageSharp
     /// </summary>
     /// <typeparam name="TColor">The pixel format.</typeparam>
     [DebuggerDisplay("Image: {Width}x{Height}")]
-    public abstract class ImageBase<TColor> : IImageBase<TColor> // IImageBase implements IDisposable
+    public abstract class ImageBase<TColor> : IImageBase<TColor>
         where TColor : struct, IPackedPixel, IEquatable<TColor>
     {
-        /// <summary>
-        /// The <see cref="ArrayPool{TColor}"/> used to pool data. TODO: Choose sensible default size and count
-        /// </summary>
-        private static readonly ArrayPool<TColor> ArrayPool = ArrayPool<TColor>.Create(int.MaxValue, 50);
-
         /// <summary>
         /// The image pixels
         /// </summary>
@@ -92,14 +87,6 @@ namespace ImageSharp
                 // Check we can do this without crashing
                 sourcePixels.CopyTo(target);
             }
-        }
-
-        /// <summary>
-        /// Finalizes an instance of the <see cref="ImageBase{TColor}"/> class.
-        /// </summary>
-        ~ImageBase()
-        {
-            this.Dispose(false);
         }
 
         /// <inheritdoc/>

--- a/src/ImageSharp/Image/ImageBase{TColor}.cs
+++ b/src/ImageSharp/Image/ImageBase{TColor}.cs
@@ -6,7 +6,6 @@
 namespace ImageSharp
 {
     using System;
-    using System.Buffers;
     using System.Diagnostics;
 
     /// <summary>

--- a/src/ImageSharp/Image/ImageBase{TColor}.cs
+++ b/src/ImageSharp/Image/ImageBase{TColor}.cs
@@ -6,6 +6,7 @@
 namespace ImageSharp
 {
     using System;
+    using System.Buffers;
     using System.Diagnostics;
 
     /// <summary>
@@ -14,13 +15,29 @@ namespace ImageSharp
     /// </summary>
     /// <typeparam name="TColor">The pixel format.</typeparam>
     [DebuggerDisplay("Image: {Width}x{Height}")]
-    public abstract class ImageBase<TColor> : IImageBase<TColor>
+    public abstract class ImageBase<TColor> : IImageBase<TColor> // IImageBase implements IDisposable
         where TColor : struct, IPackedPixel, IEquatable<TColor>
     {
+        /// <summary>
+        /// The <see cref="ArrayPool{TColor}"/> used to pool data. TODO: Choose sensible default size and count
+        /// </summary>
+        private static readonly ArrayPool<TColor> ArrayPool = ArrayPool<TColor>.Create(int.MaxValue, 50);
+
         /// <summary>
         /// The image pixels
         /// </summary>
         private TColor[] pixelBuffer;
+
+        /// <summary>
+        /// A value indicating whether this instance of the given entity has been disposed.
+        /// </summary>
+        /// <value><see langword="true"/> if this instance has been disposed; otherwise, <see langword="false"/>.</value>
+        /// <remarks>
+        /// If the entity is disposed, it must not be disposed a second time. The isDisposed field is set the first time the entity
+        /// is disposed. If the isDisposed field is true, then the Dispose() method will not dispose again. This help not to prolong the entity's
+        /// life in the Garbage Collector.
+        /// </remarks>
+        private bool isDisposed;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ImageBase{TColor}"/> class.
@@ -41,7 +58,7 @@ namespace ImageSharp
         /// <param name="configuration">
         /// The configuration providing initialization code which allows extending the library.
         /// </param>
-        /// <exception cref="System.ArgumentOutOfRangeException">
+        /// <exception cref="ArgumentOutOfRangeException">
         /// Thrown if either <paramref name="width"/> or <paramref name="height"/> are less than or equal to 0.
         /// </exception>
         protected ImageBase(int width, int height, Configuration configuration = null)
@@ -67,13 +84,22 @@ namespace ImageSharp
             this.Height = other.Height;
             this.CopyProperties(other);
 
-            // Copy the pixels. Unsafe.CopyBlock gives us a nice speed boost here.
-            this.pixelBuffer = new TColor[this.Width * this.Height];
+            // Rent then copy the pixels. Unsafe.CopyBlock gives us a nice speed boost here.
+            this.RentPixels();
             using (PixelAccessor<TColor> sourcePixels = other.Lock())
             using (PixelAccessor<TColor> target = this.Lock())
             {
+                // Check we can do this without crashing
                 sourcePixels.CopyTo(target);
             }
+        }
+
+        /// <summary>
+        /// Finalizes an instance of the <see cref="ImageBase{TColor}"/> class.
+        /// </summary>
+        ~ImageBase()
+        {
+            this.Dispose(false);
         }
 
         /// <inheritdoc/>
@@ -108,6 +134,19 @@ namespace ImageSharp
         /// </summary>
         public Configuration Configuration { get; private set; }
 
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            this.Dispose(true);
+
+            // This object will be cleaned up by the Dispose method.
+            // Therefore, you should call GC.SuppressFinalize to
+            // take this object off the finalization queue
+            // and prevent finalization code for this object
+            // from executing a second time.
+            GC.SuppressFinalize(this);
+        }
+
         /// <inheritdoc/>
         public void InitPixels(int width, int height)
         {
@@ -116,7 +155,7 @@ namespace ImageSharp
 
             this.Width = width;
             this.Height = height;
-            this.pixelBuffer = new TColor[width * height];
+            this.RentPixels();
         }
 
         /// <inheritdoc/>
@@ -126,13 +165,15 @@ namespace ImageSharp
             Guard.MustBeGreaterThan(height, 0, nameof(height));
             Guard.NotNull(pixels, nameof(pixels));
 
-            if (pixels.Length != width * height)
+            if (!(pixels.Length >= width * height))
             {
-                throw new ArgumentException("Pixel array must have the length of Width * Height.");
+                throw new ArgumentException($"Pixel array must have the length of at least {width * height}.");
             }
 
             this.Width = width;
             this.Height = height;
+
+            this.ReturnPixels();
             this.pixelBuffer = pixels;
         }
 
@@ -143,17 +184,18 @@ namespace ImageSharp
             Guard.MustBeGreaterThan(height, 0, nameof(height));
             Guard.NotNull(pixels, nameof(pixels));
 
-            if (pixels.Length != width * height)
+            if (!(pixels.Length >= width * height))
             {
-                throw new ArgumentException("Pixel array must have the length of Width * Height.");
+                throw new ArgumentException($"Pixel array must have the length of at least {width * height}.");
             }
 
             this.Width = width;
             this.Height = height;
 
             // Copy the pixels. TODO: use Unsafe.Copy.
-            this.pixelBuffer = new TColor[pixels.Length];
-            Array.Copy(pixels, this.pixelBuffer, pixels.Length);
+            this.ReturnPixels();
+            this.RentPixels();
+            Array.Copy(pixels, this.pixelBuffer, width * height);
         }
 
         /// <inheritdoc/>
@@ -173,6 +215,53 @@ namespace ImageSharp
             this.Configuration = other.Configuration;
             this.Quality = other.Quality;
             this.FrameDelay = other.FrameDelay;
+        }
+
+        /// <summary>
+        /// Releases any unmanaged resources from the inheriting class.
+        /// </summary>
+        protected virtual void ReleaseUnmanagedResources()
+        {
+            // TODO release unmanaged resources here
+        }
+
+        /// <summary>
+        /// Disposes the object and frees resources for the Garbage Collector.
+        /// </summary>
+        /// <param name="disposing">If true, the object gets disposed.</param>
+        protected virtual void Dispose(bool disposing)
+        {
+            if (this.isDisposed)
+            {
+                return;
+            }
+
+            this.ReleaseUnmanagedResources();
+
+            if (disposing)
+            {
+                this.ReturnPixels();
+            }
+
+            // Note disposing is done.
+            this.isDisposed = true;
+        }
+
+        /// <summary>
+        /// Rents the pixel array from the pool.
+        /// </summary>
+        private void RentPixels()
+        {
+            this.pixelBuffer = PixelPool<TColor>.RentPixels(this.Width * this.Height);
+        }
+
+        /// <summary>
+        /// Returns the rented pixel array back to the pool.
+        /// </summary>
+        private void ReturnPixels()
+        {
+            PixelPool<TColor>.ReturnPixels(this.pixelBuffer);
+            this.pixelBuffer = null;
         }
     }
 }

--- a/src/ImageSharp/Image/Image{TColor}.cs
+++ b/src/ImageSharp/Image/Image{TColor}.cs
@@ -334,9 +334,9 @@ namespace ImageSharp
                 target.ExifProfile = new ExifProfile(this.ExifProfile);
             }
 
-            foreach (ImageFrame<TColor> frame in this.Frames)
+            for (int i = 0; i < this.Frames.Count; i++)
             {
-                target.Frames.Add(frame.To<TColor2>());
+                target.Frames.Add(this.Frames[i].To<TColor2>());
             }
 
             return target;
@@ -370,6 +370,18 @@ namespace ImageSharp
         internal virtual ImageFrame<TColor> ToFrame()
         {
             return new ImageFrame<TColor>(this);
+        }
+
+        /// <inheritdoc />
+        protected override void Dispose(bool disposing)
+        {
+            // ReSharper disable once ForCanBeConvertedToForeach
+            for (int i = 0; i < this.Frames.Count; i++)
+            {
+                this.Frames[i].Dispose();
+            }
+
+            base.Dispose(disposing);
         }
 
         /// <summary>

--- a/src/ImageSharp/Image/PixelAccessor{TColor}.cs
+++ b/src/ImageSharp/Image/PixelAccessor{TColor}.cs
@@ -76,9 +76,9 @@ namespace ImageSharp
             Guard.MustBeGreaterThan(width, 0, nameof(width));
             Guard.MustBeGreaterThan(height, 0, nameof(height));
 
-            if (pixels.Length != width * height)
+            if (!(pixels.Length >= width * height))
             {
-                throw new ArgumentException("Pixel array must have the length of Width * Height.");
+                throw new ArgumentException($"Pixel array must have the length of at least {width * height}.");
             }
 
             this.Width = width;

--- a/src/ImageSharp/Image/PixelAccessor{TColor}.cs
+++ b/src/ImageSharp/Image/PixelAccessor{TColor}.cs
@@ -45,9 +45,9 @@ namespace ImageSharp
         private bool isDisposed;
 
         /// <summary>
-        /// The pixels data
+        /// The pixel buffer
         /// </summary>
-        private TColor[] pixels;
+        private TColor[] pixelBuffer;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="PixelAccessor{TColor}"/> class.
@@ -66,7 +66,7 @@ namespace ImageSharp
         /// <summary>
         /// Initializes a new instance of the <see cref="PixelAccessor{TColor}"/> class.
         /// </summary>
-        /// <param name="width">Gets the width of the image represented by the pixel buffer.</param>
+        /// <param name="width">The width of the image represented by the pixel buffer.</param>
         /// <param name="height">The height of the image represented by the pixel buffer.</param>
         /// <param name="pixels">The pixel buffer.</param>
         public PixelAccessor(int width, int height, TColor[] pixels)
@@ -77,7 +77,7 @@ namespace ImageSharp
         /// <summary>
         /// Initializes a new instance of the <see cref="PixelAccessor{TColor}"/> class.
         /// </summary>
-        /// <param name="width">Gets the width of the image represented by the pixel buffer.</param>
+        /// <param name="width">The width of the image represented by the pixel buffer.</param>
         /// <param name="height">The height of the image represented by the pixel buffer.</param>
         public PixelAccessor(int width, int height)
             : this(width, height, PixelPool<TColor>.RentPixels(width * height), true)
@@ -87,10 +87,10 @@ namespace ImageSharp
         /// <summary>
         /// Initializes a new instance of the <see cref="PixelAccessor{TColor}" /> class.
         /// </summary>
-        /// <param name="width">Gets the width of the image represented by the pixel buffer.</param>
+        /// <param name="width">The width of the image represented by the pixel buffer.</param>
         /// <param name="height">The height of the image represented by the pixel buffer.</param>
         /// <param name="pixels">The pixel buffer.</param>
-        /// <param name="pooledMemory">if set to <c>true</c> then the TColor[] is from the PixelPool{TColor} thus should be returned once disposed.</param>
+        /// <param name="pooledMemory">if set to <c>true</c> then the <see cref="T:TColor[]"/> is from the <see cref="PixelPool{TColor}"/> thus should be returned once disposed.</param>
         private PixelAccessor(int width, int height, TColor[] pixels, bool pooledMemory)
         {
             Guard.NotNull(pixels, nameof(pixels));
@@ -116,11 +116,8 @@ namespace ImageSharp
         }
 
         /// <summary>
-        /// Gets a value indicating whether [pooled memory].
+        /// Gets a value indicating whether the current pixel buffer is from a pooled source.
         /// </summary>
-        /// <value>
-        ///   <c>true</c> if [pooled memory]; otherwise, <c>false</c>.
-        /// </value>
         public bool PooledMemory { get; private set; }
 
         /// <summary>
@@ -259,8 +256,8 @@ namespace ImageSharp
 
             if (this.PooledMemory)
             {
-                PixelPool<TColor>.ReturnPixels(this.pixels);
-                this.pixels = null;
+                PixelPool<TColor>.ReturnPixels(this.pixelBuffer);
+                this.pixelBuffer = null;
             }
         }
 
@@ -273,17 +270,17 @@ namespace ImageSharp
         }
 
         /// <summary>
-        /// Sets the pixel buffer in an unsafe manor this should not be used unless you know what its doing!!!
+        /// Sets the pixel buffer in an unsafe manner. This should not be used unless you know what its doing!!!
         /// </summary>
         /// <param name="width">The width.</param>
         /// <param name="height">The height.</param>
         /// <param name="pixels">The pixels.</param>
-        /// <param name="pooledMemory">if set to <c>true</c> [pooled memory].</param>
+        /// <param name="pooledMemory">If set to <c>true</c> this indicates that the pixel buffer is from a pooled source.</param>
         /// <returns>Returns the old pixel data thats has gust been replaced.</returns>
-        /// <remarks>If PixelAccessor.PooledMemory is true then caller is responsible for ensuring PixelPool.ReturnPixels() is called.</remarks>
+        /// <remarks>If <see cref="M:PixelAccessor.PooledMemory"/> is true then caller is responsible for ensuring <see cref="M:PixelPool.ReturnPixels()"/> is called.</remarks>
         internal TColor[] ReturnCurrentPixelsAndReplaceThemInternally(int width, int height, TColor[] pixels, bool pooledMemory)
         {
-            TColor[] oldPixels = this.pixels;
+            TColor[] oldPixels = this.pixelBuffer;
             this.SetPixelBufferUnsafe(width, height, pixels, pooledMemory);
             return oldPixels;
         }
@@ -518,10 +515,10 @@ namespace ImageSharp
         /// <param name="width">The width.</param>
         /// <param name="height">The height.</param>
         /// <param name="pixels">The pixels.</param>
-        /// <param name="pooledMemory">if set to <c>true</c> [pooled memory].</param>
+        /// <param name="pooledMemory">If set to <c>true</c> this indicates that the pixel buffer is from a pooled source.</param>
         private void SetPixelBufferUnsafe(int width, int height, TColor[] pixels, bool pooledMemory)
         {
-            this.pixels = pixels;
+            this.pixelBuffer = pixels;
             this.PooledMemory = pooledMemory;
             this.Width = width;
             this.Height = height;
@@ -538,7 +535,7 @@ namespace ImageSharp
             // unpin any old pixels just incase
             this.UnPinPixels();
 
-            this.pixelsHandle = GCHandle.Alloc(this.pixels, GCHandleType.Pinned);
+            this.pixelsHandle = GCHandle.Alloc(this.pixelBuffer, GCHandleType.Pinned);
             this.dataPointer = this.pixelsHandle.AddrOfPinnedObject();
             this.pixelsBase = (byte*)this.dataPointer.ToPointer();
         }
@@ -639,13 +636,13 @@ namespace ImageSharp
             int width = Math.Min(area.Width, this.Width - x);
             if (width < 1)
             {
-                throw new ArgumentOutOfRangeException(nameof(width), width, $"Invalid area size specified.");
+                throw new ArgumentOutOfRangeException(nameof(width), width, "Invalid area size specified.");
             }
 
             int height = Math.Min(area.Height, this.Height - y);
             if (height < 1)
             {
-                throw new ArgumentOutOfRangeException(nameof(height), height, $"Invalid area size specified.");
+                throw new ArgumentOutOfRangeException(nameof(height), height, "Invalid area size specified.");
             }
         }
 

--- a/src/ImageSharp/Image/PixelPool{TColor}.cs
+++ b/src/ImageSharp/Image/PixelPool{TColor}.cs
@@ -36,15 +36,7 @@ namespace ImageSharp
         /// <param name="array">The array to return to the buffer pool.</param>
         public static void ReturnPixels(TColor[] array)
         {
-            try
-            {
-                ArrayPool.Return(array, true);
-            }
-            catch
-            {
-                // Do nothing.
-                // Hacky but it allows us to attempt to return non-pooled arrays and arrays that have already been returned
-            }
+            ArrayPool.Return(array, true);
         }
     }
 }

--- a/src/ImageSharp/Image/PixelPool{TColor}.cs
+++ b/src/ImageSharp/Image/PixelPool{TColor}.cs
@@ -1,0 +1,50 @@
+﻿// <copyright file="PixelPool{TColor}.cs" company="James Jackson-South">
+// Copyright (c) James Jackson-South and contributors.
+// Licensed under the Apache License, Version 2.0.
+// </copyright>
+
+namespace ImageSharp
+{
+    using System;
+    using System.Buffers;
+
+    /// <summary>
+    /// Provides a resource pool that enables reusing instances of type <see cref="T:TColor[]"/>.
+    /// </summary>
+    /// <typeparam name="TColor">The pixel format.</typeparam>
+    public static class PixelPool<TColor>
+        where TColor : struct, IPackedPixel, IEquatable<TColor>
+    {
+        /// <summary>
+        /// The <see cref="ArrayPool{T}"/> used to pool data. TODO: Choose sensible default size and count
+        /// </summary>
+        private static readonly ArrayPool<TColor> ArrayPool = ArrayPool<TColor>.Create(int.MaxValue, 50);
+
+        /// <summary>
+        /// Rents the pixel array from the pool.
+        /// </summary>
+        /// <param name="minimumLength">The minimum length of the array to return.</param>
+        /// <returns>The <see cref="T:TColor[]"/></returns>
+        public static TColor[] RentPixels(int minimumLength)
+        {
+            return ArrayPool.Rent(minimumLength);
+        }
+
+        /// <summary>
+        /// Returns the rented pixel array back to the pool.
+        /// </summary>
+        /// <param name="array">The array to return to the buffer pool.</param>
+        public static void ReturnPixels(TColor[] array)
+        {
+            try
+            {
+                ArrayPool.Return(array, true);
+            }
+            catch
+            {
+                // Do nothing.
+                // Hacky but it allows us to attempt to return non-pooled arrays and arrays that have already been returned
+            }
+        }
+    }
+}

--- a/src/ImageSharp/project.json
+++ b/src/ImageSharp/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0-alpha1-*",
+  "version": "1.0.0-alpha2-*",
   "title": "ImageSharp",
   "description": "A cross-platform library for the processing of image files; written in C#",
   "authors": [

--- a/tests/ImageSharp.Benchmarks/Drawing/DrawBeziers.cs
+++ b/tests/ImageSharp.Benchmarks/Drawing/DrawBeziers.cs
@@ -47,18 +47,22 @@ namespace ImageSharp.Benchmarks
         [Benchmark(Description = "ImageSharp Draw Beziers")]
         public void DrawLinesCore()
         {
-            CoreImage image = new CoreImage(800, 800);
-
-            image.DrawBeziers(CoreColor.HotPink, 10, new[] {
+            using (CoreImage image = new CoreImage(800, 800))
+            {
+                image.DrawBeziers(
+                    CoreColor.HotPink,
+                    10,
+                    new[] {
                         new Vector2(10, 500),
                         new Vector2(30, 10),
                         new Vector2(240, 30),
                         new Vector2(300, 500)
-            });
+                    });
 
-            using (MemoryStream ms = new MemoryStream())
-            {
-                image.SaveAsBmp(ms);
+                using (MemoryStream ms = new MemoryStream())
+                {
+                    image.SaveAsBmp(ms);
+                }
             }
         }
     }

--- a/tests/ImageSharp.Benchmarks/Drawing/DrawLines.cs
+++ b/tests/ImageSharp.Benchmarks/Drawing/DrawLines.cs
@@ -46,17 +46,21 @@ namespace ImageSharp.Benchmarks
         [Benchmark(Description = "ImageSharp Draw Lines")]
         public void DrawLinesCore()
         {
-            CoreImage image = new CoreImage(800, 800);
-
-            image.DrawLines(CoreColor.HotPink, 10, new[] {
-                     new Vector2(10, 10),
-                     new Vector2(550, 50),
-                     new Vector2(200, 400)
-            });
-
-            using (MemoryStream ms = new MemoryStream())
+            using (CoreImage image = new CoreImage(800, 800))
             {
-                image.SaveAsBmp(ms);
+                image.DrawLines(
+                    CoreColor.HotPink,
+                    10,
+                    new[] {
+                        new Vector2(10, 10),
+                        new Vector2(550, 50),
+                        new Vector2(200, 400)
+                    });
+
+                using (MemoryStream ms = new MemoryStream())
+                {
+                    image.SaveAsBmp(ms);
+                }
             }
         }
     }

--- a/tests/ImageSharp.Benchmarks/Drawing/DrawPolygon.cs
+++ b/tests/ImageSharp.Benchmarks/Drawing/DrawPolygon.cs
@@ -45,17 +45,21 @@ namespace ImageSharp.Benchmarks
         [Benchmark(Description = "ImageSharp Draw Polygon")]
         public void DrawPolygonCore()
         {
-            CoreImage image = new CoreImage(800, 800);
-
-            image.DrawPolygon(CoreColor.HotPink, 10, new[] {
-                     new Vector2(10, 10),
-                     new Vector2(550, 50),
-                     new Vector2(200, 400)
-            });
-
-            using (MemoryStream ms = new MemoryStream())
+            using (CoreImage image = new CoreImage(800, 800))
             {
-                image.SaveAsBmp(ms);
+                image.DrawPolygon(
+                    CoreColor.HotPink,
+                    10,
+                    new[] {
+                        new Vector2(10, 10),
+                        new Vector2(550, 50),
+                        new Vector2(200, 400)
+                    });
+
+                using (MemoryStream ms = new MemoryStream())
+                {
+                    image.SaveAsBmp(ms);
+                }
             }
         }
     }

--- a/tests/ImageSharp.Benchmarks/Drawing/FillPolygon.cs
+++ b/tests/ImageSharp.Benchmarks/Drawing/FillPolygon.cs
@@ -44,17 +44,20 @@ namespace ImageSharp.Benchmarks
         [Benchmark(Description = "ImageSharp Fill Polygon")]
         public void DrawSolidPolygonCore()
         {
-            CoreImage image = new CoreImage(800, 800);
-            image.FillPolygon(CoreColor.HotPink,
-                 new[] {
-                     new Vector2(10, 10),
-                     new Vector2(550, 50),
-                     new Vector2(200, 400)
-                 });
-
-            using (MemoryStream ms = new MemoryStream())
+            using (CoreImage image = new CoreImage(800, 800))
             {
-                image.SaveAsBmp(ms);
+                image.FillPolygon(
+                    CoreColor.HotPink,
+                    new[] {
+                        new Vector2(10, 10),
+                        new Vector2(550, 50),
+                        new Vector2(200, 400)
+                    });
+
+                using (MemoryStream ms = new MemoryStream())
+                {
+                    image.SaveAsBmp(ms);
+                }
             }
         }
     }

--- a/tests/ImageSharp.Benchmarks/Drawing/FillRectangle.cs
+++ b/tests/ImageSharp.Benchmarks/Drawing/FillRectangle.cs
@@ -28,7 +28,6 @@ namespace ImageSharp.Benchmarks
                 {
                     graphics.InterpolationMode = InterpolationMode.Default;
                     graphics.SmoothingMode = SmoothingMode.AntiAlias;
-                    var pen = new Pen(Color.HotPink, 10);
                     graphics.FillRectangle(Brushes.HotPink, new Rectangle(10, 10, 190, 140));
                 }
                 return destination.Size;
@@ -38,25 +37,29 @@ namespace ImageSharp.Benchmarks
         [Benchmark(Description = "ImageSharp Fill Rectangle")]
         public CoreSize FillRactangleCore()
         {
-            CoreImage image = new CoreImage(800, 800);
+            using (CoreImage image = new CoreImage(800, 800))
+            {
+                image.Fill(CoreColor.HotPink, new ImageSharp.Drawing.Shapes.RectangularPolygon(new CoreRectangle(10, 10, 190, 140)));
 
-            image.Fill(CoreColor.HotPink, new ImageSharp.Drawing.Shapes.RectangularPolygon(new CoreRectangle(10, 10, 190, 140)));
-
-            return new CoreSize(image.Width, image.Height);
+                return new CoreSize(image.Width, image.Height);
+            }
         }
 
         [Benchmark(Description = "ImageSharp Fill Rectangle - As Polygon")]
         public CoreSize FillPolygonCore()
         {
-            CoreImage image = new CoreImage(800, 800);
+            using (CoreImage image = new CoreImage(800, 800))
+            {
+                image.FillPolygon(
+                    CoreColor.HotPink,
+                    new[] {
+                new Vector2(10, 10),
+                new Vector2(200, 10),
+                new Vector2(200, 150),
+                new Vector2(10, 150) });
 
-            image.FillPolygon(CoreColor.HotPink, new[] {
-                            new Vector2(10, 10),
-                            new Vector2(200, 10),
-                            new Vector2(200, 150),
-                            new Vector2(10, 150) });
-
-            return new CoreSize(image.Width, image.Height);
+                return new CoreSize(image.Width, image.Height);
+            }
         }
     }
 }

--- a/tests/ImageSharp.Benchmarks/Drawing/FillWithPattern.cs
+++ b/tests/ImageSharp.Benchmarks/Drawing/FillWithPattern.cs
@@ -38,12 +38,14 @@ namespace ImageSharp.Benchmarks
         [Benchmark(Description = "ImageSharp Fill with Pattern")]
         public void DrawPatternPolygon3Core()
         {
-            CoreImage image = new CoreImage(800, 800);
-            image.Fill(CoreBrushes.BackwardDiagonal(CoreColor.HotPink));
-
-            using (MemoryStream ms = new MemoryStream())
+            using (CoreImage image = new CoreImage(800, 800))
             {
-                image.SaveAsBmp(ms);
+                image.Fill(CoreBrushes.BackwardDiagonal(CoreColor.HotPink));
+
+                using (MemoryStream ms = new MemoryStream())
+                {
+                    image.SaveAsBmp(ms);
+                }
             }
         }
     }

--- a/tests/ImageSharp.Benchmarks/Image/CopyPixels.cs
+++ b/tests/ImageSharp.Benchmarks/Image/CopyPixels.cs
@@ -17,24 +17,26 @@ namespace ImageSharp.Benchmarks.Image
         [Benchmark(Description = "Copy by Pixel")]
         public CoreColor CopyByPixel()
         {
-            CoreImage source = new CoreImage(1024, 768);
-            CoreImage target = new CoreImage(1024, 768);
-            using (PixelAccessor<CoreColor> sourcePixels = source.Lock())
-            using (PixelAccessor<CoreColor> targetPixels = target.Lock())
+            using (CoreImage source = new CoreImage(1024, 768))
+            using (CoreImage target = new CoreImage(1024, 768))
             {
-                Parallel.For(
-                    0,
-                    source.Height,
-                    Configuration.Default.ParallelOptions,
-                    y =>
-                    {
-                        for (int x = 0; x < source.Width; x++)
-                        {
-                            targetPixels[x, y] = sourcePixels[x, y];
-                        }
-                    });
+                using (PixelAccessor<CoreColor> sourcePixels = source.Lock())
+                using (PixelAccessor<CoreColor> targetPixels = target.Lock())
+                {
+                    Parallel.For(
+                        0,
+                        source.Height,
+                        Configuration.Default.ParallelOptions,
+                        y =>
+                            {
+                                for (int x = 0; x < source.Width; x++)
+                                {
+                                    targetPixels[x, y] = sourcePixels[x, y];
+                                }
+                            });
 
-                return targetPixels[0, 0];
+                    return targetPixels[0, 0];
+                }
             }
         }
     }

--- a/tests/ImageSharp.Benchmarks/Image/DecodeBmp.cs
+++ b/tests/ImageSharp.Benchmarks/Image/DecodeBmp.cs
@@ -43,8 +43,10 @@ namespace ImageSharp.Benchmarks.Image
         {
             using (MemoryStream memoryStream = new MemoryStream(this.bmpBytes))
             {
-                CoreImage image = new CoreImage(memoryStream);
-                return new CoreSize(image.Width, image.Height);
+                using (CoreImage image = new CoreImage(memoryStream))
+                {
+                    return new CoreSize(image.Width, image.Height);
+                }
             }
         }
     }

--- a/tests/ImageSharp.Benchmarks/Image/DecodeFilteredPng.cs
+++ b/tests/ImageSharp.Benchmarks/Image/DecodeFilteredPng.cs
@@ -29,37 +29,40 @@ namespace ImageSharp.Benchmarks.Image
             this.filter4 = new MemoryStream(File.ReadAllBytes("../ImageSharp.Tests/TestImages/Formats/Png/filter4.png"));
         }
 
-        private Image LoadPng(MemoryStream stream)
+        private Size LoadPng(MemoryStream stream)
         {
-            return new Image(stream);
+            using (Image image = new Image(stream))
+            {
+                return new Size(image.Width, image.Height);
+            }
         }
 
         [Benchmark(Baseline = true, Description = "None-filtered PNG file")]
-        public Image PngFilter0()
+        public Size PngFilter0()
         {
             return LoadPng(filter0);
         }
 
         [Benchmark(Description = "Sub-filtered PNG file")]
-        public Image PngFilter1()
+        public Size PngFilter1()
         {
             return LoadPng(filter1);
         }
 
         [Benchmark(Description = "Up-filtered PNG file")]
-        public Image PngFilter2()
+        public Size PngFilter2()
         {
             return LoadPng(filter2);
         }
 
         [Benchmark(Description = "Average-filtered PNG file")]
-        public Image PngFilter3()
+        public Size PngFilter3()
         {
             return LoadPng(filter3);
         }
 
         [Benchmark(Description = "Paeth-filtered PNG file")]
-        public Image PngFilter4()
+        public Size PngFilter4()
         {
             return LoadPng(filter4);
         }

--- a/tests/ImageSharp.Benchmarks/Image/DecodeGif.cs
+++ b/tests/ImageSharp.Benchmarks/Image/DecodeGif.cs
@@ -43,8 +43,10 @@ namespace ImageSharp.Benchmarks.Image
         {
             using (MemoryStream memoryStream = new MemoryStream(this.gifBytes))
             {
-                CoreImage image = new CoreImage(memoryStream);
-                return new CoreSize(image.Width, image.Height);
+                using (CoreImage image = new CoreImage(memoryStream))
+                {
+                    return new CoreSize(image.Width, image.Height);
+                }
             }
         }
     }

--- a/tests/ImageSharp.Benchmarks/Image/DecodeJpeg.cs
+++ b/tests/ImageSharp.Benchmarks/Image/DecodeJpeg.cs
@@ -43,8 +43,10 @@ namespace ImageSharp.Benchmarks.Image
         {
             using (MemoryStream memoryStream = new MemoryStream(this.jpegBytes))
             {
-                CoreImage image = new CoreImage(memoryStream);
-                return new CoreSize(image.Width, image.Height);
+                using (CoreImage image = new CoreImage(memoryStream))
+                {
+                    return new CoreSize(image.Width, image.Height);
+                }
             }
         }
     }

--- a/tests/ImageSharp.Benchmarks/Image/DecodePng.cs
+++ b/tests/ImageSharp.Benchmarks/Image/DecodePng.cs
@@ -43,8 +43,10 @@ namespace ImageSharp.Benchmarks.Image
         {
             using (MemoryStream memoryStream = new MemoryStream(this.pngBytes))
             {
-                CoreImage image = new CoreImage(memoryStream);
-                return new CoreSize(image.Width, image.Height);
+                using (CoreImage image = new CoreImage(memoryStream))
+                {
+                    return new CoreSize(image.Width, image.Height);
+                }
             }
         }
     }

--- a/tests/ImageSharp.Benchmarks/Image/EncodeBmp.cs
+++ b/tests/ImageSharp.Benchmarks/Image/EncodeBmp.cs
@@ -31,6 +31,14 @@ namespace ImageSharp.Benchmarks.Image
             }
         }
 
+        [Cleanup]
+        public void Cleanup()
+        {
+            this.bmpStream.Dispose();
+            this.bmpCore.Dispose();
+            this.bmpDrawing.Dispose();
+        }
+
         [Benchmark(Baseline = true, Description = "System.Drawing Bmp")]
         public void BmpSystemDrawing()
         {

--- a/tests/ImageSharp.Benchmarks/Image/EncodeBmpMultiple.cs
+++ b/tests/ImageSharp.Benchmarks/Image/EncodeBmpMultiple.cs
@@ -18,7 +18,7 @@ namespace ImageSharp.Benchmarks.Image
         protected override IEnumerable<string> InputImageSubfoldersOrFiles => new[] { "Bmp/", "Jpg/baseline" };
 
         [Benchmark(Description = "EncodeBmpMultiple - ImageSharp")]
-        public void EncodeGifImageSharp()
+        public void EncodeBmpImageSharp()
         {
             this.ForEachImageSharpImage(
                 (img, ms) =>
@@ -29,7 +29,7 @@ namespace ImageSharp.Benchmarks.Image
         }
 
         [Benchmark(Baseline = true, Description = "EncodeBmpMultiple - System.Drawing")]
-        public void EncodeGifSystemDrawing()
+        public void EncodeBmpSystemDrawing()
         {
             this.ForEachSystemDrawingImage(
                 (img, ms) =>

--- a/tests/ImageSharp.Benchmarks/Image/EncodeGif.cs
+++ b/tests/ImageSharp.Benchmarks/Image/EncodeGif.cs
@@ -31,6 +31,14 @@ namespace ImageSharp.Benchmarks.Image
             }
         }
 
+        [Cleanup]
+        public void Cleanup()
+        {
+            this.bmpStream.Dispose();
+            this.bmpCore.Dispose();
+            this.bmpDrawing.Dispose();
+        }
+
         [Benchmark(Baseline = true, Description = "System.Drawing Gif")]
         public void GifSystemDrawing()
         {

--- a/tests/ImageSharp.Benchmarks/Image/EncodeJpeg.cs
+++ b/tests/ImageSharp.Benchmarks/Image/EncodeJpeg.cs
@@ -31,6 +31,14 @@ namespace ImageSharp.Benchmarks.Image
             }
         }
 
+        [Cleanup]
+        public void Cleanup()
+        {
+            this.bmpStream.Dispose();
+            this.bmpCore.Dispose();
+            this.bmpDrawing.Dispose();
+        }
+
         [Benchmark(Baseline = true, Description = "System.Drawing Jpeg")]
         public void JpegSystemDrawing()
         {

--- a/tests/ImageSharp.Benchmarks/Image/EncodePng.cs
+++ b/tests/ImageSharp.Benchmarks/Image/EncodePng.cs
@@ -31,6 +31,14 @@ namespace ImageSharp.Benchmarks.Image
             }
         }
 
+        [Cleanup]
+        public void Cleanup()
+        {
+            this.bmpStream.Dispose();
+            this.bmpCore.Dispose();
+            this.bmpDrawing.Dispose();
+        }
+
         [Benchmark(Baseline = true, Description = "System.Drawing Png")]
         public void PngSystemDrawing()
         {

--- a/tests/ImageSharp.Benchmarks/Image/GetSetPixel.cs
+++ b/tests/ImageSharp.Benchmarks/Image/GetSetPixel.cs
@@ -28,11 +28,13 @@ namespace ImageSharp.Benchmarks.Image
         [Benchmark(Description = "ImageSharp GetSet pixel")]
         public CoreColor ResizeCore()
         {
-            CoreImage image = new CoreImage(400, 400);
-            using (PixelAccessor<CoreColor> imagePixels = image.Lock())
+            using (CoreImage image = new CoreImage(400, 400))
             {
-                imagePixels[200, 200] = CoreColor.White;
-                return imagePixels[200, 200];
+                using (PixelAccessor<CoreColor> imagePixels = image.Lock())
+                {
+                    imagePixels[200, 200] = CoreColor.White;
+                    return imagePixels[200, 200];
+                }
             }
         }
     }

--- a/tests/ImageSharp.Benchmarks/Samplers/Crop.cs
+++ b/tests/ImageSharp.Benchmarks/Samplers/Crop.cs
@@ -38,9 +38,11 @@ namespace ImageSharp.Benchmarks
         [Benchmark(Description = "ImageSharp Crop")]
         public CoreSize CropResizeCore()
         {
-            CoreImage image = new CoreImage(800, 800);
-            image.Crop(100, 100);
-            return new CoreSize(image.Width, image.Height);
+            using (CoreImage image = new CoreImage(800, 800))
+            {
+                image.Crop(100, 100);
+                return new CoreSize(image.Width, image.Height);
+            }
         }
     }
 }

--- a/tests/ImageSharp.Benchmarks/Samplers/DetectEdges.cs
+++ b/tests/ImageSharp.Benchmarks/Samplers/DetectEdges.cs
@@ -28,6 +28,12 @@ namespace ImageSharp.Benchmarks
             }
         }
 
+        [Cleanup]
+        public void Cleanup()
+        {
+            this.image.Dispose();
+        }
+
         [Benchmark(Description = "ImageSharp DetectEdges")]
         public void ImageProcessorCoreDetectEdges()
         {

--- a/tests/ImageSharp.Benchmarks/Samplers/Resize.cs
+++ b/tests/ImageSharp.Benchmarks/Samplers/Resize.cs
@@ -37,17 +37,21 @@ namespace ImageSharp.Benchmarks
         [Benchmark(Description = "ImageSharp Resize")]
         public CoreSize ResizeCore()
         {
-            CoreImage image = new CoreImage(2000, 2000);
-            image.Resize(400, 400);
-            return new CoreSize(image.Width, image.Height);
+            using (CoreImage image = new CoreImage(2000, 2000))
+            {
+                image.Resize(400, 400);
+                return new CoreSize(image.Width, image.Height);
+            }
         }
 
         [Benchmark(Description = "ImageSharp Compand Resize")]
         public CoreSize ResizeCoreCompand()
         {
-            CoreImage image = new CoreImage(2000, 2000);
-            image.Resize(400, 400, true);
-            return new CoreSize(image.Width, image.Height);
+            using (CoreImage image = new CoreImage(2000, 2000))
+            {
+                image.Resize(400, 400, true);
+                return new CoreSize(image.Width, image.Height);
+            }
         }
     }
 }

--- a/tests/ImageSharp.Tests/Drawing/BeziersTests.cs
+++ b/tests/ImageSharp.Tests/Drawing/BeziersTests.cs
@@ -15,89 +15,88 @@ namespace ImageSharp.Tests.Drawing
 
     public class Beziers : FileTestBase
     {
-
-
         [Fact]
         public void ImageShouldBeOverlayedByBezierLine()
         {
-            string path = CreateOutputDirectory("Drawing","BezierLine");
-var image = new Image(500, 500);
-
-using (FileStream output = File.OpenWrite($"{path}/Simple.png"))
-{
-    image
-        .BackgroundColor(Color.Blue)
-        .DrawBeziers(Color.HotPink, 5, new[] {
-            new Vector2(10, 400),
-            new Vector2(30, 10),
-            new Vector2(240, 30),
-            new Vector2(300, 400)
-        })
-        .Save(output);
-}
-
-            using (var sourcePixels = image.Lock())
+            string path = this.CreateOutputDirectory("Drawing", "BezierLine");
+            using (Image image = new Image(500, 500))
             {
-                //top of curve
-                Assert.Equal(Color.HotPink, sourcePixels[138,115]);
+                using (FileStream output = File.OpenWrite($"{path}/Simple.png"))
+                {
+                    image.BackgroundColor(Color.Blue)
+                        .DrawBeziers(Color.HotPink, 5,
+                            new[] {
+                                new Vector2(10, 400),
+                                new Vector2(30, 10),
+                                new Vector2(240, 30),
+                                new Vector2(300, 400)
+                            })
+                        .Save(output);
+                }
 
-                //start points                
-                Assert.Equal(Color.HotPink, sourcePixels[10, 400]);
-                Assert.Equal(Color.HotPink, sourcePixels[300, 400]);
+                using (PixelAccessor<Color> sourcePixels = image.Lock())
+                {
+                    //top of curve
+                    Assert.Equal(Color.HotPink, sourcePixels[138, 115]);
 
-                //curve points should not be never be set
-                Assert.Equal(Color.Blue, sourcePixels[30, 10]);
-                Assert.Equal(Color.Blue, sourcePixels[240, 30]);
+                    //start points
+                    Assert.Equal(Color.HotPink, sourcePixels[10, 400]);
+                    Assert.Equal(Color.HotPink, sourcePixels[300, 400]);
 
-                // inside shape should be empty
-                Assert.Equal(Color.Blue, sourcePixels[200, 250]);
+                    //curve points should not be never be set
+                    Assert.Equal(Color.Blue, sourcePixels[30, 10]);
+                    Assert.Equal(Color.Blue, sourcePixels[240, 30]);
+
+                    // inside shape should be empty
+                    Assert.Equal(Color.Blue, sourcePixels[200, 250]);
+                }
             }
-
         }
 
 
         [Fact]
         public void ImageShouldBeOverlayedBezierLineWithOpacity()
         {
-            string path = CreateOutputDirectory("Drawing", "BezierLine");
+            string path = this.CreateOutputDirectory("Drawing", "BezierLine");
 
-            var color = new Color(Color.HotPink.R, Color.HotPink.G, Color.HotPink.B, 150);
+            Color color = new Color(Color.HotPink.R, Color.HotPink.G, Color.HotPink.B, 150);
 
-            var image = new Image(500, 500);
-            
-            using (FileStream output = File.OpenWrite($"{path}/Opacity.png"))
+            using (Image image = new Image(500, 500))
             {
-                image
-                    .BackgroundColor(Color.Blue)
-                    .DrawBeziers(color, 10, new[] {
-                        new Vector2(10, 400),
-                        new Vector2(30, 10),
-                        new Vector2(240, 30),
-                        new Vector2(300, 400)
-                    })
-                    .Save(output);
+                using (FileStream output = File.OpenWrite($"{path}/Opacity.png"))
+                {
+                    image.BackgroundColor(Color.Blue)
+                        .DrawBeziers(color,
+                        10,
+                        new[] {
+                            new Vector2(10, 400),
+                            new Vector2(30, 10),
+                            new Vector2(240, 30),
+                            new Vector2(300, 400)
+                        })
+                        .Save(output);
+                }
+
+                //shift background color towards forground color by the opacity amount
+                Color mergedColor = new Color(Vector4.Lerp(Color.Blue.ToVector4(), Color.HotPink.ToVector4(), 150f / 255f));
+
+                using (PixelAccessor<Color> sourcePixels = image.Lock())
+                {
+                    //top of curve
+                    Assert.Equal(mergedColor, sourcePixels[138, 115]);
+
+                    //start points
+                    Assert.Equal(mergedColor, sourcePixels[10, 400]);
+                    Assert.Equal(mergedColor, sourcePixels[300, 400]);
+
+                    //curve points should not be never be set
+                    Assert.Equal(Color.Blue, sourcePixels[30, 10]);
+                    Assert.Equal(Color.Blue, sourcePixels[240, 30]);
+
+                    // inside shape should be empty
+                    Assert.Equal(Color.Blue, sourcePixels[200, 250]);
+                }
             }
-
-            //shift background color towards forground color by the opacity amount
-            var mergedColor = new Color(Vector4.Lerp(Color.Blue.ToVector4(), Color.HotPink.ToVector4(), 150f/255f));
-
-            using (var sourcePixels = image.Lock())
-            {
-                //top of curve
-                Assert.Equal(mergedColor, sourcePixels[138, 115]);
-
-                //start points                
-                Assert.Equal(mergedColor, sourcePixels[10, 400]);
-                Assert.Equal(mergedColor, sourcePixels[300, 400]);
-
-                //curve points should not be never be set
-                Assert.Equal(Color.Blue, sourcePixels[30, 10]);
-                Assert.Equal(Color.Blue, sourcePixels[240, 30]);
-
-                // inside shape should be empty
-                Assert.Equal(Color.Blue, sourcePixels[200, 250]);
-            }
-        }       
-        
+        }
     }
 }

--- a/tests/ImageSharp.Tests/Drawing/DrawImageTest.cs
+++ b/tests/ImageSharp.Tests/Drawing/DrawImageTest.cs
@@ -6,7 +6,6 @@
 namespace ImageSharp.Tests
 {
     using System.IO;
-    using System.Linq;
 
     using Xunit;
 
@@ -15,18 +14,20 @@ namespace ImageSharp.Tests
         [Fact]
         public void ImageShouldApplyDrawImageFilter()
         {
-            string path = CreateOutputDirectory("Drawing", "DrawImage");
+            string path = this.CreateOutputDirectory("Drawing", "DrawImage");
 
-            Image blend = TestFile.Create(TestImages.Bmp.Car).CreateImage();
-
-            foreach (TestFile file in Files)
+            using (Image blend = TestFile.Create(TestImages.Bmp.Car).CreateImage())
             {
-                Image image = file.CreateImage();
-
-                using (FileStream output = File.OpenWrite($"{path}/{file.FileName}"))
+                foreach (TestFile file in Files)
                 {
-                    image.DrawImage(blend, 75, new Size(image.Width / 2, image.Height / 2), new Point(image.Width / 4, image.Height / 4))
-                         .Save(output);
+                    using (Image image = file.CreateImage())
+                    {
+                        using (FileStream output = File.OpenWrite($"{path}/{file.FileName}"))
+                        {
+                            image.DrawImage(blend, 75, new Size(image.Width / 2, image.Height / 2), new Point(image.Width / 4, image.Height / 4))
+                                 .Save(output);
+                        }
+                    }
                 }
             }
         }

--- a/tests/ImageSharp.Tests/Drawing/DrawPathTests.cs
+++ b/tests/ImageSharp.Tests/Drawing/DrawPathTests.cs
@@ -20,81 +20,82 @@ namespace ImageSharp.Tests.Drawing
         [Fact]
         public void ImageShouldBeOverlayedByPath()
         {
-            string path = CreateOutputDirectory("Drawing", "Path");
-            var image = new Image(500, 500);
-
-            var linerSegemnt = new LinearLineSegment(
-                            new Vector2(10, 10),
-                            new Vector2(200, 150),
-                            new Vector2(50, 300));
-            var bazierSegment = new BezierLineSegment(new Vector2(50, 300),
-                            new Vector2(500, 500),
-                            new Vector2(60, 10),
-                            new Vector2(10, 400));
-
-            var p = new CorePath(linerSegemnt, bazierSegment);
-
-            using (FileStream output = File.OpenWrite($"{path}/Simple.png"))
+            string path = this.CreateOutputDirectory("Drawing", "Path");
+            using (Image image = new Image(500, 500))
             {
-                image
-                    .BackgroundColor(Color.Blue)
-                    .DrawPath(Color.HotPink, 5, p)
-                    .Save(output);
+                LinearLineSegment linerSegemnt = new LinearLineSegment(
+                    new Vector2(10, 10),
+                    new Vector2(200, 150),
+                    new Vector2(50, 300));
+                BezierLineSegment bazierSegment = new BezierLineSegment(new Vector2(50, 300),
+                    new Vector2(500, 500),
+                    new Vector2(60, 10),
+                    new Vector2(10, 400));
+
+                CorePath p = new CorePath(linerSegemnt, bazierSegment);
+
+                using (FileStream output = File.OpenWrite($"{path}/Simple.png"))
+                {
+                    image
+                        .BackgroundColor(Color.Blue)
+                        .DrawPath(Color.HotPink, 5, p)
+                        .Save(output);
+                }
+
+                using (PixelAccessor<Color> sourcePixels = image.Lock())
+                {
+                    Assert.Equal(Color.HotPink, sourcePixels[9, 9]);
+
+                    Assert.Equal(Color.HotPink, sourcePixels[199, 149]);
+
+                    Assert.Equal(Color.Blue, sourcePixels[50, 50]);
+                }
             }
-
-            using (var sourcePixels = image.Lock())
-            {
-                Assert.Equal(Color.HotPink, sourcePixels[9, 9]);
-
-                Assert.Equal(Color.HotPink, sourcePixels[199, 149]);
-
-                Assert.Equal(Color.Blue, sourcePixels[50, 50]);
-            }
-
         }
 
 
         [Fact]
         public void ImageShouldBeOverlayedPathWithOpacity()
         {
-            string path = CreateOutputDirectory("Drawing", "Path");
+            string path = this.CreateOutputDirectory("Drawing", "Path");
 
-            var color = new Color(Color.HotPink.R, Color.HotPink.G, Color.HotPink.B, 150);
+            Color color = new Color(Color.HotPink.R, Color.HotPink.G, Color.HotPink.B, 150);
 
 
-            var linerSegemnt = new LinearLineSegment(
+            LinearLineSegment linerSegemnt = new LinearLineSegment(
                             new Vector2(10, 10),
                             new Vector2(200, 150),
                             new Vector2(50, 300)
                     );
-            var bazierSegment = new BezierLineSegment(new Vector2(50, 300),
+
+            BezierLineSegment bazierSegment = new BezierLineSegment(new Vector2(50, 300),
                 new Vector2(500, 500),
                 new Vector2(60, 10),
                 new Vector2(10, 400));
 
-            var p = new CorePath(linerSegemnt, bazierSegment);
+            CorePath p = new CorePath(linerSegemnt, bazierSegment);
 
-            var image = new Image(500, 500);
-
-
-            using (FileStream output = File.OpenWrite($"{path}/Opacity.png"))
+            using (Image image = new Image(500, 500))
             {
-                image
-                    .BackgroundColor(Color.Blue)
-                    .DrawPath(color, 10, p)
-                    .Save(output);
-            }
+                using (FileStream output = File.OpenWrite($"{path}/Opacity.png"))
+                {
+                    image
+                        .BackgroundColor(Color.Blue)
+                        .DrawPath(color, 10, p)
+                        .Save(output);
+                }
 
-            //shift background color towards forground color by the opacity amount
-            var mergedColor = new Color(Vector4.Lerp(Color.Blue.ToVector4(), Color.HotPink.ToVector4(), 150f / 255f));
+                //shift background color towards forground color by the opacity amount
+                Color mergedColor = new Color(Vector4.Lerp(Color.Blue.ToVector4(), Color.HotPink.ToVector4(), 150f / 255f));
 
-            using (var sourcePixels = image.Lock())
-            {
-                Assert.Equal(mergedColor, sourcePixels[9, 9]);
+                using (PixelAccessor<Color> sourcePixels = image.Lock())
+                {
+                    Assert.Equal(mergedColor, sourcePixels[9, 9]);
 
-                Assert.Equal(mergedColor, sourcePixels[199, 149]);
+                    Assert.Equal(mergedColor, sourcePixels[199, 149]);
 
-                Assert.Equal(Color.Blue, sourcePixels[50, 50]);
+                    Assert.Equal(Color.Blue, sourcePixels[50, 50]);
+                }
             }
         }
 

--- a/tests/ImageSharp.Tests/Drawing/FillPatternTests.cs
+++ b/tests/ImageSharp.Tests/Drawing/FillPatternTests.cs
@@ -15,55 +15,56 @@ namespace ImageSharp.Tests.Drawing
 
     public class FillPatternBrushTests : FileTestBase
     {
-        private Image Test(string name, Color background, IBrush<Color> brush, Color[,] expectedPattern)
+        private void Test(string name, Color background, IBrush<Color> brush, Color[,] expectedPattern)
         {
-            string path = CreateOutputDirectory("Fill", "PatternBrush");
-            Image image = new Image(20, 20);
-            image
-                  .Fill(background)
-                  .Fill(brush);
+            string path = this.CreateOutputDirectory("Fill", "PatternBrush");
+            using (Image image = new Image(20, 20))
+            {
+                image
+                    .Fill(background)
+                    .Fill(brush);
 
-            using (FileStream output = File.OpenWrite($"{path}/{name}.png"))
-            {
-                image.Save(output);
-            }
-            using (var sourcePixels = image.Lock())
-            {
-                // lets pick random spots to start checking
-                var r = new Random();
-                var xStride = expectedPattern.GetLength(1);
-                var yStride = expectedPattern.GetLength(0);
-                var offsetX = r.Next(image.Width / xStride) * xStride;
-                var offsetY = r.Next(image.Height / yStride) * yStride;
-                for (var x = 0; x < xStride; x++)
+                using (FileStream output = File.OpenWrite($"{path}/{name}.png"))
                 {
-                    for (var y = 0; y < yStride; y++)
+                    image.Save(output);
+                }
+
+                using (PixelAccessor<Color> sourcePixels = image.Lock())
+                {
+                    // lets pick random spots to start checking
+                    Random r = new Random();
+                    int xStride = expectedPattern.GetLength(1);
+                    int yStride = expectedPattern.GetLength(0);
+                    int offsetX = r.Next(image.Width / xStride) * xStride;
+                    int offsetY = r.Next(image.Height / yStride) * yStride;
+                    for (int x = 0; x < xStride; x++)
                     {
-                        var actualX = x + offsetX;
-                        var actualY = y + offsetY;
-                        var expected = expectedPattern[y, x]; // inverted pattern
-                        var actual = sourcePixels[actualX, actualY];
-                        if (expected != actual)
+                        for (int y = 0; y < yStride; y++)
                         {
-                            Assert.True(false, $"Expected {expected} but found {actual} at ({actualX},{actualY})");
+                            int actualX = x + offsetX;
+                            int actualY = y + offsetY;
+                            Color expected = expectedPattern[y, x]; // inverted pattern
+                            Color actual = sourcePixels[actualX, actualY];
+                            if (expected != actual)
+                            {
+                                Assert.True(false, $"Expected {expected} but found {actual} at ({actualX},{actualY})");
+                            }
                         }
                     }
                 }
+                using (FileStream output = File.OpenWrite($"{path}/{name}x4.png"))
+                {
+                    image.Resize(80, 80).Save(output);
+                }
             }
-            using (FileStream output = File.OpenWrite($"{path}/{name}x4.png"))
-            {
-                image.Resize(80, 80).Save(output);
-            }
-
-
-
-            return image;
         }
 
         [Fact]
         public void ImageShouldBeFloodFilledWithPercent10()
         {
-            Test("Percent10", Color.Blue, Brushes.Percent10(Color.HotPink, Color.LimeGreen), new Color[,] {
+            this.Test("Percent10", Color.Blue, Brushes.Percent10(Color.HotPink, Color.LimeGreen),
+                new[,]
+                {
                 { Color.HotPink , Color.LimeGreen, Color.LimeGreen, Color.LimeGreen},
                 { Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen},
                 { Color.LimeGreen, Color.LimeGreen, Color.HotPink , Color.LimeGreen},

--- a/tests/ImageSharp.Tests/Drawing/FillSolidBrushTests.cs
+++ b/tests/ImageSharp.Tests/Drawing/FillSolidBrushTests.cs
@@ -18,71 +18,73 @@ namespace ImageSharp.Tests.Drawing
         [Fact]
         public void ImageShouldBeFloodFilledWithColorOnDefaultBackground()
         {
-            string path = CreateOutputDirectory("Fill", "SolidBrush");
-            var image = new Image(500, 500);
-
-            using (FileStream output = File.OpenWrite($"{path}/DefaultBack.png"))
+            string path = this.CreateOutputDirectory("Fill", "SolidBrush");
+            using (Image image = new Image(500, 500))
             {
-                image
-                    .Fill(Color.HotPink)
-                    .Save(output);
-            }
+                using (FileStream output = File.OpenWrite($"{path}/DefaultBack.png"))
+                {
+                    image
+                        .Fill(Color.HotPink)
+                        .Save(output);
+                }
 
-            using (var sourcePixels = image.Lock())
-            {
-                Assert.Equal(Color.HotPink, sourcePixels[9, 9]);
+                using (PixelAccessor<Color> sourcePixels = image.Lock())
+                {
+                    Assert.Equal(Color.HotPink, sourcePixels[9, 9]);
 
-                Assert.Equal(Color.HotPink, sourcePixels[199, 149]);
+                    Assert.Equal(Color.HotPink, sourcePixels[199, 149]);
+                }
             }
         }
 
         [Fact]
         public void ImageShouldBeFloodFilledWithColor()
         {
-            string path = CreateOutputDirectory("Fill", "SolidBrush");
-            var image = new Image(500, 500);
-
-            using (FileStream output = File.OpenWrite($"{path}/Simple.png"))
+            string path = this.CreateOutputDirectory("Fill", "SolidBrush");
+            using (Image image = new Image(500, 500))
             {
-                image
-                    .BackgroundColor(Color.Blue)
-                    .Fill(Color.HotPink)
-                    .Save(output);
-            }
+                using (FileStream output = File.OpenWrite($"{path}/Simple.png"))
+                {
+                    image
+                        .BackgroundColor(Color.Blue)
+                        .Fill(Color.HotPink)
+                        .Save(output);
+                }
 
-            using (var sourcePixels = image.Lock())
-            {
-                Assert.Equal(Color.HotPink, sourcePixels[9, 9]);
+                using (PixelAccessor<Color> sourcePixels = image.Lock())
+                {
+                    Assert.Equal(Color.HotPink, sourcePixels[9, 9]);
 
-                Assert.Equal(Color.HotPink, sourcePixels[199, 149]);
+                    Assert.Equal(Color.HotPink, sourcePixels[199, 149]);
+                }
             }
         }
 
         [Fact]
         public void ImageShouldBeFloodFilledWithColorOpacity()
         {
-            string path = CreateOutputDirectory("Fill", "SolidBrush");
-            var image = new Image(500, 500);
-
-            var color = new Color(Color.HotPink.R, Color.HotPink.G, Color.HotPink.B, 150);
-
-            using (FileStream output = File.OpenWrite($"{path}/Opacity.png"))
+            string path = this.CreateOutputDirectory("Fill", "SolidBrush");
+            using (Image image = new Image(500, 500))
             {
-                image
-                    .BackgroundColor(Color.Blue)
-                    .Fill(color)
-                    .Save(output);
+                Color color = new Color(Color.HotPink.R, Color.HotPink.G, Color.HotPink.B, 150);
+
+                using (FileStream output = File.OpenWrite($"{path}/Opacity.png"))
+                {
+                    image
+                        .BackgroundColor(Color.Blue)
+                        .Fill(color)
+                        .Save(output);
+                }
+                //shift background color towards forground color by the opacity amount
+                Color mergedColor = new Color(Vector4.Lerp(Color.Blue.ToVector4(), Color.HotPink.ToVector4(), 150f / 255f));
+
+
+                using (PixelAccessor<Color> sourcePixels = image.Lock())
+                {
+                    Assert.Equal(mergedColor, sourcePixels[9, 9]);
+                    Assert.Equal(mergedColor, sourcePixels[199, 149]);
+                }
             }
-            //shift background color towards forground color by the opacity amount
-            var mergedColor = new Color(Vector4.Lerp(Color.Blue.ToVector4(), Color.HotPink.ToVector4(), 150f / 255f));
-
-
-            using (var sourcePixels = image.Lock())
-            {
-                Assert.Equal(mergedColor, sourcePixels[9, 9]);
-                Assert.Equal(mergedColor, sourcePixels[199, 149]);
-            }
-
         }
 
     }

--- a/tests/ImageSharp.Tests/Drawing/LineComplexPolygonTests.cs
+++ b/tests/ImageSharp.Tests/Drawing/LineComplexPolygonTests.cs
@@ -5,12 +5,9 @@
 
 namespace ImageSharp.Tests.Drawing
 {
-    using System;
-    using System.Diagnostics.CodeAnalysis;
     using System.IO;
     using Xunit;
-    using Drawing;
-    using ImageSharp.Drawing;
+
     using System.Numerics;
     using ImageSharp.Drawing.Shapes;
     using ImageSharp.Drawing.Pens;
@@ -20,98 +17,100 @@ namespace ImageSharp.Tests.Drawing
         [Fact]
         public void ImageShouldBeOverlayedByPolygonOutline()
         {
-            string path = CreateOutputDirectory("Drawing", "LineComplexPolygon");
-            var simplePath = new LinearPolygon(
+            string path = this.CreateOutputDirectory("Drawing", "LineComplexPolygon");
+            LinearPolygon simplePath = new LinearPolygon(
                             new Vector2(10, 10),
                             new Vector2(200, 150),
                             new Vector2(50, 300));
 
-            var hole1 = new LinearPolygon(
+            LinearPolygon hole1 = new LinearPolygon(
                             new Vector2(37, 85),
                             new Vector2(93, 85),
                             new Vector2(65, 137));
 
-            var image = new Image(500, 500);
-
-            using (FileStream output = File.OpenWrite($"{path}/Simple.png"))
+            using (Image image = new Image(500, 500))
             {
-                image
-                .BackgroundColor(Color.Blue)
-                .DrawPolygon(Color.HotPink, 5, new ComplexPolygon(simplePath, hole1))
-                .Save(output);
-            }
+                using (FileStream output = File.OpenWrite($"{path}/Simple.png"))
+                {
+                    image
+                        .BackgroundColor(Color.Blue)
+                        .DrawPolygon(Color.HotPink, 5, new ComplexPolygon(simplePath, hole1))
+                        .Save(output);
+                }
 
-            using (var sourcePixels = image.Lock())
-            {
-                Assert.Equal(Color.HotPink, sourcePixels[10, 10]);
+                using (PixelAccessor<Color> sourcePixels = image.Lock())
+                {
+                    Assert.Equal(Color.HotPink, sourcePixels[10, 10]);
 
-                Assert.Equal(Color.HotPink, sourcePixels[200, 150]);
+                    Assert.Equal(Color.HotPink, sourcePixels[200, 150]);
 
-                Assert.Equal(Color.HotPink, sourcePixels[50, 300]);
+                    Assert.Equal(Color.HotPink, sourcePixels[50, 300]);
 
 
-                Assert.Equal(Color.HotPink, sourcePixels[37, 85]);
+                    Assert.Equal(Color.HotPink, sourcePixels[37, 85]);
 
-                Assert.Equal(Color.HotPink, sourcePixels[93, 85]);
+                    Assert.Equal(Color.HotPink, sourcePixels[93, 85]);
 
-                Assert.Equal(Color.HotPink, sourcePixels[65, 137]);
+                    Assert.Equal(Color.HotPink, sourcePixels[65, 137]);
 
-                Assert.Equal(Color.Blue, sourcePixels[2, 2]);
+                    Assert.Equal(Color.Blue, sourcePixels[2, 2]);
 
-                //inside hole
-                Assert.Equal(Color.Blue, sourcePixels[57, 99]);
+                    //inside hole
+                    Assert.Equal(Color.Blue, sourcePixels[57, 99]);
 
-                //inside shape
-                Assert.Equal(Color.Blue, sourcePixels[100, 192]);
+                    //inside shape
+                    Assert.Equal(Color.Blue, sourcePixels[100, 192]);
+                }
             }
         }
 
         [Fact]
         public void ImageShouldBeOverlayedByPolygonOutlineNoOverlapping()
         {
-            string path = CreateOutputDirectory("Drawing", "LineComplexPolygon");
-            var simplePath = new LinearPolygon(
+            string path = this.CreateOutputDirectory("Drawing", "LineComplexPolygon");
+            LinearPolygon simplePath = new LinearPolygon(
                             new Vector2(10, 10),
                             new Vector2(200, 150),
                             new Vector2(50, 300));
 
-            var hole1 = new LinearPolygon(
+            LinearPolygon hole1 = new LinearPolygon(
                             new Vector2(207, 25),
                             new Vector2(263, 25),
                             new Vector2(235, 57));
 
-            var image = new Image(500, 500);
-
-            using (FileStream output = File.OpenWrite($"{path}/SimpleVanishHole.png"))
+            using (Image image = new Image(500, 500))
             {
-                image
-                .BackgroundColor(Color.Blue)
-                .DrawPolygon(Color.HotPink, 5, new ComplexPolygon(simplePath, hole1))
-                .Save(output);
-            }
+                using (FileStream output = File.OpenWrite($"{path}/SimpleVanishHole.png"))
+                {
+                    image
+                        .BackgroundColor(Color.Blue)
+                        .DrawPolygon(Color.HotPink, 5, new ComplexPolygon(simplePath, hole1))
+                        .Save(output);
+                }
 
-            using (var sourcePixels = image.Lock())
-            {
-                Assert.Equal(Color.HotPink, sourcePixels[10, 10]);
+                using (PixelAccessor<Color> sourcePixels = image.Lock())
+                {
+                    Assert.Equal(Color.HotPink, sourcePixels[10, 10]);
 
-                Assert.Equal(Color.HotPink, sourcePixels[200, 150]);
+                    Assert.Equal(Color.HotPink, sourcePixels[200, 150]);
 
-                Assert.Equal(Color.HotPink, sourcePixels[50, 300]);
+                    Assert.Equal(Color.HotPink, sourcePixels[50, 300]);
 
 
-                //Assert.Equal(Color.HotPink, sourcePixels[37, 85]);
+                    //Assert.Equal(Color.HotPink, sourcePixels[37, 85]);
 
-                //Assert.Equal(Color.HotPink, sourcePixels[93, 85]);
+                    //Assert.Equal(Color.HotPink, sourcePixels[93, 85]);
 
-                //Assert.Equal(Color.HotPink, sourcePixels[65, 137]);
+                    //Assert.Equal(Color.HotPink, sourcePixels[65, 137]);
 
-                Assert.Equal(Color.Blue, sourcePixels[2, 2]);
+                    Assert.Equal(Color.Blue, sourcePixels[2, 2]);
 
-                //inside hole
-                Assert.Equal(Color.Blue, sourcePixels[57, 99]);
+                    //inside hole
+                    Assert.Equal(Color.Blue, sourcePixels[57, 99]);
 
-                //inside shape
-                Assert.Equal(Color.Blue, sourcePixels[100, 192]);
+                    //inside shape
+                    Assert.Equal(Color.Blue, sourcePixels[100, 192]);
+                }
             }
         }
 
@@ -119,44 +118,45 @@ namespace ImageSharp.Tests.Drawing
         [Fact]
         public void ImageShouldBeOverlayedByPolygonOutlineOverlapping()
         {
-            string path = CreateOutputDirectory("Drawing", "LineComplexPolygon");
-            var simplePath = new LinearPolygon(
+            string path = this.CreateOutputDirectory("Drawing", "LineComplexPolygon");
+            LinearPolygon simplePath = new LinearPolygon(
                             new Vector2(10, 10),
                             new Vector2(200, 150),
                             new Vector2(50, 300));
 
-            var hole1 = new LinearPolygon(
+            LinearPolygon hole1 = new LinearPolygon(
                             new Vector2(37, 85),
                             new Vector2(130, 40),
                             new Vector2(65, 137));
 
-            var image = new Image(500, 500);
-
-            using (FileStream output = File.OpenWrite($"{path}/SimpleOverlapping.png"))
+            using (Image image = new Image(500, 500))
             {
-                image
-                .BackgroundColor(Color.Blue)
-                .DrawPolygon(Color.HotPink, 5, new ComplexPolygon(simplePath, hole1))
-                .Save(output);
-            }
+                using (FileStream output = File.OpenWrite($"{path}/SimpleOverlapping.png"))
+                {
+                    image
+                        .BackgroundColor(Color.Blue)
+                        .DrawPolygon(Color.HotPink, 5, new ComplexPolygon(simplePath, hole1))
+                        .Save(output);
+                }
 
-            using (var sourcePixels = image.Lock())
-            {
-                Assert.Equal(Color.HotPink, sourcePixels[10, 10]);
+                using (PixelAccessor<Color> sourcePixels = image.Lock())
+                {
+                    Assert.Equal(Color.HotPink, sourcePixels[10, 10]);
 
-                Assert.Equal(Color.HotPink, sourcePixels[200, 150]);
+                    Assert.Equal(Color.HotPink, sourcePixels[200, 150]);
 
-                Assert.Equal(Color.HotPink, sourcePixels[50, 300]);                
+                    Assert.Equal(Color.HotPink, sourcePixels[50, 300]);
 
-                Assert.Equal(Color.Blue, sourcePixels[130, 41]);
-                
-                Assert.Equal(Color.Blue, sourcePixels[2, 2]);
+                    Assert.Equal(Color.Blue, sourcePixels[130, 41]);
 
-                //inside hole
-                Assert.Equal(Color.Blue, sourcePixels[57, 99]);
+                    Assert.Equal(Color.Blue, sourcePixels[2, 2]);
 
-                //inside shape
-                Assert.Equal(Color.Blue, sourcePixels[100, 192]);
+                    //inside hole
+                    Assert.Equal(Color.Blue, sourcePixels[57, 99]);
+
+                    //inside shape
+                    Assert.Equal(Color.Blue, sourcePixels[100, 192]);
+                }
             }
         }
 
@@ -164,25 +164,26 @@ namespace ImageSharp.Tests.Drawing
         [Fact]
         public void ImageShouldBeOverlayedByPolygonOutlineDashed()
         {
-            string path = CreateOutputDirectory("Drawing", "LineComplexPolygon");
-            var simplePath = new LinearPolygon(
+            string path = this.CreateOutputDirectory("Drawing", "LineComplexPolygon");
+            LinearPolygon simplePath = new LinearPolygon(
                             new Vector2(10, 10),
                             new Vector2(200, 150),
                             new Vector2(50, 300));
 
-            var hole1 = new LinearPolygon(
+            LinearPolygon hole1 = new LinearPolygon(
                             new Vector2(37, 85),
                             new Vector2(93, 85),
                             new Vector2(65, 137));
 
-            var image = new Image(500, 500);
-
-            using (FileStream output = File.OpenWrite($"{path}/Dashed.png"))
+            using (Image image = new Image(500, 500))
             {
-                image
-                .BackgroundColor(Color.Blue)
-                .DrawPolygon(Pens.Dash(Color.HotPink, 5), new ComplexPolygon(simplePath, hole1))
-                .Save(output);
+                using (FileStream output = File.OpenWrite($"{path}/Dashed.png"))
+                {
+                    image
+                        .BackgroundColor(Color.Blue)
+                        .DrawPolygon(Pens.Dash(Color.HotPink, 5), new ComplexPolygon(simplePath, hole1))
+                        .Save(output);
+                }
             }
         }
 
@@ -190,54 +191,55 @@ namespace ImageSharp.Tests.Drawing
         [Fact]
         public void ImageShouldBeOverlayedPolygonOutlineWithOpacity()
         {
-            string path = CreateOutputDirectory("Drawing", "LineComplexPolygon");
-            var simplePath = new LinearPolygon(
+            string path = this.CreateOutputDirectory("Drawing", "LineComplexPolygon");
+            LinearPolygon simplePath = new LinearPolygon(
                             new Vector2(10, 10),
                             new Vector2(200, 150),
                             new Vector2(50, 300));
 
-            var hole1 = new LinearPolygon(
+            LinearPolygon hole1 = new LinearPolygon(
                             new Vector2(37, 85),
                             new Vector2(93, 85),
                             new Vector2(65, 137));
-            var color = new Color(Color.HotPink.R, Color.HotPink.G, Color.HotPink.B, 150);
+            Color color = new Color(Color.HotPink.R, Color.HotPink.G, Color.HotPink.B, 150);
 
-            var image = new Image(500, 500);
-
-            using (FileStream output = File.OpenWrite($"{path}/Opacity.png"))
+            using (Image image = new Image(500, 500))
             {
-                image
-                    .BackgroundColor(Color.Blue)
-                    .DrawPolygon(color, 5, new ComplexPolygon(simplePath, hole1))
-                    .Save(output);
-            }
+                using (FileStream output = File.OpenWrite($"{path}/Opacity.png"))
+                {
+                    image
+                        .BackgroundColor(Color.Blue)
+                        .DrawPolygon(color, 5, new ComplexPolygon(simplePath, hole1))
+                        .Save(output);
+                }
 
-            //shift background color towards forground color by the opacity amount
-            var mergedColor = new Color(Vector4.Lerp(Color.Blue.ToVector4(), Color.HotPink.ToVector4(), 150f / 255f));
+                //shift background color towards forground color by the opacity amount
+                Color mergedColor = new Color(Vector4.Lerp(Color.Blue.ToVector4(), Color.HotPink.ToVector4(), 150f / 255f));
 
-            using (var sourcePixels = image.Lock())
-            {
-                Assert.Equal(mergedColor, sourcePixels[10, 10]);
+                using (PixelAccessor<Color> sourcePixels = image.Lock())
+                {
+                    Assert.Equal(mergedColor, sourcePixels[10, 10]);
 
-                Assert.Equal(mergedColor, sourcePixels[200, 150]);
+                    Assert.Equal(mergedColor, sourcePixels[200, 150]);
 
-                Assert.Equal(mergedColor, sourcePixels[50, 300]);
-
-
-                Assert.Equal(mergedColor, sourcePixels[37, 85]);
-
-                Assert.Equal(mergedColor, sourcePixels[93, 85]);
-
-                Assert.Equal(mergedColor, sourcePixels[65, 137]);
-
-                Assert.Equal(Color.Blue, sourcePixels[2, 2]);
-
-                //inside hole
-                Assert.Equal(Color.Blue, sourcePixels[57, 99]);
+                    Assert.Equal(mergedColor, sourcePixels[50, 300]);
 
 
-                //inside shape
-                Assert.Equal(Color.Blue, sourcePixels[100, 192]);
+                    Assert.Equal(mergedColor, sourcePixels[37, 85]);
+
+                    Assert.Equal(mergedColor, sourcePixels[93, 85]);
+
+                    Assert.Equal(mergedColor, sourcePixels[65, 137]);
+
+                    Assert.Equal(Color.Blue, sourcePixels[2, 2]);
+
+                    //inside hole
+                    Assert.Equal(Color.Blue, sourcePixels[57, 99]);
+
+
+                    //inside shape
+                    Assert.Equal(Color.Blue, sourcePixels[100, 192]);
+                }
             }
         }
     }

--- a/tests/ImageSharp.Tests/Drawing/LineTests.cs
+++ b/tests/ImageSharp.Tests/Drawing/LineTests.cs
@@ -5,11 +5,9 @@
 
 namespace ImageSharp.Tests.Drawing
 {
-    using Drawing;
     using ImageSharp.Drawing;
     using ImageSharp.Drawing.Pens;
-    using System;
-    using System.Diagnostics.CodeAnalysis;
+
     using System.IO;
     using System.Numerics;
     using Xunit;
@@ -19,123 +17,132 @@ namespace ImageSharp.Tests.Drawing
         [Fact]
         public void ImageShouldBeOverlayedByPath()
         {
-            string path = CreateOutputDirectory("Drawing", "Lines");
-            var image = new Image(500, 500);
-
-            using (FileStream output = File.OpenWrite($"{path}/Simple.png"))
+            string path = this.CreateOutputDirectory("Drawing", "Lines");
+            using (Image image = new Image(500, 500))
             {
-                image
-                    .BackgroundColor(Color.Blue)
-                    .DrawLines(Color.HotPink, 5, new[] {
+                using (FileStream output = File.OpenWrite($"{path}/Simple.png"))
+                {
+                    image
+                        .BackgroundColor(Color.Blue)
+                        .DrawLines(Color.HotPink, 5,
+                        new[] {
                             new Vector2(10, 10),
                             new Vector2(200, 150),
                             new Vector2(50, 300)
-                    })
-                    .Save(output);
-            }
+                        })
+                        .Save(output);
+                }
 
-            using (var sourcePixels = image.Lock())
-            {
-                Assert.Equal(Color.HotPink, sourcePixels[9, 9]);
+                using (PixelAccessor<Color> sourcePixels = image.Lock())
+                {
+                    Assert.Equal(Color.HotPink, sourcePixels[9, 9]);
 
-                Assert.Equal(Color.HotPink, sourcePixels[199, 149]);
+                    Assert.Equal(Color.HotPink, sourcePixels[199, 149]);
 
-                Assert.Equal(Color.Blue, sourcePixels[50, 50]);
+                    Assert.Equal(Color.Blue, sourcePixels[50, 50]);
+                }
             }
         }
 
         [Fact]
         public void ImageShouldBeOverlayedByPath_NoAntialias()
         {
-            string path = CreateOutputDirectory("Drawing", "Lines");
-            var image = new Image(500, 500);
-
-            using (FileStream output = File.OpenWrite($"{path}/Simple_noantialias.png"))
+            string path = this.CreateOutputDirectory("Drawing", "Lines");
+            using (Image image = new Image(500, 500))
             {
-                image
-                    .BackgroundColor(Color.Blue)
-                    .DrawLines(Color.HotPink, 5, new[] {
+                using (FileStream output = File.OpenWrite($"{path}/Simple_noantialias.png"))
+                {
+                    image
+                        .BackgroundColor(Color.Blue)
+                        .DrawLines(Color.HotPink, 5,
+                        new[] {
                             new Vector2(10, 10),
                             new Vector2(200, 150),
                             new Vector2(50, 300)
-                    }, new GraphicsOptions(false))
-                    .Save(output);
-            }
+                        },
+                        new GraphicsOptions(false))
+                        .Save(output);
+                }
 
-            using (var sourcePixels = image.Lock())
-            {
-                Assert.Equal(Color.HotPink, sourcePixels[9, 9]);
+                using (PixelAccessor<Color> sourcePixels = image.Lock())
+                {
+                    Assert.Equal(Color.HotPink, sourcePixels[9, 9]);
 
-                Assert.Equal(Color.HotPink, sourcePixels[199, 149]);
+                    Assert.Equal(Color.HotPink, sourcePixels[199, 149]);
 
-                Assert.Equal(Color.Blue, sourcePixels[50, 50]);
+                    Assert.Equal(Color.Blue, sourcePixels[50, 50]);
+                }
             }
         }
 
         [Fact]
         public void ImageShouldBeOverlayedByPathDashed()
         {
-            string path = CreateOutputDirectory("Drawing", "Lines");
-            var image = new Image(500, 500);
-
-            using (FileStream output = File.OpenWrite($"{path}/Dashed.png"))
+            string path = this.CreateOutputDirectory("Drawing", "Lines");
+            using (Image image = new Image(500, 500))
             {
-                image
-                    .BackgroundColor(Color.Blue)
-                    .DrawLines(Pens.Dash(Color.HotPink, 5), new[] {
+                using (FileStream output = File.OpenWrite($"{path}/Dashed.png"))
+                {
+                    image
+                        .BackgroundColor(Color.Blue)
+                        .DrawLines(Pens.Dash(Color.HotPink, 5),
+                        new[] {
                             new Vector2(10, 10),
                             new Vector2(200, 150),
                             new Vector2(50, 300)
-                    })
-                    .Save(output);
+                        })
+                        .Save(output);
+                }
             }
-
         }
 
         [Fact]
         public void ImageShouldBeOverlayedByPathDotted()
         {
-            string path = CreateOutputDirectory("Drawing", "Lines");
-            var image = new Image(500, 500);
-
-            using (FileStream output = File.OpenWrite($"{path}/Dot.png"))
+            string path = this.CreateOutputDirectory("Drawing", "Lines");
+            using (Image image = new Image(500, 500))
             {
-                image
-                    .BackgroundColor(Color.Blue)
-                    .DrawLines(Pens.Dot(Color.HotPink, 5), new[] {
+                using (FileStream output = File.OpenWrite($"{path}/Dot.png"))
+                {
+                    image
+                        .BackgroundColor(Color.Blue)
+                        .DrawLines(Pens.Dot(Color.HotPink, 5),
+                        new[] {
                             new Vector2(10, 10),
                             new Vector2(200, 150),
                             new Vector2(50, 300)
-                    })
-                    .Save(output);
+                        })
+                        .Save(output);
+                }
             }
         }
 
         [Fact]
         public void ImageShouldBeOverlayedByPathDashDot()
         {
-            string path = CreateOutputDirectory("Drawing", "Lines");
-            var image = new Image(500, 500);
-
-            using (FileStream output = File.OpenWrite($"{path}/DashDot.png"))
+            string path = this.CreateOutputDirectory("Drawing", "Lines");
+            using (Image image = new Image(500, 500))
             {
-                image
-                    .BackgroundColor(Color.Blue)
-                    .DrawLines(Pens.DashDot(Color.HotPink, 5), new[] {
+                using (FileStream output = File.OpenWrite($"{path}/DashDot.png"))
+                {
+                    image
+                        .BackgroundColor(Color.Blue)
+                        .DrawLines(Pens.DashDot(Color.HotPink, 5),
+                        new[] {
                             new Vector2(10, 10),
                             new Vector2(200, 150),
                             new Vector2(50, 300)
-                    })
-                    .Save(output);
+                        })
+                        .Save(output);
+                }
             }
-
         }
 
         [Fact]
         public void ImageShouldBeOverlayedByPathDashDotDot()
         {
-            string path = CreateOutputDirectory("Drawing", "Lines");
-            var image = new Image(500, 500);
+            string path = this.CreateOutputDirectory("Drawing", "Lines");
+            Image image = new Image(500, 500);
 
             using (FileStream output = File.OpenWrite($"{path}/DashDotDot.png"))
             {
@@ -153,12 +160,12 @@ namespace ImageSharp.Tests.Drawing
         [Fact]
         public void ImageShouldBeOverlayedPathWithOpacity()
         {
-            string path = CreateOutputDirectory("Drawing", "Lines");
+            string path = this.CreateOutputDirectory("Drawing", "Lines");
 
-            var color = new Color(Color.HotPink.R, Color.HotPink.G, Color.HotPink.B, 150);
+            Color color = new Color(Color.HotPink.R, Color.HotPink.G, Color.HotPink.B, 150);
 
-            var image = new Image(500, 500);
-            
+            Image image = new Image(500, 500);
+
 
             using (FileStream output = File.OpenWrite($"{path}/Opacity.png"))
             {
@@ -173,9 +180,9 @@ namespace ImageSharp.Tests.Drawing
             }
 
             //shift background color towards forground color by the opacity amount
-            var mergedColor = new Color(Vector4.Lerp(Color.Blue.ToVector4(), Color.HotPink.ToVector4(), 150f/255f));
+            Color mergedColor = new Color(Vector4.Lerp(Color.Blue.ToVector4(), Color.HotPink.ToVector4(), 150f/255f));
 
-            using (var sourcePixels = image.Lock())
+            using (PixelAccessor<Color> sourcePixels = image.Lock())
             {
                 Assert.Equal(mergedColor, sourcePixels[9, 9]);
 
@@ -188,9 +195,9 @@ namespace ImageSharp.Tests.Drawing
         [Fact]
         public void ImageShouldBeOverlayedByPathOutline()
         {
-            string path = CreateOutputDirectory("Drawing", "Lines");
+            string path = this.CreateOutputDirectory("Drawing", "Lines");
 
-            var image = new Image(500, 500);
+            Image image = new Image(500, 500);
 
             using (FileStream output = File.OpenWrite($"{path}/Rectangle.png"))
             {
@@ -205,7 +212,7 @@ namespace ImageSharp.Tests.Drawing
                     .Save(output);
             }
 
-            using (var sourcePixels = image.Lock())
+            using (PixelAccessor<Color> sourcePixels = image.Lock())
             {
                 Assert.Equal(Color.HotPink, sourcePixels[8, 8]);
 
@@ -216,6 +223,6 @@ namespace ImageSharp.Tests.Drawing
                 Assert.Equal(Color.Blue, sourcePixels[50, 50]);
             }
         }
-        
+
     }
 }

--- a/tests/ImageSharp.Tests/Drawing/PolygonTests.cs
+++ b/tests/ImageSharp.Tests/Drawing/PolygonTests.cs
@@ -18,97 +18,101 @@ namespace ImageSharp.Tests.Drawing
         [Fact]
         public void ImageShouldBeOverlayedByPolygonOutline()
         {
-            string path = CreateOutputDirectory("Drawing", "Polygons");
+            string path = this.CreateOutputDirectory("Drawing", "Polygons");
 
-            var image = new Image(500, 500);
-
-            using (FileStream output = File.OpenWrite($"{path}/Simple.png"))
+            using (Image image = new Image(500, 500))
             {
-                image
-                    .BackgroundColor(Color.Blue)
-                    .DrawPolygon(Color.HotPink, 5, new[] {
-                        new Vector2(10, 10),
-                        new Vector2(200, 150),
-                        new Vector2(50, 300)
-                    })
-                    .Save(output);
-            }
+                using (FileStream output = File.OpenWrite($"{path}/Simple.png"))
+                {
+                    image
+                        .BackgroundColor(Color.Blue)
+                        .DrawPolygon(Color.HotPink, 5,
+                        new[] {
+                            new Vector2(10, 10),
+                            new Vector2(200, 150),
+                            new Vector2(50, 300)
+                        })
+                        .Save(output);
+                }
 
-            using (var sourcePixels = image.Lock())
-            {
-                Assert.Equal(Color.HotPink, sourcePixels[9, 9]);
+                using (PixelAccessor<Color> sourcePixels = image.Lock())
+                {
+                    Assert.Equal(Color.HotPink, sourcePixels[9, 9]);
 
-                Assert.Equal(Color.HotPink, sourcePixels[199, 149]);
+                    Assert.Equal(Color.HotPink, sourcePixels[199, 149]);
 
-                Assert.Equal(Color.Blue, sourcePixels[50, 50]);
+                    Assert.Equal(Color.Blue, sourcePixels[50, 50]);
 
-                Assert.Equal(Color.Blue, sourcePixels[2, 2]);
+                    Assert.Equal(Color.Blue, sourcePixels[2, 2]);
+                }
             }
         }
 
         [Fact]
         public void ImageShouldBeOverlayedPolygonOutlineWithOpacity()
         {
-            string path = CreateOutputDirectory("Drawing", "Polygons");
-            var simplePath = new[] {
+            string path = this.CreateOutputDirectory("Drawing", "Polygons");
+            Vector2[] simplePath = new[] {
                             new Vector2(10, 10),
                             new Vector2(200, 150),
                             new Vector2(50, 300)
             };
 
-            var color = new Color(Color.HotPink.R, Color.HotPink.G, Color.HotPink.B, 150);
+            Color color = new Color(Color.HotPink.R, Color.HotPink.G, Color.HotPink.B, 150);
 
-            var image = new Image(500, 500);
-
-            using (FileStream output = File.OpenWrite($"{path}/Opacity.png"))
+            using (Image image = new Image(500, 500))
             {
-                image
-                    .BackgroundColor(Color.Blue)
-                    .DrawPolygon(color, 10, simplePath)
-                    .Save(output);
-            }
+                using (FileStream output = File.OpenWrite($"{path}/Opacity.png"))
+                {
+                    image
+                        .BackgroundColor(Color.Blue)
+                        .DrawPolygon(color, 10, simplePath)
+                        .Save(output);
+                }
 
-            //shift background color towards forground color by the opacity amount
-            var mergedColor = new Color(Vector4.Lerp(Color.Blue.ToVector4(), Color.HotPink.ToVector4(), 150f / 255f));
+                //shift background color towards forground color by the opacity amount
+                Color mergedColor = new Color(Vector4.Lerp(Color.Blue.ToVector4(), Color.HotPink.ToVector4(), 150f / 255f));
 
-            using (var sourcePixels = image.Lock())
-            {
-                Assert.Equal(mergedColor, sourcePixels[9, 9]);
+                using (PixelAccessor<Color> sourcePixels = image.Lock())
+                {
+                    Assert.Equal(mergedColor, sourcePixels[9, 9]);
 
-                Assert.Equal(mergedColor, sourcePixels[199, 149]);
+                    Assert.Equal(mergedColor, sourcePixels[199, 149]);
 
-                Assert.Equal(Color.Blue, sourcePixels[50, 50]);
+                    Assert.Equal(Color.Blue, sourcePixels[50, 50]);
 
-                Assert.Equal(Color.Blue, sourcePixels[2, 2]);
+                    Assert.Equal(Color.Blue, sourcePixels[2, 2]);
+                }
             }
         }
 
         [Fact]
         public void ImageShouldBeOverlayedByRectangleOutline()
         {
-            string path = CreateOutputDirectory("Drawing", "Polygons");
+            string path = this.CreateOutputDirectory("Drawing", "Polygons");
 
-            var image = new Image(500, 500);
-
-            using (FileStream output = File.OpenWrite($"{path}/Rectangle.png"))
+            using (Image image = new Image(500, 500))
             {
-                image
-                    .BackgroundColor(Color.Blue)
-                    .DrawPolygon(Color.HotPink, 10, new Rectangle(10, 10, 190, 140))
-                    .Save(output);
-            }
+                using (FileStream output = File.OpenWrite($"{path}/Rectangle.png"))
+                {
+                    image
+                        .BackgroundColor(Color.Blue)
+                        .DrawPolygon(Color.HotPink, 10, new Rectangle(10, 10, 190, 140))
+                        .Save(output);
+                }
 
-            using (var sourcePixels = image.Lock())
-            {
-                Assert.Equal(Color.HotPink, sourcePixels[8, 8]);
+                using (PixelAccessor<Color> sourcePixels = image.Lock())
+                {
+                    Assert.Equal(Color.HotPink, sourcePixels[8, 8]);
 
-                Assert.Equal(Color.HotPink, sourcePixels[198, 10]);
+                    Assert.Equal(Color.HotPink, sourcePixels[198, 10]);
 
-                Assert.Equal(Color.HotPink, sourcePixels[10, 50]);
+                    Assert.Equal(Color.HotPink, sourcePixels[10, 50]);
 
-                Assert.Equal(Color.Blue, sourcePixels[50, 50]);
+                    Assert.Equal(Color.Blue, sourcePixels[50, 50]);
 
-                Assert.Equal(Color.Blue, sourcePixels[2, 2]);
+                    Assert.Equal(Color.Blue, sourcePixels[2, 2]);
+                }
             }
         }
     }

--- a/tests/ImageSharp.Tests/Drawing/RecolorImageTest.cs
+++ b/tests/ImageSharp.Tests/Drawing/RecolorImageTest.cs
@@ -16,18 +16,19 @@ namespace ImageSharp.Tests
         [Fact]
         public void ImageShouldRecolorYellowToHotPink()
         {
-            string path = CreateOutputDirectory("Drawing", "RecolorImage");
+            string path = this.CreateOutputDirectory("Drawing", "RecolorImage");
 
-            var brush = new RecolorBrush(Color.Yellow, Color.HotPink, 0.2f);
+            RecolorBrush brush = new RecolorBrush(Color.Yellow, Color.HotPink, 0.2f);
 
             foreach (TestFile file in Files)
             {
-                Image image = file.CreateImage();
-
-                using (FileStream output = File.OpenWrite($"{path}/{file.FileName}"))
+                using (Image image = file.CreateImage())
                 {
-                    image.Fill(brush)
-                         .Save(output);
+                    using (FileStream output = File.OpenWrite($"{path}/{file.FileName}"))
+                    {
+                        image.Fill(brush)
+                            .Save(output);
+                    }
                 }
             }
         }
@@ -35,19 +36,20 @@ namespace ImageSharp.Tests
         [Fact]
         public void ImageShouldRecolorYellowToHotPinkInARectangle()
         {
-            string path = CreateOutputDirectory("Drawing", "RecolorImage");
+            string path = this.CreateOutputDirectory("Drawing", "RecolorImage");
 
-            var brush = new RecolorBrush(Color.Yellow, Color.HotPink, 0.2f);
+            RecolorBrush brush = new RecolorBrush(Color.Yellow, Color.HotPink, 0.2f);
 
             foreach (TestFile file in Files)
             {
-                Image image = file.CreateImage();
-
-                using (FileStream output = File.OpenWrite($"{path}/Shaped_{file.FileName}"))
+                using (Image image = file.CreateImage())
                 {
-                    var imageHeight = image.Height;
-                    image.Fill(brush, new Rectangle(0, imageHeight/2 - imageHeight/4, image.Width, imageHeight/2))
-                         .Save(output);
+                    using (FileStream output = File.OpenWrite($"{path}/Shaped_{file.FileName}"))
+                    {
+                        int imageHeight = image.Height;
+                        image.Fill(brush, new Rectangle(0, imageHeight/2 - imageHeight/4, image.Width, imageHeight/2))
+                            .Save(output);
+                    }
                 }
             }
         }

--- a/tests/ImageSharp.Tests/Drawing/SolidBezierTests.cs
+++ b/tests/ImageSharp.Tests/Drawing/SolidBezierTests.cs
@@ -5,11 +5,8 @@
 
 namespace ImageSharp.Tests.Drawing
 {
-    using Drawing;
-    using ImageSharp.Drawing;
     using ImageSharp.Drawing.Shapes;
-    using System;
-    using System.Diagnostics.CodeAnalysis;
+
     using System.IO;
     using System.Numerics;
     using Xunit;
@@ -19,83 +16,84 @@ namespace ImageSharp.Tests.Drawing
         [Fact]
         public void ImageShouldBeOverlayedByFilledPolygon()
         {
-            string path = CreateOutputDirectory("Drawing", "FilledBezier");
-            var simplePath = new[] {
+            string path = this.CreateOutputDirectory("Drawing", "FilledBezier");
+            Vector2[] simplePath = new[] {
                         new Vector2(10, 400),
                         new Vector2(30, 10),
                         new Vector2(240, 30),
                         new Vector2(300, 400)
             };
-            var image = new Image(500, 500);
-
-            using (FileStream output = File.OpenWrite($"{path}/Simple.png"))
+            using (Image image = new Image(500, 500))
             {
-                image
-                    .BackgroundColor(Color.Blue)
-                    .Fill(Color.HotPink,new BezierPolygon(simplePath))
-                    .Save(output);
-            }
+                using (FileStream output = File.OpenWrite($"{path}/Simple.png"))
+                {
+                    image
+                        .BackgroundColor(Color.Blue)
+                        .Fill(Color.HotPink,new BezierPolygon(simplePath))
+                        .Save(output);
+                }
 
-            using (var sourcePixels = image.Lock())
-            {
-                //top of curve
-                Assert.Equal(Color.HotPink, sourcePixels[138, 116]);
+                using (PixelAccessor<Color> sourcePixels = image.Lock())
+                {
+                    //top of curve
+                    Assert.Equal(Color.HotPink, sourcePixels[138, 116]);
 
-                //start points                
-                Assert.Equal(Color.HotPink, sourcePixels[10, 400]);
-                Assert.Equal(Color.HotPink, sourcePixels[300, 400]);
+                    //start points
+                    Assert.Equal(Color.HotPink, sourcePixels[10, 400]);
+                    Assert.Equal(Color.HotPink, sourcePixels[300, 400]);
 
-                //curve points should not be never be set
-                Assert.Equal(Color.Blue, sourcePixels[30, 10]);
-                Assert.Equal(Color.Blue, sourcePixels[240, 30]);
+                    //curve points should not be never be set
+                    Assert.Equal(Color.Blue, sourcePixels[30, 10]);
+                    Assert.Equal(Color.Blue, sourcePixels[240, 30]);
 
-                // inside shape should not be empty
-                Assert.Equal(Color.HotPink, sourcePixels[200, 250]);
+                    // inside shape should not be empty
+                    Assert.Equal(Color.HotPink, sourcePixels[200, 250]);
+                }
             }
         }
 
         [Fact]
         public void ImageShouldBeOverlayedByFilledPolygonOpacity()
         {
-            string path = CreateOutputDirectory("Drawing", "FilledBezier");
-            var simplePath = new[] {
+            string path = this.CreateOutputDirectory("Drawing", "FilledBezier");
+            Vector2[] simplePath = new[] {
                         new Vector2(10, 400),
                         new Vector2(30, 10),
                         new Vector2(240, 30),
                         new Vector2(300, 400)
             };
-            var color = new Color(Color.HotPink.R, Color.HotPink.G, Color.HotPink.B, 150);
+            Color color = new Color(Color.HotPink.R, Color.HotPink.G, Color.HotPink.B, 150);
 
-            var image = new Image(500, 500);
-
-            using (FileStream output = File.OpenWrite($"{path}/Opacity.png"))
+            using (Image image = new Image(500, 500))
             {
-                image
-                    .BackgroundColor(Color.Blue)
-                    .Fill(color, new BezierPolygon(simplePath))
-                    .Save(output);
-            }
+                using (FileStream output = File.OpenWrite($"{path}/Opacity.png"))
+                {
+                    image
+                        .BackgroundColor(Color.Blue)
+                        .Fill(color, new BezierPolygon(simplePath))
+                        .Save(output);
+                }
 
-            //shift background color towards forground color by the opacity amount
-            var mergedColor = new Color(Vector4.Lerp(Color.Blue.ToVector4(), Color.HotPink.ToVector4(), 150f / 255f));
+                //shift background color towards forground color by the opacity amount
+                Color mergedColor = new Color(Vector4.Lerp(Color.Blue.ToVector4(), Color.HotPink.ToVector4(), 150f / 255f));
 
-            using (var sourcePixels = image.Lock())
-            {
-                //top of curve
-                Assert.Equal(mergedColor, sourcePixels[138, 116]);
+                using (PixelAccessor<Color> sourcePixels = image.Lock())
+                {
+                    //top of curve
+                    Assert.Equal(mergedColor, sourcePixels[138, 116]);
 
-                //start points                
-                Assert.Equal(mergedColor, sourcePixels[10, 400]);
-                Assert.Equal(mergedColor, sourcePixels[300, 400]);
+                    //start points
+                    Assert.Equal(mergedColor, sourcePixels[10, 400]);
+                    Assert.Equal(mergedColor, sourcePixels[300, 400]);
 
-                //curve points should not be never be set
-                Assert.Equal(Color.Blue, sourcePixels[30, 10]);
-                Assert.Equal(Color.Blue, sourcePixels[240, 30]);
+                    //curve points should not be never be set
+                    Assert.Equal(Color.Blue, sourcePixels[30, 10]);
+                    Assert.Equal(Color.Blue, sourcePixels[240, 30]);
 
-                // inside shape should not be empty
-                Assert.Equal(mergedColor, sourcePixels[200, 250]);
+                    // inside shape should not be empty
+                    Assert.Equal(mergedColor, sourcePixels[200, 250]);
+                }
             }
         }
-        
     }
 }

--- a/tests/ImageSharp.Tests/Drawing/SolidComplexPolygonTests.cs
+++ b/tests/ImageSharp.Tests/Drawing/SolidComplexPolygonTests.cs
@@ -5,12 +5,9 @@
 
 namespace ImageSharp.Tests.Drawing
 {
-    using System;
-    using System.Diagnostics.CodeAnalysis;
     using System.IO;
     using Xunit;
-    using Drawing;
-    using ImageSharp.Drawing;
+
     using System.Numerics;
     using ImageSharp.Drawing.Shapes;
 
@@ -19,41 +16,42 @@ namespace ImageSharp.Tests.Drawing
         [Fact]
         public void ImageShouldBeOverlayedByPolygonOutline()
         {
-            string path = CreateOutputDirectory("Drawing", "ComplexPolygon");
-            var simplePath = new LinearPolygon(
+            string path = this.CreateOutputDirectory("Drawing", "ComplexPolygon");
+            LinearPolygon simplePath = new LinearPolygon(
                             new Vector2(10, 10),
                             new Vector2(200, 150),
                             new Vector2(50, 300));
 
-            var hole1 = new LinearPolygon(
+            LinearPolygon hole1 = new LinearPolygon(
                             new Vector2(37, 85),
                             new Vector2(93, 85),
                             new Vector2(65, 137));
 
-            var image = new Image(500, 500);
-
-            using (FileStream output = File.OpenWrite($"{path}/Simple.png"))
+            using (Image image = new Image(500, 500))
             {
-                image
-                .BackgroundColor(Color.Blue)
-                .Fill(Color.HotPink, new ComplexPolygon(simplePath, hole1))
-                .Save(output);
-            }
+                using (FileStream output = File.OpenWrite($"{path}/Simple.png"))
+                {
+                    image
+                        .BackgroundColor(Color.Blue)
+                        .Fill(Color.HotPink, new ComplexPolygon(simplePath, hole1))
+                        .Save(output);
+                }
 
-            using (var sourcePixels = image.Lock())
-            {
-                Assert.Equal(Color.HotPink, sourcePixels[11, 11]);
+                using (PixelAccessor<Color> sourcePixels = image.Lock())
+                {
+                    Assert.Equal(Color.HotPink, sourcePixels[11, 11]);
 
-                Assert.Equal(Color.HotPink, sourcePixels[200, 150]);
+                    Assert.Equal(Color.HotPink, sourcePixels[200, 150]);
 
-                Assert.Equal(Color.HotPink, sourcePixels[50, 50]);
+                    Assert.Equal(Color.HotPink, sourcePixels[50, 50]);
 
-                Assert.Equal(Color.HotPink, sourcePixels[35, 100]);
+                    Assert.Equal(Color.HotPink, sourcePixels[35, 100]);
 
-                Assert.Equal(Color.Blue, sourcePixels[2, 2]);
+                    Assert.Equal(Color.Blue, sourcePixels[2, 2]);
 
-                //inside hole
-                Assert.Equal(Color.Blue, sourcePixels[57, 99]);
+                    //inside hole
+                    Assert.Equal(Color.Blue, sourcePixels[57, 99]);
+                }
             }
         }
 
@@ -61,86 +59,88 @@ namespace ImageSharp.Tests.Drawing
         [Fact]
         public void ImageShouldBeOverlayedPolygonOutlineWithOverlap()
         {
-            string path = CreateOutputDirectory("Drawing", "ComplexPolygon");
-            var simplePath = new LinearPolygon(
+            string path = this.CreateOutputDirectory("Drawing", "ComplexPolygon");
+            LinearPolygon simplePath = new LinearPolygon(
                             new Vector2(10, 10),
                             new Vector2(200, 150),
                             new Vector2(50, 300));
 
-            var hole1 = new LinearPolygon(
+            LinearPolygon hole1 = new LinearPolygon(
                             new Vector2(37, 85),
                             new Vector2(130, 40),
                             new Vector2(65, 137));
 
-            var image = new Image(500, 500);
-
-            using (FileStream output = File.OpenWrite($"{path}/SimpleOverlapping.png"))
+            using (Image image = new Image(500, 500))
             {
-                image
-                    .BackgroundColor(Color.Blue)
-                    .Fill(Color.HotPink, new ComplexPolygon(simplePath, hole1))
-                    .Save(output);
-            }
-            
-            using (var sourcePixels = image.Lock())
-            {
-                Assert.Equal(Color.HotPink, sourcePixels[11, 11]);
+                using (FileStream output = File.OpenWrite($"{path}/SimpleOverlapping.png"))
+                {
+                    image
+                        .BackgroundColor(Color.Blue)
+                        .Fill(Color.HotPink, new ComplexPolygon(simplePath, hole1))
+                        .Save(output);
+                }
 
-                Assert.Equal(Color.HotPink, sourcePixels[200, 150]);
+                using (PixelAccessor<Color> sourcePixels = image.Lock())
+                {
+                    Assert.Equal(Color.HotPink, sourcePixels[11, 11]);
 
-                Assert.Equal(Color.HotPink, sourcePixels[50, 50]);
+                    Assert.Equal(Color.HotPink, sourcePixels[200, 150]);
 
-                Assert.Equal(Color.HotPink, sourcePixels[35, 100]);
+                    Assert.Equal(Color.HotPink, sourcePixels[50, 50]);
 
-                Assert.Equal(Color.Blue, sourcePixels[2, 2]);
+                    Assert.Equal(Color.HotPink, sourcePixels[35, 100]);
 
-                //inside hole
-                Assert.Equal(Color.Blue, sourcePixels[57, 99]);
+                    Assert.Equal(Color.Blue, sourcePixels[2, 2]);
+
+                    //inside hole
+                    Assert.Equal(Color.Blue, sourcePixels[57, 99]);
+                }
             }
         }
 
         [Fact]
         public void ImageShouldBeOverlayedPolygonOutlineWithOpacity()
         {
-            string path = CreateOutputDirectory("Drawing", "ComplexPolygon");
-            var simplePath = new LinearPolygon(
+            string path = this.CreateOutputDirectory("Drawing", "ComplexPolygon");
+            LinearPolygon simplePath = new LinearPolygon(
                             new Vector2(10, 10),
                             new Vector2(200, 150),
                             new Vector2(50, 300));
 
-            var hole1 = new LinearPolygon(
+            LinearPolygon hole1 = new LinearPolygon(
                             new Vector2(37, 85),
                             new Vector2(93, 85),
                             new Vector2(65, 137));
-            var color = new Color(Color.HotPink.R, Color.HotPink.G, Color.HotPink.B, 150);
+            Color color = new Color(Color.HotPink.R, Color.HotPink.G, Color.HotPink.B, 150);
 
-            var image = new Image(500, 500);
-
-            using (FileStream output = File.OpenWrite($"{path}/Opacity.png"))
+            using (Image image = new Image(500, 500))
             {
-                image
-                    .BackgroundColor(Color.Blue)
-                    .Fill(color, new ComplexPolygon(simplePath, hole1))
-                    .Save(output);
-            }
+                using (FileStream output = File.OpenWrite($"{path}/Opacity.png"))
+                {
+                    image
+                        .BackgroundColor(Color.Blue)
+                        .Fill(color, new ComplexPolygon(simplePath, hole1))
+                        .Save(output);
+                }
 
-            //shift background color towards forground color by the opacity amount
-            var mergedColor = new Color(Vector4.Lerp(Color.Blue.ToVector4(), Color.HotPink.ToVector4(), 150f / 255f));
+                //shift background color towards forground color by the opacity amount
+                Color mergedColor = new Color(Vector4.Lerp(Color.Blue.ToVector4(), Color.HotPink.ToVector4(), 150f / 255f));
 
-            using (var sourcePixels = image.Lock())
-            {
-                Assert.Equal(mergedColor, sourcePixels[11, 11]);
+                using (PixelAccessor<Color> sourcePixels = image.Lock())
+                {
+                    Assert.Equal(mergedColor, sourcePixels[11, 11]);
 
-                Assert.Equal(mergedColor, sourcePixels[200, 150]);
+                    Assert.Equal(mergedColor, sourcePixels[200, 150]);
 
-                Assert.Equal(mergedColor, sourcePixels[50, 50]);
+                    Assert.Equal(mergedColor, sourcePixels[50, 50]);
 
-                Assert.Equal(mergedColor, sourcePixels[35, 100]);
+                    Assert.Equal(mergedColor, sourcePixels[35, 100]);
 
-                Assert.Equal(Color.Blue, sourcePixels[2, 2]);
+                    Assert.Equal(Color.Blue, sourcePixels[2, 2]);
 
-                //inside hole
-                Assert.Equal(Color.Blue, sourcePixels[57, 99]);
+                    //inside hole
+                    Assert.Equal(Color.Blue, sourcePixels[57, 99]);
+                }
             }
         }
     }

--- a/tests/ImageSharp.Tests/Drawing/SolidPolygonTests.cs
+++ b/tests/ImageSharp.Tests/Drawing/SolidPolygonTests.cs
@@ -5,10 +5,8 @@
 
 namespace ImageSharp.Tests.Drawing
 {
-    using Drawing;
     using ImageSharp.Drawing;
-    using System;
-    using System.Diagnostics.CodeAnalysis;
+
     using System.IO;
     using System.Numerics;
     using Xunit;
@@ -19,155 +17,153 @@ namespace ImageSharp.Tests.Drawing
         [Fact]
         public void ImageShouldBeOverlayedByFilledPolygon()
         {
-            string path = CreateOutputDirectory("Drawing", "FilledPolygons");
-            var simplePath = new[] {
+            string path = this.CreateOutputDirectory("Drawing", "FilledPolygons");
+            Vector2[] simplePath = new[] {
                             new Vector2(10, 10),
                             new Vector2(200, 150),
                             new Vector2(50, 300)
             };
-            var image = new Image(500, 500);
 
-            using (FileStream output = File.OpenWrite($"{path}/Simple.png"))
+            using (Image image = new Image(500, 500))
             {
-                image
-                    .BackgroundColor(Color.Blue)
-                    .FillPolygon(Color.HotPink, simplePath, new GraphicsOptions(true))
-                    .Save(output);
-            }
+                using (FileStream output = File.OpenWrite($"{path}/Simple.png"))
+                {
+                    image
+                        .BackgroundColor(Color.Blue)
+                        .FillPolygon(Color.HotPink, simplePath, new GraphicsOptions(true))
+                        .Save(output);
+                }
 
-            using (var sourcePixels = image.Lock())
-            {
-                Assert.Equal(Color.HotPink, sourcePixels[11, 11]);
+                using (PixelAccessor<Color> sourcePixels = image.Lock())
+                {
+                    Assert.Equal(Color.HotPink, sourcePixels[11, 11]);
 
-                Assert.Equal(Color.HotPink, sourcePixels[200, 150]);
+                    Assert.Equal(Color.HotPink, sourcePixels[200, 150]);
 
-                Assert.Equal(Color.HotPink, sourcePixels[50, 50]);
+                    Assert.Equal(Color.HotPink, sourcePixels[50, 50]);
 
-                Assert.Equal(Color.Blue, sourcePixels[2, 2]);
+                    Assert.Equal(Color.Blue, sourcePixels[2, 2]);
+                }
             }
         }
 
         [Fact]
-        public void ImageShouldBeOverlayedByFilledPolygon_NoAntialias()
+        public void ImageShouldBeOverlayedByFilledPolygonNoAntialias()
         {
-            string path = CreateOutputDirectory("Drawing", "FilledPolygons");
-            var simplePath = new[] {
+            string path = this.CreateOutputDirectory("Drawing", "FilledPolygons");
+            Vector2[] simplePath = new[] {
                             new Vector2(10, 10),
                             new Vector2(200, 150),
                             new Vector2(50, 300)
             };
-            var image = new Image(500, 500);
 
+            using (Image image = new Image(500, 500))
             using (FileStream output = File.OpenWrite($"{path}/Simple_NoAntialias.png"))
             {
                 image
                     .BackgroundColor(Color.Blue)
                     .FillPolygon(Color.HotPink, simplePath, new GraphicsOptions(false))
                     .Save(output);
-            }
 
-            using (var sourcePixels = image.Lock())
-            {
-                Assert.Equal(Color.HotPink, sourcePixels[11, 11]);
+                using (PixelAccessor<Color> sourcePixels = image.Lock())
+                {
+                    Assert.Equal(Color.HotPink, sourcePixels[11, 11]);
 
-                Assert.Equal(Color.HotPink, sourcePixels[200, 150]);
+                    Assert.Equal(Color.HotPink, sourcePixels[200, 150]);
 
-                Assert.Equal(Color.HotPink, sourcePixels[50, 50]);
+                    Assert.Equal(Color.HotPink, sourcePixels[50, 50]);
 
-                Assert.Equal(Color.Blue, sourcePixels[2, 2]);
+                    Assert.Equal(Color.Blue, sourcePixels[2, 2]);
+                }
             }
         }
 
         [Fact]
-        public void ImageShouldBeOverlayedByFilledPolygon_Image()
+        public void ImageShouldBeOverlayedByFilledPolygonImage()
         {
-            string path = CreateOutputDirectory("Drawing", "FilledPolygons");
-            var simplePath = new[] {
+            string path = this.CreateOutputDirectory("Drawing", "FilledPolygons");
+            Vector2[] simplePath = new[] {
                             new Vector2(10, 10),
                             new Vector2(200, 150),
                             new Vector2(50, 300)
             };
 
-            var brush = new ImageBrush(TestFile.Create(TestImages.Bmp.Car).CreateImage());
-            var image = new Image(500, 500);
-
+            using (Image brushImage = TestFile.Create(TestImages.Bmp.Car).CreateImage())
+            using (Image image = new Image(500, 500))
             using (FileStream output = File.OpenWrite($"{path}/Image.png"))
             {
+                ImageBrush brush = new ImageBrush(brushImage);
+
                 image
-                    .BackgroundColor(Color.Blue)
-                    .FillPolygon(brush, simplePath)
-                    .Save(output);
+                .BackgroundColor(Color.Blue)
+                .FillPolygon(brush, simplePath)
+                .Save(output);
             }
         }
 
         [Fact]
         public void ImageShouldBeOverlayedByFilledPolygonOpacity()
         {
-            string path = CreateOutputDirectory("Drawing", "FilledPolygons");
-            var simplePath = new[] {
+            string path = this.CreateOutputDirectory("Drawing", "FilledPolygons");
+            Vector2[] simplePath = new[] {
                             new Vector2(10, 10),
                             new Vector2(200, 150),
                             new Vector2(50, 300)
             };
-            var color = new Color(Color.HotPink.R, Color.HotPink.G, Color.HotPink.B, 150);
+            Color color = new Color(Color.HotPink.R, Color.HotPink.G, Color.HotPink.B, 150);
 
-            var image = new Image(500, 500);
-
-            using (FileStream output = File.OpenWrite($"{path}/Opacity.png"))
+            using (Image image = new Image(500, 500))
             {
-                image
-                    .BackgroundColor(Color.Blue)
-                    .FillPolygon(color, simplePath)
-                    .Save(output);
-            }
+                using (FileStream output = File.OpenWrite($"{path}/Opacity.png"))
+                {
+                    image
+                        .BackgroundColor(Color.Blue)
+                        .FillPolygon(color, simplePath)
+                        .Save(output);
+                }
 
-            //shift background color towards forground color by the opacity amount
-            var mergedColor = new Color(Vector4.Lerp(Color.Blue.ToVector4(), Color.HotPink.ToVector4(), 150f / 255f));
+                //shift background color towards forground color by the opacity amount
+                Color mergedColor = new Color(Vector4.Lerp(Color.Blue.ToVector4(), Color.HotPink.ToVector4(), 150f / 255f));
 
-            using (var sourcePixels = image.Lock())
-            {
-                Assert.Equal(mergedColor, sourcePixels[11, 11]);
+                using (PixelAccessor<Color> sourcePixels = image.Lock())
+                {
+                    Assert.Equal(mergedColor, sourcePixels[11, 11]);
 
-                Assert.Equal(mergedColor, sourcePixels[200, 150]);
+                    Assert.Equal(mergedColor, sourcePixels[200, 150]);
 
-                Assert.Equal(mergedColor, sourcePixels[50, 50]);
+                    Assert.Equal(mergedColor, sourcePixels[50, 50]);
 
-                Assert.Equal(Color.Blue, sourcePixels[2, 2]);
+                    Assert.Equal(Color.Blue, sourcePixels[2, 2]);
+                }
             }
         }
 
         [Fact]
         public void ImageShouldBeOverlayedByFilledRectangle()
         {
-            string path = CreateOutputDirectory("Drawing", "FilledPolygons");
-            var simplePath = new[] {
-                            new Vector2(10, 10),
-                            new Vector2(200, 10),
-                            new Vector2(200, 150),
-                            new Vector2(10, 150)
-                            };
-
-            var image = new Image(500, 500);
-
-            using (FileStream output = File.OpenWrite($"{path}/Rectangle.png"))
+            string path = this.CreateOutputDirectory("Drawing", "FilledPolygons");
+            using (Image image = new Image(500, 500))
             {
-                image
-                    .BackgroundColor(Color.Blue)
-                    .Fill(Color.HotPink, new ImageSharp.Drawing.Shapes.RectangularPolygon(new Rectangle(10,10, 190, 140)))
-                    .Save(output);
-            }
+                using (FileStream output = File.OpenWrite($"{path}/Rectangle.png"))
+                {
+                    image
+                        .BackgroundColor(Color.Blue)
+                        .Fill(Color.HotPink, new ImageSharp.Drawing.Shapes.RectangularPolygon(new Rectangle(10, 10, 190, 140)))
+                        .Save(output);
+                }
 
-            using (var sourcePixels = image.Lock())
-            {
-                Assert.Equal(Color.HotPink, sourcePixels[11, 11]);
+                using (PixelAccessor<Color> sourcePixels = image.Lock())
+                {
+                    Assert.Equal(Color.HotPink, sourcePixels[11, 11]);
 
-                Assert.Equal(Color.HotPink, sourcePixels[198, 10]);
+                    Assert.Equal(Color.HotPink, sourcePixels[198, 10]);
 
-                Assert.Equal(Color.HotPink, sourcePixels[10, 50]);
+                    Assert.Equal(Color.HotPink, sourcePixels[10, 50]);
 
-                Assert.Equal(Color.HotPink, sourcePixels[50, 50]);
+                    Assert.Equal(Color.HotPink, sourcePixels[50, 50]);
 
-                Assert.Equal(Color.Blue, sourcePixels[2, 2]);
+                    Assert.Equal(Color.Blue, sourcePixels[2, 2]);
+                }
             }
         }
     }

--- a/tests/ImageSharp.Tests/Formats/Bmp/BitmapTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Bmp/BitmapTests.cs
@@ -9,8 +9,6 @@ namespace ImageSharp.Tests
 {
     using System.IO;
 
-    using Formats;
-
     using Xunit;
 
     public class BitmapTests : FileTestBase
@@ -23,19 +21,20 @@ namespace ImageSharp.Tests
         };
 
         [Theory]
-        [MemberData("BitsPerPixel")]
+        [MemberData(nameof(BitsPerPixel))]
         public void BitmapCanEncodeDifferentBitRates(BmpBitsPerPixel bitsPerPixel)
         {
-            string path = CreateOutputDirectory("Bmp");
+            string path = this.CreateOutputDirectory("Bmp");
 
             foreach (TestFile file in Files)
             {
                 string filename = file.GetFileNameWithoutExtension(bitsPerPixel);
-                Image image = file.CreateImage();
-
-                using (FileStream output = File.OpenWrite($"{path}/{filename}.bmp"))
+                using (Image image = file.CreateImage())
                 {
-                    image.Save(output, new BmpEncoder { BitsPerPixel = bitsPerPixel });
+                    using (FileStream output = File.OpenWrite($"{path}/{filename}.bmp"))
+                    {
+                        image.Save(output, new BmpEncoder { BitsPerPixel = bitsPerPixel });
+                    }
                 }
             }
         }

--- a/tests/ImageSharp.Tests/Formats/GeneralFormatTests.cs
+++ b/tests/ImageSharp.Tests/Formats/GeneralFormatTests.cs
@@ -71,30 +71,34 @@ namespace ImageSharp.Tests
 
             foreach (TestFile file in Files)
             {
-                using (Image image = file.CreateImage())
+                using (Image srcImage = file.CreateImage())
                 {
-                    Color[] pixels = new Color[image.Width * image.Height];
-                    Array.Copy(image.Pixels, pixels, image.Width * image.Height);
-
-                    using (FileStream output = File.OpenWrite($"{path}/Octree-{file.FileName}"))
+                    using (Image image = new Image(srcImage))
                     {
-                        image.Quantize(Quantization.Octree)
-                            .Save(output, image.CurrentImageFormat);
+                        using (FileStream output = File.OpenWrite($"{path}/Octree-{file.FileName}"))
+                        {
+                            image.Quantize(Quantization.Octree)
+                                .Save(output, image.CurrentImageFormat);
 
+                        }
                     }
 
-                    image.SetPixels(image.Width, image.Height, pixels);
-                    using (FileStream output = File.OpenWrite($"{path}/Wu-{file.FileName}"))
+                    using (Image image = new Image(srcImage))
                     {
-                        image.Quantize(Quantization.Wu)
-                            .Save(output, image.CurrentImageFormat);
+                        using (FileStream output = File.OpenWrite($"{path}/Wu-{file.FileName}"))
+                        {
+                            image.Quantize(Quantization.Wu)
+                                .Save(output, image.CurrentImageFormat);
+                        }
                     }
 
-                    image.SetPixels(image.Width, image.Height, pixels);
-                    using (FileStream output = File.OpenWrite($"{path}/Palette-{file.FileName}"))
+                    using (Image image = new Image(srcImage))
                     {
-                        image.Quantize(Quantization.Palette)
-                            .Save(output, image.CurrentImageFormat);
+                        using (FileStream output = File.OpenWrite($"{path}/Wu-{file.FileName}"))
+                        {
+                            image.Quantize(Quantization.Palette)
+                                .Save(output, image.CurrentImageFormat);
+                        }
                     }
                 }
             }

--- a/tests/ImageSharp.Tests/Formats/GeneralFormatTests.cs
+++ b/tests/ImageSharp.Tests/Formats/GeneralFormatTests.cs
@@ -94,7 +94,7 @@ namespace ImageSharp.Tests
 
                     using (Image image = new Image(srcImage))
                     {
-                        using (FileStream output = File.OpenWrite($"{path}/Wu-{file.FileName}"))
+                        using (FileStream output = File.OpenWrite($"{path}/Palette-{file.FileName}"))
                         {
                             image.Quantize(Quantization.Palette)
                                 .Save(output, image.CurrentImageFormat);

--- a/tests/ImageSharp.Tests/Formats/GeneralFormatTests.cs
+++ b/tests/ImageSharp.Tests/Formats/GeneralFormatTests.cs
@@ -16,17 +16,18 @@ namespace ImageSharp.Tests
         [Fact]
         public void ResolutionShouldChange()
         {
-            string path = CreateOutputDirectory("Resolution");
+            string path = this.CreateOutputDirectory("Resolution");
 
             foreach (TestFile file in Files)
             {
-                Image image = file.CreateImage();
-
-                using (FileStream output = File.OpenWrite($"{path}/{file.FileName}"))
+                using (Image image = file.CreateImage())
                 {
-                    image.VerticalResolution = 150;
-                    image.HorizontalResolution = 150;
-                    image.Save(output);
+                    using (FileStream output = File.OpenWrite($"{path}/{file.FileName}"))
+                    {
+                        image.VerticalResolution = 150;
+                        image.HorizontalResolution = 150;
+                        image.Save(output);
+                    }
                 }
             }
         }
@@ -34,45 +35,31 @@ namespace ImageSharp.Tests
         [Fact]
         public void ImageCanEncodeToString()
         {
-            string path = CreateOutputDirectory("ToString");
+            string path = this.CreateOutputDirectory("ToString");
 
             foreach (TestFile file in Files)
             {
-                Image image = file.CreateImage();
-
-                string filename = path + "/" + file.FileNameWithoutExtension + ".txt";
-                File.WriteAllText(filename, image.ToBase64String());
+                using (Image image = file.CreateImage())
+                {
+                    string filename = path + "/" + file.FileNameWithoutExtension + ".txt";
+                    File.WriteAllText(filename, image.ToBase64String());
+                }
             }
         }
 
         [Fact]
         public void DecodeThenEncodeImageFromStreamShouldSucceed()
         {
-            string path = CreateOutputDirectory("Encode");
+            string path = this.CreateOutputDirectory("Encode");
 
             foreach (TestFile file in Files)
             {
-                Image image = file.CreateImage();
-
-                //Image<Bgr565> image = file.CreateImage().To<Bgr565>();
-                //Image<Bgra4444> image = file.CreateImage().To<Bgra4444>();
-                //Image<Bgra5551> image = file.CreateImage().To<Bgra5551>();
-                //Image<Byte4> image = file.CreateImage().To<Byte4>();
-                //Image<HalfSingle> image = file.CreateImage().To<HalfSingle>();
-                //Image<HalfVector2> image = file.CreateImage().To<HalfVector2>();
-                //Image<HalfVector4> image = file.CreateImage().To<HalfVector4>();
-                //Image<Rg32> image = file.CreateImage().To<Rg32>();
-                //Image<Rgba1010102> image = file.CreateImage().To<Rgba1010102>();
-                //Image<Rgba64> image = file.CreateImage().To<Rgba64>();
-                //Image<NormalizedByte2> image = file.CreateImage().To<NormalizedByte2>();
-                //Image<NormalizedByte4> image = file.CreateImage().To<NormalizedByte4>();
-                //Image<NormalizedShort2> image = file.CreateImage().To<NormalizedShort2>();
-                //Image<NormalizedShort4> image = file.CreateImage().To<NormalizedShort4>();
-                //Image<Short2> image = file.CreateImage().To<Short2>();
-                //Image<Short4> image = file.CreateImage().To<Short4>();
-                using (FileStream output = File.OpenWrite($"{path}/{file.FileName}"))
+                using (Image image = file.CreateImage())
                 {
-                    image.Save(output);
+                    using (FileStream output = File.OpenWrite($"{path}/{file.FileName}"))
+                    {
+                        image.Save(output);
+                    }
                 }
             }
         }
@@ -80,35 +67,35 @@ namespace ImageSharp.Tests
         [Fact]
         public void QuantizeImageShouldPreserveMaximumColorPrecision()
         {
-            string path = CreateOutputDirectory("Quantize");
+            string path = this.CreateOutputDirectory("Quantize");
 
             foreach (TestFile file in Files)
             {
-                Image image = file.CreateImage();
-
-                // Copy the original pixels to save decoding time.
-                Color[] pixels = new Color[image.Width * image.Height];
-                Array.Copy(image.Pixels, pixels, image.Pixels.Length);
-
-                using (FileStream output = File.OpenWrite($"{path}/Octree-{file.FileName}"))
+                using (Image image = file.CreateImage())
                 {
-                    image.Quantize(Quantization.Octree)
-                          .Save(output, image.CurrentImageFormat);
+                    Color[] pixels = new Color[image.Width * image.Height];
+                    Array.Copy(image.Pixels, pixels, image.Width * image.Height);
 
-                }
+                    using (FileStream output = File.OpenWrite($"{path}/Octree-{file.FileName}"))
+                    {
+                        image.Quantize(Quantization.Octree)
+                            .Save(output, image.CurrentImageFormat);
 
-                image.SetPixels(image.Width, image.Height, pixels);
-                using (FileStream output = File.OpenWrite($"{path}/Wu-{file.FileName}"))
-                {
-                    image.Quantize(Quantization.Wu)
-                          .Save(output, image.CurrentImageFormat);
-                }
+                    }
 
-                image.SetPixels(image.Width, image.Height, pixels);
-                using (FileStream output = File.OpenWrite($"{path}/Palette-{file.FileName}"))
-                {
-                    image.Quantize(Quantization.Palette)
-                          .Save(output, image.CurrentImageFormat);
+                    image.SetPixels(image.Width, image.Height, pixels);
+                    using (FileStream output = File.OpenWrite($"{path}/Wu-{file.FileName}"))
+                    {
+                        image.Quantize(Quantization.Wu)
+                            .Save(output, image.CurrentImageFormat);
+                    }
+
+                    image.SetPixels(image.Width, image.Height, pixels);
+                    using (FileStream output = File.OpenWrite($"{path}/Palette-{file.FileName}"))
+                    {
+                        image.Quantize(Quantization.Palette)
+                            .Save(output, image.CurrentImageFormat);
+                    }
                 }
             }
         }
@@ -116,7 +103,7 @@ namespace ImageSharp.Tests
         [Fact]
         public void ImageCanConvertFormat()
         {
-            string path = CreateOutputDirectory("Format");
+            string path = this.CreateOutputDirectory("Format");
 
             foreach (TestFile file in Files)
             {
@@ -147,7 +134,7 @@ namespace ImageSharp.Tests
         [Fact]
         public void ImageShouldPreservePixelByteOrderWhenSerialized()
         {
-            string path = CreateOutputDirectory("Serialized");
+            string path = this.CreateOutputDirectory("Serialized");
 
             foreach (TestFile file in Files)
             {

--- a/tests/ImageSharp.Tests/Formats/Jpg/BadEofJpegTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/BadEofJpegTests.cs
@@ -31,9 +31,11 @@ namespace ImageSharp.Tests
         public void LoadBaselineImage<TColor>(TestImageProvider<TColor> provider)
             where TColor : struct, IPackedPixel, IEquatable<TColor>
         {
-            var image = provider.GetImage();
-            Assert.NotNull(image);
-            provider.Utility.SaveTestOutputFile(image, "bmp");
+            using (Image<TColor> image = provider.GetImage())
+            {
+                Assert.NotNull(image);
+                provider.Utility.SaveTestOutputFile(image, "bmp");
+            }
         }
 
         [Theory] // TODO: #18
@@ -41,9 +43,11 @@ namespace ImageSharp.Tests
         public void LoadProgressiveImage<TColor>(TestImageProvider<TColor> provider)
             where TColor : struct, IPackedPixel, IEquatable<TColor>
         {
-            var image = provider.GetImage();
-            Assert.NotNull(image);
-            provider.Utility.SaveTestOutputFile(image, "bmp");
+            using (Image<TColor> image = provider.GetImage())
+            {
+                Assert.NotNull(image);
+                provider.Utility.SaveTestOutputFile(image, "bmp");
+            }
         }
     }
 }

--- a/tests/ImageSharp.Tests/Formats/Jpg/JpegDecoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/JpegDecoderTests.cs
@@ -29,19 +29,21 @@ namespace ImageSharp.Tests
         public void OpenBaselineJpeg_SaveBmp<TColor>(TestImageProvider<TColor> provider)
             where TColor : struct, IPackedPixel, IEquatable<TColor>
         {
-            Image<TColor> image = provider.GetImage();
-
-            provider.Utility.SaveTestOutputFile(image, "bmp");
+            using (Image<TColor> image = provider.GetImage())
+            {
+                provider.Utility.SaveTestOutputFile(image, "bmp");
+            }
         }
-        
+
         [Theory]
         [WithFileCollection(nameof(ProgressiveTestJpegs), PixelTypes.Color | PixelTypes.StandardImageClass | PixelTypes.Argb)]
         public void OpenProgressiveJpeg_SaveBmp<TColor>(TestImageProvider<TColor> provider)
             where TColor : struct, IPackedPixel, IEquatable<TColor>
         {
-            Image<TColor> image = provider.GetImage();
-
-            provider.Utility.SaveTestOutputFile(image, "bmp");
+            using (Image<TColor> image = provider.GetImage())
+            {
+                provider.Utility.SaveTestOutputFile(image, "bmp");
+            }
         }
 
         [Theory]
@@ -53,17 +55,19 @@ namespace ImageSharp.Tests
         public void DecodeGenerated_SaveBmp<TColor>(
             TestImageProvider<TColor> provider,
             JpegSubsample subsample,
-            int quality) 
+            int quality)
             where TColor : struct, IPackedPixel, IEquatable<TColor>
         {
-            Image<TColor> image = provider.GetImage();
-
-            JpegEncoder encoder = new JpegEncoder() { Subsample = subsample, Quality = quality };
-
-            byte[] data = new byte[65536];
-            using (MemoryStream ms = new MemoryStream(data))
+            byte[] data;
+            using (Image<TColor> image = provider.GetImage())
             {
-                image.Save(ms, encoder);
+                JpegEncoder encoder = new JpegEncoder() { Subsample = subsample, Quality = quality };
+
+                data = new byte[65536];
+                using (MemoryStream ms = new MemoryStream(data))
+                {
+                    image.Save(ms, encoder);
+                }
             }
 
             // TODO: Automatic image comparers could help here a lot :P
@@ -75,23 +79,24 @@ namespace ImageSharp.Tests
         [Theory]
         [WithSolidFilledImages(42, 88, 255, 0, 0, PixelTypes.StandardImageClass)]
         public void DecodeGenerated_MetadataOnly<TColor>(
-            TestImageProvider<TColor> provider) 
+            TestImageProvider<TColor> provider)
             where TColor : struct, IPackedPixel, IEquatable<TColor>
         {
-            Image<TColor> image = provider.GetImage();
-            
-            using (MemoryStream ms = new MemoryStream())
+            using (Image<TColor> image = provider.GetImage())
             {
-                image.Save(ms, new JpegEncoder());
-                ms.Seek(0, SeekOrigin.Begin);
-
-                Image<TColor> mirror = provider.Factory.CreateImage(1, 1);
-                using (JpegDecoderCore decoder = new JpegDecoderCore())
+                using (MemoryStream ms = new MemoryStream())
                 {
-                    decoder.Decode(mirror, ms, true);
-                    
-                    Assert.Equal(decoder.ImageWidth, image.Width);
-                    Assert.Equal(decoder.ImageHeight, image.Height);
+                    image.Save(ms, new JpegEncoder());
+                    ms.Seek(0, SeekOrigin.Begin);
+
+                    Image<TColor> mirror = provider.Factory.CreateImage(1, 1);
+                    using (JpegDecoderCore decoder = new JpegDecoderCore())
+                    {
+                        decoder.Decode(mirror, ms, true);
+
+                        Assert.Equal(decoder.ImageWidth, image.Width);
+                        Assert.Equal(decoder.ImageHeight, image.Height);
+                    }
                 }
             }
         }

--- a/tests/ImageSharp.Tests/Formats/Jpg/JpegEncoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/JpegEncoderTests.cs
@@ -34,19 +34,16 @@ namespace ImageSharp.Tests
         public void LoadResizeSave<TColor>(TestImageProvider<TColor> provider, int quality, JpegSubsample subsample)
             where TColor : struct, IPackedPixel, IEquatable<TColor>
         {
-            Image<TColor> image = provider.GetImage()
-                .Resize(new ResizeOptions
-                {
-                    Size = new Size(150, 100),
-                    Mode = ResizeMode.Max
-                });
-            image.Quality = quality;
-            image.ExifProfile = null; // Reduce the size of the file
-            JpegEncoder encoder = new JpegEncoder { Subsample = subsample, Quality = quality };
+            using (Image<TColor> image = provider.GetImage().Resize(new ResizeOptions { Size = new Size(150, 100), Mode = ResizeMode.Max }))
+            {
+                image.Quality = quality;
+                image.ExifProfile = null; // Reduce the size of the file
+                JpegEncoder encoder = new JpegEncoder { Subsample = subsample, Quality = quality };
 
-            provider.Utility.TestName += $"{subsample}_Q{quality}";
-            provider.Utility.SaveTestOutputFile(image, "png");
-            provider.Utility.SaveTestOutputFile(image, "jpg", encoder);
+                provider.Utility.TestName += $"{subsample}_Q{quality}";
+                provider.Utility.SaveTestOutputFile(image, "png");
+                provider.Utility.SaveTestOutputFile(image, "jpg", encoder);
+            }
         }
 
         [Theory]
@@ -55,20 +52,21 @@ namespace ImageSharp.Tests
         public void OpenBmp_SaveJpeg<TColor>(TestImageProvider<TColor> provider, JpegSubsample subSample, int quality)
            where TColor : struct, IPackedPixel, IEquatable<TColor>
         {
-            Image<TColor> image = provider.GetImage();
-
-            ImagingTestCaseUtility utility = provider.Utility;
-            utility.TestName += "_" + subSample + "_Q" + quality;
-
-            using (var outputStream = File.OpenWrite(utility.GetTestOutputFileName("jpg")))
+            using (Image<TColor> image = provider.GetImage())
             {
-                var encoder = new JpegEncoder()
-                {
-                    Subsample = subSample,
-                    Quality = quality
-                };
+                ImagingTestCaseUtility utility = provider.Utility;
+                utility.TestName += "_" + subSample + "_Q" + quality;
 
-                image.Save(outputStream, encoder);
+                using (FileStream outputStream = File.OpenWrite(utility.GetTestOutputFileName("jpg")))
+                {
+                    JpegEncoder encoder = new JpegEncoder()
+                                              {
+                                                  Subsample = subSample,
+                                                  Quality = quality
+                                              };
+
+                    image.Save(outputStream, encoder);
+                }
             }
         }
     }

--- a/tests/ImageSharp.Tests/Formats/Jpg/JpegUtilsTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/JpegUtilsTests.cs
@@ -19,7 +19,6 @@ namespace ImageSharp.Tests
             where TColor : struct, IPackedPixel, IEquatable<TColor>
         {
             Image<TColor> image = factory.CreateImage(10, 10);
-
             using (PixelAccessor<TColor> pixels = image.Lock())
             {
                 for (int i = 0; i < 10; i++)
@@ -35,6 +34,7 @@ namespace ImageSharp.Tests
                     }
                 }
             }
+
             return image;
         }
 
@@ -43,24 +43,21 @@ namespace ImageSharp.Tests
         public void CopyStretchedRGBTo_FromOrigo<TColor>(TestImageProvider<TColor> provider)
             where TColor : struct, IPackedPixel, IEquatable<TColor>
         {
-            Image<TColor> src = provider.GetImage();
-
-            PixelArea<TColor> area = new PixelArea<TColor>(8, 8, ComponentOrder.Xyz);
-            Image<TColor> dest = provider.Factory.CreateImage(8, 8);
-
-            using (var s = src.Lock())
+            using (Image<TColor> src = provider.GetImage())
+            using (Image<TColor> dest = provider.Factory.CreateImage(8, 8))
+            using (PixelArea<TColor> area = new PixelArea<TColor>(8, 8, ComponentOrder.Xyz))
+            using (PixelAccessor<TColor> s = src.Lock())
+            using (PixelAccessor<TColor> d = dest.Lock())
             {
-                using (var d = dest.Lock())
-                {
-                    s.CopyRGBBytesStretchedTo(area, 0, 0);
-                    d.CopyFrom(area, 0, 0);
+                s.CopyRGBBytesStretchedTo(area, 0, 0);
+                d.CopyFrom(area, 0, 0);
 
-                    Assert.Equal(s[0, 0], d[0, 0]);
-                    Assert.Equal(s[7, 0], d[7, 0]);
-                    Assert.Equal(s[0, 7], d[0, 7]);
-                    Assert.Equal(s[7, 7], d[7, 7]);
-                }
+                Assert.Equal(s[0, 0], d[0, 0]);
+                Assert.Equal(s[7, 0], d[7, 0]);
+                Assert.Equal(s[0, 7], d[0, 7]);
+                Assert.Equal(s[7, 7], d[7, 7]);
             }
+
         }
 
         [Theory]
@@ -68,45 +65,41 @@ namespace ImageSharp.Tests
         public void CopyStretchedRGBTo_WithOffset<TColor>(TestImageProvider<TColor> provider)
             where TColor : struct, IPackedPixel, IEquatable<TColor>
         {
-            Image<TColor> src = provider.GetImage();
-
-            PixelArea<TColor> area = new PixelArea<TColor>(8, 8, ComponentOrder.Xyz);
-            Image<TColor> dest = provider.Factory.CreateImage(8, 8);
-
+            using (Image<TColor> src = provider.GetImage())
+            using (PixelArea<TColor> area = new PixelArea<TColor>(8, 8, ComponentOrder.Xyz))
+            using (Image<TColor> dest = provider.Factory.CreateImage(8, 8))
             using (PixelAccessor<TColor> s = src.Lock())
+            using (PixelAccessor<TColor> d = dest.Lock())
             {
-                using (var d = dest.Lock())
-                {
-                    s.CopyRGBBytesStretchedTo(area, 7, 6);
-                    d.CopyFrom(area, 0, 0);
+                s.CopyRGBBytesStretchedTo(area, 7, 6);
+                d.CopyFrom(area, 0, 0);
 
-                    Assert.Equal(s[6, 7], d[0, 0]);
-                    Assert.Equal(s[6, 8], d[0, 1]);
-                    Assert.Equal(s[7, 8], d[1, 1]);
+                Assert.Equal(s[6, 7], d[0, 0]);
+                Assert.Equal(s[6, 8], d[0, 1]);
+                Assert.Equal(s[7, 8], d[1, 1]);
 
-                    Assert.Equal(s[6, 9], d[0, 2]);
-                    Assert.Equal(s[6, 9], d[0, 3]);
-                    Assert.Equal(s[6, 9], d[0, 7]);
+                Assert.Equal(s[6, 9], d[0, 2]);
+                Assert.Equal(s[6, 9], d[0, 3]);
+                Assert.Equal(s[6, 9], d[0, 7]);
 
-                    Assert.Equal(s[7, 9], d[1, 2]);
-                    Assert.Equal(s[7, 9], d[1, 3]);
-                    Assert.Equal(s[7, 9], d[1, 7]);
+                Assert.Equal(s[7, 9], d[1, 2]);
+                Assert.Equal(s[7, 9], d[1, 3]);
+                Assert.Equal(s[7, 9], d[1, 7]);
 
-                    Assert.Equal(s[9, 9], d[3, 2]);
-                    Assert.Equal(s[9, 9], d[3, 3]);
-                    Assert.Equal(s[9, 9], d[3, 7]);
+                Assert.Equal(s[9, 9], d[3, 2]);
+                Assert.Equal(s[9, 9], d[3, 3]);
+                Assert.Equal(s[9, 9], d[3, 7]);
 
-                    Assert.Equal(s[9, 7], d[3, 0]);
-                    Assert.Equal(s[9, 7], d[4, 0]);
-                    Assert.Equal(s[9, 7], d[7, 0]);
+                Assert.Equal(s[9, 7], d[3, 0]);
+                Assert.Equal(s[9, 7], d[4, 0]);
+                Assert.Equal(s[9, 7], d[7, 0]);
 
-                    Assert.Equal(s[9, 9], d[3, 2]);
-                    Assert.Equal(s[9, 9], d[4, 2]);
-                    Assert.Equal(s[9, 9], d[7, 2]);
+                Assert.Equal(s[9, 9], d[3, 2]);
+                Assert.Equal(s[9, 9], d[4, 2]);
+                Assert.Equal(s[9, 9], d[7, 2]);
 
-                    Assert.Equal(s[9, 9], d[4, 3]);
-                    Assert.Equal(s[9, 9], d[7, 7]);
-                }
+                Assert.Equal(s[9, 9], d[4, 3]);
+                Assert.Equal(s[9, 9], d[7, 7]);
             }
         }
     }

--- a/tests/ImageSharp.Tests/Formats/Jpg/ReferenceImplementationsTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/ReferenceImplementationsTests.cs
@@ -6,8 +6,6 @@
 // ReSharper disable InconsistentNaming
 namespace ImageSharp.Tests.Formats.Jpg
 {
-    using System.Numerics;
-    using ImageSharp.Formats;
     using ImageSharp.Formats.Jpg;
 
     using Xunit;
@@ -97,7 +95,7 @@ namespace ImageSharp.Tests.Formats.Jpg
                 Assert.Equal(expected, actual, new ApproximateFloatComparer(2f));
             }
         }
-        
+
         [Theory]
         [InlineData(42)]
         [InlineData(1)]

--- a/tests/ImageSharp.Tests/Formats/Png/PngTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Png/PngTests.cs
@@ -23,12 +23,13 @@ namespace ImageSharp.Tests
 
             foreach (TestFile file in Files)
             {
-                Image image = file.CreateImage();
-
-                using (FileStream output = File.OpenWrite($"{path}/{file.FileNameWithoutExtension}.png"))
+                using (Image image = file.CreateImage())
                 {
-                    image.Quality = 256;
-                    image.Save(output, new PngFormat());
+                    using (FileStream output = File.OpenWrite($"{path}/{file.FileNameWithoutExtension}.png"))
+                    {
+                        image.Quality = 256;
+                        image.Save(output, new PngFormat());
+                    }
                 }
             }
         }
@@ -42,11 +43,12 @@ namespace ImageSharp.Tests
                 Files,
                 file =>
                     {
-                        Image image = file.CreateImage();
-
-                        using (FileStream output = File.OpenWrite($"{path}/{file.FileNameWithoutExtension}.png"))
+                        using (Image image = file.CreateImage())
                         {
-                            image.SaveAsPng(output);
+                            using (FileStream output = File.OpenWrite($"{path}/{file.FileNameWithoutExtension}.png"))
+                            {
+                                image.SaveAsPng(output);
+                            }
                         }
                     });
         }

--- a/tests/ImageSharp.Tests/Image/ImageTests.cs
+++ b/tests/ImageSharp.Tests/Image/ImageTests.cs
@@ -23,10 +23,11 @@ namespace ImageSharp.Tests
             });
 
             TestFile file = TestFile.Create(TestImages.Bmp.Car);
-            Image image = new Image(file.Bytes);
-
-            Assert.Equal(600, image.Width);
-            Assert.Equal(450, image.Height);
+            using (Image image = new Image(file.Bytes))
+            {
+                Assert.Equal(600, image.Width);
+                Assert.Equal(450, image.Height);
+            }
         }
     }
 }

--- a/tests/ImageSharp.Tests/Image/PixelPoolTests.cs
+++ b/tests/ImageSharp.Tests/Image/PixelPoolTests.cs
@@ -1,0 +1,74 @@
+﻿// <copyright file="PixelPoolTests.cs" company="James Jackson-South">
+// Copyright (c) James Jackson-South and contributors.
+// Licensed under the Apache License, Version 2.0.
+// </copyright>
+
+namespace ImageSharp.Tests
+{
+    using System.Linq;
+
+    using Xunit;
+
+    /// <summary>
+    /// Tests the <see cref="PixelAccessor"/> class.
+    /// </summary>
+    public class PixelPoolTests
+    {
+        [Fact]
+        public void PixelPoolRentsMinimumSize()
+        {
+            Color[] pixels = PixelPool<Color>.RentPixels(1024);
+
+            Assert.True(pixels.Length >= 1024);
+        }
+
+        [Fact]
+        public void PixelPoolRentsEmptyArray()
+        {
+            for (int i = 16; i < 1024; i += 16)
+            {
+                Color[] pixels = PixelPool<Color>.RentPixels(i);
+
+                Assert.True(pixels.All(p => p == default(Color)));
+
+                PixelPool<Color>.ReturnPixels(pixels);
+            }
+
+            for (int i = 16; i < 1024; i += 16)
+            {
+                Color[] pixels = PixelPool<Color>.RentPixels(i);
+
+                Assert.True(pixels.All(p => p == default(Color)));
+
+                PixelPool<Color>.ReturnPixels(pixels);
+            }
+        }
+
+        [Fact]
+        public void PixelPoolDoesNotThrowWhenReturningNonPooled()
+        {
+            Color[] pixels = new Color[1024];
+
+            PixelPool<Color>.ReturnPixels(pixels);
+
+            Assert.True(pixels.Length >= 1024);
+        }
+
+        [Fact]
+        public void PixelPoolCleansRentedArray()
+        {
+            Color[] pixels = PixelPool<Color>.RentPixels(256);
+
+            for (int i = 0; i < pixels.Length; i++)
+            {
+                pixels[i] = Color.Azure;
+            }
+
+            Assert.True(pixels.All(p => p == Color.Azure));
+
+            PixelPool<Color>.ReturnPixels(pixels);
+
+            Assert.True(pixels.All(p => p == default(Color)));
+        }
+    }
+}

--- a/tests/ImageSharp.Tests/Processors/Filters/AlphaTest.cs
+++ b/tests/ImageSharp.Tests/Processors/Filters/AlphaTest.cs
@@ -19,39 +19,35 @@ namespace ImageSharp.Tests
         };
 
         [Theory]
-        [MemberData("AlphaValues")]
+        [MemberData(nameof(AlphaValues))]
         public void ImageShouldApplyAlphaFilter(int value)
         {
-            string path = CreateOutputDirectory("Alpha");
+            string path = this.CreateOutputDirectory("Alpha");
 
             foreach (TestFile file in Files)
             {
                 string filename = file.GetFileName(value);
-                Image image = file.CreateImage();
-
+                using (Image image = file.CreateImage())
                 using (FileStream output = File.OpenWrite($"{path}/{filename}"))
                 {
-                    image.Alpha(value)
-                          .Save(output);
+                    image.Alpha(value).Save(output);
                 }
             }
         }
 
         [Theory]
-        [MemberData("AlphaValues")]
+        [MemberData(nameof(AlphaValues))]
         public void ImageShouldApplyAlphaFilterInBox(int value)
         {
-            string path = CreateOutputDirectory("Alpha");
+            string path = this.CreateOutputDirectory("Alpha");
 
             foreach (TestFile file in Files)
             {
                 string filename = file.GetFileName(value);
-                Image image = file.CreateImage();
-
+                using (Image image = file.CreateImage())
                 using (FileStream output = File.OpenWrite($"{path}/{filename}"))
                 {
-                    image.Alpha(value, new Rectangle(10, 10, image.Width / 2, image.Height / 2))
-                          .Save(output);
+                    image.Alpha(value, new Rectangle(10, 10, image.Width / 2, image.Height / 2)).Save(output);
                 }
             }
         }

--- a/tests/ImageSharp.Tests/Processors/Filters/AutoOrientTests.cs
+++ b/tests/ImageSharp.Tests/Processors/Filters/AutoOrientTests.cs
@@ -26,25 +26,22 @@ namespace ImageSharp.Tests
         };
 
         [Theory]
-        [MemberData("OrientationValues")]
+        [MemberData(nameof(OrientationValues))]
         public void ImageShouldFlip(RotateType rotateType, FlipType flipType, ushort orientation)
         {
-            string path = CreateOutputDirectory("AutoOrient");
+            string path = this.CreateOutputDirectory("AutoOrient");
 
             TestFile file = TestFile.Create(TestImages.Bmp.F);
 
-            Image image = file.CreateImage();
-            image.ExifProfile = new ExifProfile();
-            image.ExifProfile.SetValue(ExifTag.Orientation, orientation);
-
-            using (FileStream before = File.OpenWrite($"{path}/before-{file.FileName}"))
+            using (Image image = file.CreateImage())
             {
+                image.ExifProfile = new ExifProfile();
+                image.ExifProfile.SetValue(ExifTag.Orientation, orientation);
+
+                using (FileStream before = File.OpenWrite($"{path}/before-{file.FileName}"))
                 using (FileStream after = File.OpenWrite($"{path}/after-{file.FileName}"))
                 {
-                    image.RotateFlip(rotateType, flipType)
-                          .Save(before)
-                          .AutoOrient()
-                          .Save(after);
+                    image.RotateFlip(rotateType, flipType).Save(before).AutoOrient().Save(after);
                 }
             }
         }

--- a/tests/ImageSharp.Tests/Processors/Filters/BackgroundColorTest.cs
+++ b/tests/ImageSharp.Tests/Processors/Filters/BackgroundColorTest.cs
@@ -14,16 +14,14 @@ namespace ImageSharp.Tests
         [Fact]
         public void ImageShouldApplyBackgroundColorFilter()
         {
-            string path = CreateOutputDirectory("BackgroundColor");
+            string path = this.CreateOutputDirectory("BackgroundColor");
 
             foreach (TestFile file in Files)
             {
-                Image image = file.CreateImage();
-
+                using (Image image = file.CreateImage())
                 using (FileStream output = File.OpenWrite($"{path}/{file.FileName}"))
                 {
-                    image.BackgroundColor(Color.HotPink)
-                          .Save(output);
+                    image.BackgroundColor(Color.HotPink).Save(output);
                 }
             }
         }

--- a/tests/ImageSharp.Tests/Processors/Filters/BinaryThreshold.cs
+++ b/tests/ImageSharp.Tests/Processors/Filters/BinaryThreshold.cs
@@ -19,20 +19,18 @@ namespace ImageSharp.Tests
         };
 
         [Theory]
-        [MemberData("BinaryThresholdValues")]
+        [MemberData(nameof(BinaryThresholdValues))]
         public void ImageShouldApplyBinaryThresholdFilter(float value)
         {
-            string path = CreateOutputDirectory("BinaryThreshold");
+            string path = this.CreateOutputDirectory("BinaryThreshold");
 
             foreach (TestFile file in Files)
             {
                 string filename = file.GetFileName(value);
-                Image image = file.CreateImage();
-
+                using (Image image = file.CreateImage())
                 using (FileStream output = File.OpenWrite($"{path}/{filename}"))
                 {
-                    image.BinaryThreshold(value)
-                          .Save(output);
+                    image.BinaryThreshold(value).Save(output);
                 }
             }
         }

--- a/tests/ImageSharp.Tests/Processors/Filters/BlackWhiteTest.cs
+++ b/tests/ImageSharp.Tests/Processors/Filters/BlackWhiteTest.cs
@@ -14,16 +14,14 @@ namespace ImageSharp.Tests
         [Fact]
         public void ImageShouldApplyBlackWhiteFilter()
         {
-            string path = CreateOutputDirectory("BlackWhite");
+            string path = this.CreateOutputDirectory("BlackWhite");
 
             foreach (TestFile file in Files)
             {
-                Image image = file.CreateImage();
-
+                using (Image image = file.CreateImage())
                 using (FileStream output = File.OpenWrite($"{path}/{file.FileName}"))
                 {
-                    image.BlackWhite()
-                          .Save(output);
+                    image.BlackWhite().Save(output);
                 }
             }
         }

--- a/tests/ImageSharp.Tests/Processors/Filters/BoxBlurTest.cs
+++ b/tests/ImageSharp.Tests/Processors/Filters/BoxBlurTest.cs
@@ -19,20 +19,18 @@ namespace ImageSharp.Tests
         };
 
         [Theory]
-        [MemberData("BoxBlurValues")]
+        [MemberData(nameof(BoxBlurValues))]
         public void ImageShouldApplyBoxBlurFilter(int value)
         {
-            string path = CreateOutputDirectory("BoxBlur");
+            string path = this.CreateOutputDirectory("BoxBlur");
 
             foreach (TestFile file in Files)
             {
                 string filename = file.GetFileName(value);
-                Image image = file.CreateImage();
-
+                using (Image image = file.CreateImage())
                 using (FileStream output = File.OpenWrite($"{path}/{filename}"))
                 {
-                    image.BoxBlur(value)
-                          .Save(output);
+                    image.BoxBlur(value).Save(output);
                 }
             }
         }

--- a/tests/ImageSharp.Tests/Processors/Filters/BrightnessTest.cs
+++ b/tests/ImageSharp.Tests/Processors/Filters/BrightnessTest.cs
@@ -19,20 +19,18 @@ namespace ImageSharp.Tests
         };
 
         [Theory]
-        [MemberData("BrightnessValues")]
+        [MemberData(nameof(BrightnessValues))]
         public void ImageShouldApplyBrightnessFilter(int value)
         {
-            string path = CreateOutputDirectory("Brightness");
+            string path = this.CreateOutputDirectory("Brightness");
 
             foreach (TestFile file in Files)
             {
                 string filename = file.GetFileName(value);
-                Image image = file.CreateImage();
-
+                using (Image image = file.CreateImage())
                 using (FileStream output = File.OpenWrite($"{path}/{filename}"))
                 {
-                    image.Brightness(value)
-                          .Save(output);
+                    image.Brightness(value).Save(output);
                 }
             }
         }

--- a/tests/ImageSharp.Tests/Processors/Filters/ColorBlindnessTest.cs
+++ b/tests/ImageSharp.Tests/Processors/Filters/ColorBlindnessTest.cs
@@ -26,20 +26,18 @@ namespace ImageSharp.Tests
         };
 
         [Theory]
-        [MemberData("ColorBlindnessFilters")]
+        [MemberData(nameof(ColorBlindnessFilters))]
         public void ImageShouldApplyColorBlindnessFilter(ColorBlindness colorBlindness)
         {
-            string path = CreateOutputDirectory("ColorBlindness");
+            string path = this.CreateOutputDirectory("ColorBlindness");
 
             foreach (TestFile file in Files)
             {
                 string filename = file.GetFileName(colorBlindness);
-                Image image = file.CreateImage();
-
+                using (Image image = file.CreateImage())
                 using (FileStream output = File.OpenWrite($"{path}/{filename}"))
                 {
-                    image.ColorBlindness(colorBlindness)
-                          .Save(output);
+                    image.ColorBlindness(colorBlindness).Save(output);
                 }
             }
         }

--- a/tests/ImageSharp.Tests/Processors/Filters/ContrastTest.cs
+++ b/tests/ImageSharp.Tests/Processors/Filters/ContrastTest.cs
@@ -19,19 +19,17 @@ namespace ImageSharp.Tests
         };
 
         [Theory]
-        [MemberData("ContrastValues")]
+        [MemberData(nameof(ContrastValues))]
         public void ImageShouldApplyContrastFilter(int value)
         {
-            string path = CreateOutputDirectory("Contrast");
+            string path = this.CreateOutputDirectory("Contrast");
 
             foreach (TestFile file in Files)
             {
-                Image image = file.CreateImage();
-
+                using (Image image = file.CreateImage())
                 using (FileStream output = File.OpenWrite($"{path}/{file.FileName}"))
                 {
-                    image.Contrast(value)
-                          .Save(output);
+                    image.Contrast(value).Save(output);
                 }
             }
         }

--- a/tests/ImageSharp.Tests/Processors/Filters/CropTest.cs
+++ b/tests/ImageSharp.Tests/Processors/Filters/CropTest.cs
@@ -14,16 +14,14 @@ namespace ImageSharp.Tests
         [Fact]
         public void ImageShouldApplyCropSampler()
         {
-            string path = CreateOutputDirectory("Crop");
+            string path = this.CreateOutputDirectory("Crop");
 
             foreach (TestFile file in Files)
             {
-                Image image = file.CreateImage();
-
+                using (Image image = file.CreateImage())
                 using (FileStream output = File.OpenWrite($"{path}/{file.FileName}"))
                 {
-                    image.Crop(image.Width / 2, image.Height / 2)
-                          .Save(output);
+                    image.Crop(image.Width / 2, image.Height / 2).Save(output);
                 }
             }
         }

--- a/tests/ImageSharp.Tests/Processors/Filters/DetectEdgesTest.cs
+++ b/tests/ImageSharp.Tests/Processors/Filters/DetectEdgesTest.cs
@@ -31,32 +31,29 @@ namespace ImageSharp.Tests
         [MemberData(nameof(DetectEdgesFilters))]
         public void ImageShouldApplyDetectEdgesFilter(EdgeDetection detector)
         {
-            string path = CreateOutputDirectory("DetectEdges");
+            string path = this.CreateOutputDirectory("DetectEdges");
 
             foreach (TestFile file in Files)
             {
                 string filename = file.GetFileName(detector);
-                Image image = file.CreateImage();
-
+                using (Image image = file.CreateImage())
                 using (FileStream output = File.OpenWrite($"{path}/{filename}"))
                 {
-                    image.DetectEdges(detector)
-                         .Save(output);
+                    image.DetectEdges(detector).Save(output);
                 }
             }
         }
 
         [Theory]
-        [MemberData("DetectEdgesFilters")]
+        [MemberData(nameof(DetectEdgesFilters))]
         public void ImageShouldApplyDetectEdgesFilterInBox(EdgeDetection detector)
         {
-            string path = CreateOutputDirectory("DetectEdges");
+            string path = this.CreateOutputDirectory("DetectEdges");
 
             foreach (TestFile file in Files)
             {
                 string filename = file.GetFileName(detector + "-InBox");
-                Image image = file.CreateImage();
-
+                using (Image image = file.CreateImage())
                 using (FileStream output = File.OpenWrite($"{path}/{filename}"))
                 {
                     image.DetectEdges(detector, new Rectangle(image.Width / 4, image.Height / 4, image.Width / 2, image.Height / 2))

--- a/tests/ImageSharp.Tests/Processors/Filters/EntropyCropTest.cs
+++ b/tests/ImageSharp.Tests/Processors/Filters/EntropyCropTest.cs
@@ -19,20 +19,18 @@ namespace ImageSharp.Tests
         };
 
         [Theory]
-        [MemberData("EntropyCropValues")]
+        [MemberData(nameof(EntropyCropValues))]
         public void ImageShouldApplyEntropyCropSampler(float value)
         {
-            string path = CreateOutputDirectory("EntropyCrop");
+            string path = this.CreateOutputDirectory("EntropyCrop");
 
             foreach (TestFile file in Files)
             {
                 string filename = file.GetFileName(value);
-                Image image = file.CreateImage();
-
+                using (Image image = file.CreateImage())
                 using (FileStream output = File.OpenWrite($"{path}/{filename}"))
                 {
-                    image.EntropyCrop(value)
-                          .Save(output);
+                    image.EntropyCrop(value).Save(output);
                 }
             }
         }

--- a/tests/ImageSharp.Tests/Processors/Filters/FlipTests.cs
+++ b/tests/ImageSharp.Tests/Processors/Filters/FlipTests.cs
@@ -20,20 +20,18 @@ namespace ImageSharp.Tests
         };
 
         [Theory]
-        [MemberData("FlipValues")]
+        [MemberData(nameof(FlipValues))]
         public void ImageShouldFlip(FlipType flipType)
         {
-            string path = CreateOutputDirectory("Flip");
+            string path = this.CreateOutputDirectory("Flip");
 
             foreach (TestFile file in Files)
             {
                 string filename = file.GetFileName(flipType);
-                Image image = file.CreateImage();
-
+                using (Image image = file.CreateImage())
                 using (FileStream output = File.OpenWrite($"{path}/{filename}"))
                 {
-                    image.Flip(flipType)
-                          .Save(output);
+                    image.Flip(flipType).Save(output);
                 }
             }
         }

--- a/tests/ImageSharp.Tests/Processors/Filters/GaussianBlurTest.cs
+++ b/tests/ImageSharp.Tests/Processors/Filters/GaussianBlurTest.cs
@@ -19,20 +19,18 @@ namespace ImageSharp.Tests
         };
 
         [Theory]
-        [MemberData("GaussianBlurValues")]
+        [MemberData(nameof(GaussianBlurValues))]
         public void ImageShouldApplyGaussianBlurFilter(int value)
         {
-            string path = CreateOutputDirectory("GaussianBlur");
+            string path = this.CreateOutputDirectory("GaussianBlur");
 
             foreach (TestFile file in Files)
             {
                 string filename = file.GetFileName(value);
-                Image image = file.CreateImage();
-
+                using (Image image = file.CreateImage())
                 using (FileStream output = File.OpenWrite($"{path}/{filename}"))
                 {
-                    image.GaussianBlur(value)
-                          .Save(output);
+                    image.GaussianBlur(value).Save(output);
                 }
             }
         }

--- a/tests/ImageSharp.Tests/Processors/Filters/GaussianSharpenTest.cs
+++ b/tests/ImageSharp.Tests/Processors/Filters/GaussianSharpenTest.cs
@@ -19,20 +19,18 @@ namespace ImageSharp.Tests
         };
 
         [Theory]
-        [MemberData("GaussianSharpenValues")]
+        [MemberData(nameof(GaussianSharpenValues))]
         public void ImageShouldApplyGaussianSharpenFilter(int value)
         {
-            string path = CreateOutputDirectory("GaussianSharpen");
+            string path = this.CreateOutputDirectory("GaussianSharpen");
 
             foreach (TestFile file in Files)
             {
                 string filename = file.GetFileName(value);
-                Image image = file.CreateImage();
-
+                using (Image image = file.CreateImage())
                 using (FileStream output = File.OpenWrite($"{path}/{filename}"))
                 {
-                    image.GaussianSharpen(value)
-                          .Save(output);
+                    image.GaussianSharpen(value).Save(output);
                 }
             }
         }

--- a/tests/ImageSharp.Tests/Processors/Filters/GlowTest.cs
+++ b/tests/ImageSharp.Tests/Processors/Filters/GlowTest.cs
@@ -14,16 +14,14 @@ namespace ImageSharp.Tests
         [Fact]
         public void ImageShouldApplyGlowFilter()
         {
-            string path = CreateOutputDirectory("Glow");
+            string path = this.CreateOutputDirectory("Glow");
 
             foreach (TestFile file in Files)
             {
-                Image image = file.CreateImage();
-
+                using (Image image = file.CreateImage())
                 using (FileStream output = File.OpenWrite($"{path}/{file.FileName}"))
                 {
-                    image.Glow()
-                          .Save(output);
+                    image.Glow().Save(output);
                 }
             }
         }
@@ -31,17 +29,15 @@ namespace ImageSharp.Tests
         [Fact]
         public void ImageShouldApplyGlowFilterColor()
         {
-            string path = CreateOutputDirectory("Glow");
+            string path = this.CreateOutputDirectory("Glow");
 
             foreach (TestFile file in Files)
             {
                 string filename = file.GetFileName("Color");
-                Image image = file.CreateImage();
-
+                using (Image image = file.CreateImage())
                 using (FileStream output = File.OpenWrite($"{path}/{filename}"))
                 {
-                    image.Glow(Color.HotPink)
-                          .Save(output);
+                    image.Glow(Color.HotPink).Save(output);
                 }
             }
         }
@@ -49,17 +45,15 @@ namespace ImageSharp.Tests
         [Fact]
         public void ImageShouldApplyGlowFilterRadius()
         {
-            string path = CreateOutputDirectory("Glow");
+            string path = this.CreateOutputDirectory("Glow");
 
             foreach (TestFile file in Files)
             {
                 string filename = file.GetFileName("Radius");
-                Image image = file.CreateImage();
-
+                using (Image image = file.CreateImage())
                 using (FileStream output = File.OpenWrite($"{path}/{filename}"))
                 {
-                    image.Glow(image.Width / 4)
-                          .Save(output);
+                    image.Glow(image.Width / 4F).Save(output);
                 }
             }
         }
@@ -67,17 +61,16 @@ namespace ImageSharp.Tests
         [Fact]
         public void ImageShouldApplyGlowFilterInBox()
         {
-            string path = CreateOutputDirectory("Glow");
+            string path = this.CreateOutputDirectory("Glow");
 
             foreach (TestFile file in Files)
             {
                 string filename = file.GetFileName("InBox");
-                Image image = file.CreateImage();
-
+                using (Image image = file.CreateImage())
                 using (FileStream output = File.OpenWrite($"{path}/{filename}"))
                 {
                     image.Glow(new Rectangle(image.Width / 4, image.Height / 4, image.Width / 2, image.Height / 2))
-                          .Save(output);
+                        .Save(output);
                 }
             }
         }

--- a/tests/ImageSharp.Tests/Processors/Filters/GrayscaleTest.cs
+++ b/tests/ImageSharp.Tests/Processors/Filters/GrayscaleTest.cs
@@ -20,20 +20,18 @@ namespace ImageSharp.Tests
         };
 
         [Theory]
-        [MemberData("GrayscaleValues")]
+        [MemberData(nameof(GrayscaleValues))]
         public void ImageShouldApplyGrayscaleFilter(GrayscaleMode value)
         {
-            string path = CreateOutputDirectory("Grayscale");
+            string path = this.CreateOutputDirectory("Grayscale");
 
             foreach (TestFile file in Files)
             {
                 string filename = file.GetFileName(value);
-                Image image = file.CreateImage();
-
+                using (Image image = file.CreateImage())
                 using (FileStream output = File.OpenWrite($"{path}/{filename}"))
                 {
-                    image.Grayscale(value)
-                          .Save(output);
+                    image.Grayscale(value).Save(output);
                 }
             }
         }

--- a/tests/ImageSharp.Tests/Processors/Filters/HueTest.cs
+++ b/tests/ImageSharp.Tests/Processors/Filters/HueTest.cs
@@ -19,20 +19,18 @@ namespace ImageSharp.Tests
         };
 
         [Theory]
-        [MemberData("HueValues")]
+        [MemberData(nameof(HueValues))]
         public void ImageShouldApplyHueFilter(int value)
         {
-            string path = CreateOutputDirectory("Hue");
+            string path = this.CreateOutputDirectory("Hue");
 
             foreach (TestFile file in Files)
             {
                 string filename = file.GetFileName(value);
-                Image image = file.CreateImage();
-
+                using (Image image = file.CreateImage())
                 using (FileStream output = File.OpenWrite($"{path}/{filename}"))
                 {
-                    image.Hue(value)
-                          .Save(output);
+                    image.Hue(value).Save(output);
                 }
             }
         }

--- a/tests/ImageSharp.Tests/Processors/Filters/InvertTest.cs
+++ b/tests/ImageSharp.Tests/Processors/Filters/InvertTest.cs
@@ -14,15 +14,13 @@ namespace ImageSharp.Tests
         [Fact]
         public void ImageShouldApplyInvertFilter()
         {
-            string path = CreateOutputDirectory("Invert");
+            string path = this.CreateOutputDirectory("Invert");
             foreach (TestFile file in Files)
             {
-                Image image = file.CreateImage();
-
+                using (Image image = file.CreateImage())
                 using (FileStream output = File.OpenWrite($"{path}/{file.FileName}"))
                 {
-                    image.Invert()
-                          .Save(output);
+                    image.Invert().Save(output);
                 }
             }
         }
@@ -30,17 +28,15 @@ namespace ImageSharp.Tests
         [Fact]
         public void ImageShouldApplyInvertFilterInBox()
         {
-            string path = CreateOutputDirectory("Invert");
+            string path = this.CreateOutputDirectory("Invert");
 
             foreach (TestFile file in Files)
             {
                 string filename = file.GetFileName("InBox");
-                Image image = file.CreateImage();
-
+                using (Image image = file.CreateImage())
                 using (FileStream output = File.OpenWrite($"{path}/{filename}"))
                 {
-                    image.Invert(new Rectangle(10, 10, image.Width / 2, image.Height / 2))
-                          .Save(output);
+                    image.Invert(new Rectangle(10, 10, image.Width / 2, image.Height / 2)).Save(output);
                 }
             }
         }

--- a/tests/ImageSharp.Tests/Processors/Filters/KodachromeTest.cs
+++ b/tests/ImageSharp.Tests/Processors/Filters/KodachromeTest.cs
@@ -14,16 +14,14 @@ namespace ImageSharp.Tests
         [Fact]
         public void ImageShouldApplyKodachromeFilter()
         {
-            string path = CreateOutputDirectory("Kodachrome");
+            string path = this.CreateOutputDirectory("Kodachrome");
 
             foreach (TestFile file in Files)
             {
-                Image image = file.CreateImage();
-
+                using (Image image = file.CreateImage())
                 using (FileStream output = File.OpenWrite($"{path}/{file.FileName}"))
                 {
-                    image.Kodachrome()
-                          .Save(output);
+                    image.Kodachrome().Save(output);
                 }
             }
         }

--- a/tests/ImageSharp.Tests/Processors/Filters/LomographTest.cs
+++ b/tests/ImageSharp.Tests/Processors/Filters/LomographTest.cs
@@ -14,16 +14,14 @@ namespace ImageSharp.Tests
         [Fact]
         public void ImageShouldApplyLomographFilter()
         {
-            string path = CreateOutputDirectory("Lomograph");
+            string path = this.CreateOutputDirectory("Lomograph");
 
             foreach (TestFile file in Files)
             {
-                Image image = file.CreateImage();
-
+                using (Image image = file.CreateImage())
                 using (FileStream output = File.OpenWrite($"{path}/{file.FileName}"))
                 {
-                    image.Lomograph()
-                          .Save(output);
+                    image.Lomograph().Save(output);
                 }
             }
         }
@@ -31,17 +29,16 @@ namespace ImageSharp.Tests
         [Fact]
         public void ImageShouldApplyLomographFilterInBox()
         {
-            string path = CreateOutputDirectory("Lomograph");
+            string path = this.CreateOutputDirectory("Lomograph");
 
             foreach (TestFile file in Files)
             {
                 string filename = file.GetFileName("InBox");
-                Image image = file.CreateImage();
-
+                using (Image image = file.CreateImage())
                 using (FileStream output = File.OpenWrite($"{path}/{filename}"))
                 {
                     image.Lomograph(new Rectangle(image.Width / 4, image.Width / 4, image.Width / 2, image.Height / 2))
-                          .Save(output);
+                         .Save(output);
                 }
             }
         }

--- a/tests/ImageSharp.Tests/Processors/Filters/OilPaintTest.cs
+++ b/tests/ImageSharp.Tests/Processors/Filters/OilPaintTest.cs
@@ -23,19 +23,17 @@ namespace ImageSharp.Tests
         [MemberData(nameof(OilPaintValues))]
         public void ImageShouldApplyOilPaintFilter(Tuple<int, int> value)
         {
-            string path = CreateOutputDirectory("OilPaint");
+            string path = this.CreateOutputDirectory("OilPaint");
 
             foreach (TestFile file in Files)
             {
                 string filename = file.GetFileName(value);
-                Image image = file.CreateImage();
-
+                using (Image image = file.CreateImage())
                 using (FileStream output = File.OpenWrite($"{path}/{filename}"))
                 {
                     if (image.Width > value.Item2 && image.Height > value.Item2)
                     {
-                        image.OilPaint(value.Item1, value.Item2)
-                             .Save(output);
+                        image.OilPaint(value.Item1, value.Item2).Save(output);
                     }
                 }
             }
@@ -45,18 +43,19 @@ namespace ImageSharp.Tests
         [MemberData(nameof(OilPaintValues))]
         public void ImageShouldApplyOilPaintFilterInBox(Tuple<int, int> value)
         {
-            string path = CreateOutputDirectory("OilPaint");
+            string path = this.CreateOutputDirectory("OilPaint");
 
             foreach (TestFile file in Files)
             {
                 string filename = file.GetFileName(value + "-InBox");
-                Image image = file.CreateImage();
-
-                if (image.Width > value.Item2 && image.Height > value.Item2)
+                using (Image image = file.CreateImage())
                 {
-                    using (FileStream output = File.OpenWrite($"{path}/{filename}"))
+                    if (image.Width > value.Item2 && image.Height > value.Item2)
                     {
-                        image.OilPaint(value.Item1, value.Item2, new Rectangle(image.Width / 4, image.Width / 4, image.Width / 2, image.Height / 2)).Save(output);
+                        using (FileStream output = File.OpenWrite($"{path}/{filename}"))
+                        {
+                            image.OilPaint(value.Item1, value.Item2, new Rectangle(image.Width / 4, image.Width / 4, image.Width / 2, image.Height / 2)).Save(output);
+                        }
                     }
                 }
             }

--- a/tests/ImageSharp.Tests/Processors/Filters/PadTest.cs
+++ b/tests/ImageSharp.Tests/Processors/Filters/PadTest.cs
@@ -14,16 +14,14 @@ namespace ImageSharp.Tests
         [Fact]
         public void ImageShouldApplyPadSampler()
         {
-            string path = CreateOutputDirectory("Pad");
+            string path = this.CreateOutputDirectory("Pad");
 
             foreach (TestFile file in Files)
             {
-                Image image = file.CreateImage();
-
+                using (Image image = file.CreateImage())
                 using (FileStream output = File.OpenWrite($"{path}/{file.FileName}"))
                 {
-                    image.Pad(image.Width + 50, image.Height + 50)
-                          .Save(output);
+                    image.Pad(image.Width + 50, image.Height + 50).Save(output);
                 }
             }
         }

--- a/tests/ImageSharp.Tests/Processors/Filters/PixelateTest.cs
+++ b/tests/ImageSharp.Tests/Processors/Filters/PixelateTest.cs
@@ -41,17 +41,15 @@ namespace ImageSharp.Tests
         [MemberData(nameof(PixelateValues))]
         public void ImageShouldApplyPixelateFilterInBox(int value)
         {
-            string path = CreateOutputDirectory("Pixelate");
+            string path = this.CreateOutputDirectory("Pixelate");
 
             foreach (TestFile file in Files)
             {
                 string filename = file.GetFileName(value + "-InBox");
-                Image image = file.CreateImage();
-
+                using (Image image = file.CreateImage())
                 using (FileStream output = File.OpenWrite($"{path}/{filename}"))
                 {
-                    image.Pixelate(value, new Rectangle(10, 10, image.Width / 2, image.Height / 2))
-                         .Save(output);
+                    image.Pixelate(value, new Rectangle(10, 10, image.Width / 2, image.Height / 2)).Save(output);
                 }
             }
         }

--- a/tests/ImageSharp.Tests/Processors/Filters/PolaroidTest.cs
+++ b/tests/ImageSharp.Tests/Processors/Filters/PolaroidTest.cs
@@ -14,16 +14,14 @@ namespace ImageSharp.Tests
         [Fact]
         public void ImageShouldApplyPolaroidFilter()
         {
-            string path = CreateOutputDirectory("Polaroid");
+            string path = this.CreateOutputDirectory("Polaroid");
 
             foreach (TestFile file in Files)
             {
-                Image image = file.CreateImage();
-
+                using (Image image = file.CreateImage())
                 using (FileStream output = File.OpenWrite($"{path}/{file.FileName}"))
                 {
-                    image.Polaroid()
-                          .Save(output);
+                    image.Polaroid().Save(output);
                 }
             }
         }

--- a/tests/ImageSharp.Tests/Processors/Filters/ResizeTests.cs
+++ b/tests/ImageSharp.Tests/Processors/Filters/ResizeTests.cs
@@ -42,12 +42,10 @@ namespace ImageSharp.Tests
             foreach (TestFile file in Files)
             {
                 string filename = file.GetFileName(name);
-                Image image = file.CreateImage();
-
+                using (Image image = file.CreateImage())
                 using (FileStream output = File.OpenWrite($"{path}/{filename}"))
                 {
-                    image.Resize(image.Width / 2, image.Height / 2, sampler, true)
-                         .Save(output);
+                    image.Resize(image.Width / 2, image.Height / 2, sampler, true).Save(output);
                 }
             }
         }
@@ -63,12 +61,10 @@ namespace ImageSharp.Tests
             foreach (TestFile file in Files)
             {
                 string filename = file.GetFileName(name);
-                Image image = file.CreateImage();
-
+                using (Image image = file.CreateImage())
                 using (FileStream output = File.OpenWrite($"{path}/{filename}"))
                 {
-                    image.Resize(image.Width / 3, 0, sampler, false)
-                          .Save(output);
+                    image.Resize(image.Width / 3, 0, sampler, false).Save(output);
                 }
             }
         }
@@ -84,12 +80,10 @@ namespace ImageSharp.Tests
             foreach (TestFile file in Files)
             {
                 string filename = file.GetFileName(name);
-                Image image = file.CreateImage();
-
+                using (Image image = file.CreateImage())
                 using (FileStream output = File.OpenWrite($"{path}/{filename}"))
                 {
-                    image.Resize(0, image.Height / 3, sampler, false)
-                          .Save(output);
+                    image.Resize(0, image.Height / 3, sampler, false).Save(output);
                 }
             }
         }
@@ -105,18 +99,16 @@ namespace ImageSharp.Tests
             foreach (TestFile file in Files)
             {
                 string filename = file.GetFileName(name);
-                Image image = file.CreateImage();
-
+                using (Image image = file.CreateImage())
                 using (FileStream output = File.OpenWrite($"{path}/{filename}"))
                 {
-                    ResizeOptions options = new ResizeOptions()
+                    ResizeOptions options = new ResizeOptions
                     {
                         Sampler = sampler,
                         Size = new Size(image.Width / 2, image.Height)
                     };
 
-                    image.Resize(options)
-                          .Save(output);
+                    image.Resize(options).Save(output);
                 }
             }
         }
@@ -132,18 +124,16 @@ namespace ImageSharp.Tests
             foreach (TestFile file in Files)
             {
                 string filename = file.GetFileName(name);
-                Image image = file.CreateImage();
-
+                using (Image image = file.CreateImage())
                 using (FileStream output = File.OpenWrite($"{path}/{filename}"))
                 {
-                    ResizeOptions options = new ResizeOptions()
+                    ResizeOptions options = new ResizeOptions
                     {
                         Sampler = sampler,
                         Size = new Size(image.Width, image.Height / 2)
                     };
 
-                    image.Resize(options)
-                          .Save(output);
+                    image.Resize(options).Save(output);
                 }
             }
         }
@@ -159,18 +149,16 @@ namespace ImageSharp.Tests
             foreach (TestFile file in Files)
             {
                 string filename = file.GetFileName(name);
-                Image image = file.CreateImage();
-
+                using (Image image = file.CreateImage())
                 using (FileStream output = File.OpenWrite($"{path}/{filename}"))
                 {
-                    ResizeOptions options = new ResizeOptions()
+                    ResizeOptions options = new ResizeOptions
                     {
                         Size = new Size(image.Width + 200, image.Height),
                         Mode = ResizeMode.Pad
                     };
 
-                    image.Resize(options)
-                          .Save(output);
+                    image.Resize(options).Save(output);
                 }
             }
         }
@@ -186,19 +174,17 @@ namespace ImageSharp.Tests
             foreach (TestFile file in Files)
             {
                 string filename = file.GetFileName(name);
-                Image image = file.CreateImage();
-
+                using (Image image = file.CreateImage())
                 using (FileStream output = File.OpenWrite($"{path}/{filename}"))
                 {
-                    ResizeOptions options = new ResizeOptions()
+                    ResizeOptions options = new ResizeOptions
                     {
                         Sampler = sampler,
                         Size = new Size(image.Width + 200, image.Height + 200),
                         Mode = ResizeMode.BoxPad
                     };
 
-                    image.Resize(options)
-                          .Save(output);
+                    image.Resize(options).Save(output);
                 }
             }
         }
@@ -214,19 +200,17 @@ namespace ImageSharp.Tests
             foreach (TestFile file in Files)
             {
                 string filename = file.GetFileName(name);
-                Image image = file.CreateImage();
-
+                using (Image image = file.CreateImage())
                 using (FileStream output = File.OpenWrite($"{path}/{filename}"))
                 {
-                    ResizeOptions options = new ResizeOptions()
+                    ResizeOptions options = new ResizeOptions
                     {
                         Sampler = sampler,
                         Size = new Size(300, 300),
                         Mode = ResizeMode.Max
                     };
 
-                    image.Resize(options)
-                          .Save(output);
+                    image.Resize(options).Save(output);
                 }
             }
         }
@@ -242,19 +226,17 @@ namespace ImageSharp.Tests
             foreach (TestFile file in Files)
             {
                 string filename = file.GetFileName(name);
-                Image image = file.CreateImage();
-
+                using (Image image = file.CreateImage())
                 using (FileStream output = File.OpenWrite($"{path}/{filename}"))
                 {
-                    ResizeOptions options = new ResizeOptions()
+                    ResizeOptions options = new ResizeOptions
                     {
                         Sampler = sampler,
-                        Size = new Size((int)Math.Round(image.Width * .75F), (int)Math.Round(image.Height * 95F)),
+                        Size = new Size((int)Math.Round(image.Width * .75F), (int)Math.Round(image.Height * .95F)),
                         Mode = ResizeMode.Min
                     };
 
-                    image.Resize(options)
-                          .Save(output);
+                    image.Resize(options).Save(output);
                 }
             }
         }
@@ -270,19 +252,17 @@ namespace ImageSharp.Tests
             foreach (TestFile file in Files)
             {
                 string filename = file.GetFileName(name);
-                Image image = file.CreateImage();
-
+                using (Image image = file.CreateImage())
                 using (FileStream output = File.OpenWrite($"{path}/{filename}"))
                 {
-                    ResizeOptions options = new ResizeOptions()
+                    ResizeOptions options = new ResizeOptions
                     {
                         Sampler = sampler,
                         Size = new Size(image.Width / 2, image.Height),
                         Mode = ResizeMode.Stretch
                     };
 
-                    image.Resize(options)
-                          .Save(output);
+                    image.Resize(options).Save(output);
                 }
             }
         }

--- a/tests/ImageSharp.Tests/Processors/Filters/RotateFlipTest.cs
+++ b/tests/ImageSharp.Tests/Processors/Filters/RotateFlipTest.cs
@@ -22,20 +22,18 @@ namespace ImageSharp.Tests
         };
 
         [Theory]
-        [MemberData("RotateFlipValues")]
+        [MemberData(nameof(RotateFlipValues))]
         public void ImageShouldRotateFlip(RotateType rotateType, FlipType flipType)
         {
-            string path = CreateOutputDirectory("RotateFlip");
+            string path = this.CreateOutputDirectory("RotateFlip");
 
             foreach (TestFile file in Files)
             {
                 string filename = file.GetFileName(rotateType + "-" + flipType);
-                Image image = file.CreateImage();
-
+                using (Image image = file.CreateImage())
                 using (FileStream output = File.OpenWrite($"{path}/{filename}"))
                 {
-                    image.RotateFlip(rotateType, flipType)
-                          .Save(output);
+                    image.RotateFlip(rotateType, flipType).Save(output);
                 }
             }
         }

--- a/tests/ImageSharp.Tests/Processors/Filters/RotateTest.cs
+++ b/tests/ImageSharp.Tests/Processors/Filters/RotateTest.cs
@@ -28,39 +28,35 @@ namespace ImageSharp.Tests
         };
 
         [Theory]
-        [MemberData("RotateFloatValues")]
+        [MemberData(nameof(RotateFloatValues))]
         public void ImageShouldApplyRotateSampler(float value)
         {
-            string path = CreateOutputDirectory("Rotate");
+            string path = this.CreateOutputDirectory("Rotate");
 
             foreach (TestFile file in Files)
             {
                 string filename = file.GetFileName(value);
-                Image image = file.CreateImage();
-
+                using (Image image = file.CreateImage())
                 using (FileStream output = File.OpenWrite($"{path}/{filename}"))
                 {
-                    image.Rotate(value)
-                          .Save(output);
+                    image.Rotate(value).Save(output);
                 }
             }
         }
 
         [Theory]
-        [MemberData("RotateEnumValues")]
+        [MemberData(nameof(RotateEnumValues))]
         public void ImageShouldApplyRotateSampler(RotateType value)
         {
-            string path = CreateOutputDirectory("Rotate");
+            string path = this.CreateOutputDirectory("Rotate");
 
             foreach (TestFile file in Files)
             {
                 string filename = file.GetFileName(value);
-                Image image = file.CreateImage();
-
+                using (Image image = file.CreateImage())
                 using (FileStream output = File.OpenWrite($"{path}/{filename}"))
                 {
-                    image.Rotate(value)
-                          .Save(output);
+                    image.Rotate(value).Save(output);
                 }
             }
         }

--- a/tests/ImageSharp.Tests/Processors/Filters/SaturationTest.cs
+++ b/tests/ImageSharp.Tests/Processors/Filters/SaturationTest.cs
@@ -19,7 +19,7 @@ namespace ImageSharp.Tests
         };
 
         [Theory]
-        [MemberData("SaturationValues")]
+        [MemberData(nameof(SaturationValues))]
         public void ImageShouldApplySaturationFilter(int value)
         {
             string path = CreateOutputDirectory("Saturation");
@@ -27,12 +27,10 @@ namespace ImageSharp.Tests
             foreach (TestFile file in Files)
             {
                 string filename = file.GetFileName(value);
-                Image image = file.CreateImage();
-
+                using (Image image = file.CreateImage())
                 using (FileStream output = File.OpenWrite($"{path}/{filename}"))
                 {
-                    image.Saturation(value)
-                          .Save(output);
+                    image.Saturation(value).Save(output);
                 }
             }
         }

--- a/tests/ImageSharp.Tests/Processors/Filters/SepiaTest.cs
+++ b/tests/ImageSharp.Tests/Processors/Filters/SepiaTest.cs
@@ -18,12 +18,10 @@ namespace ImageSharp.Tests
 
             foreach (TestFile file in Files)
             {
-                Image image = file.CreateImage();
-
+                using (Image image = file.CreateImage())
                 using (FileStream output = File.OpenWrite($"{path}/{file.FileName}"))
                 {
-                    image.Sepia()
-                          .Save(output);
+                    image.Sepia().Save(output);
                 }
             }
         }

--- a/tests/ImageSharp.Tests/Processors/Filters/SkewTest.cs
+++ b/tests/ImageSharp.Tests/Processors/Filters/SkewTest.cs
@@ -19,22 +19,20 @@ namespace ImageSharp.Tests
         };
 
         [Theory]
-        [MemberData("SkewValues")]
+        [MemberData(nameof(SkewValues))]
         public void ImageShouldApplySkewSampler(float x, float y)
         {
-            string path = CreateOutputDirectory("Skew");
+            string path = this.CreateOutputDirectory("Skew");
 
-            // Matches live example 
+            // Matches live example
             // http://www.w3schools.com/css/tryit.asp?filename=trycss3_transform_skew
             foreach (TestFile file in Files)
             {
                 string filename = file.GetFileName(x + "-" + y);
-                Image image = file.CreateImage();
-
+                using (Image image = file.CreateImage())
                 using (FileStream output = File.OpenWrite($"{path}/{filename}"))
                 {
-                    image.Skew(x, y)
-                          .Save(output);
+                    image.Skew(x, y).Save(output);
                 }
             }
         }

--- a/tests/ImageSharp.Tests/Processors/Filters/VignetteTest.cs
+++ b/tests/ImageSharp.Tests/Processors/Filters/VignetteTest.cs
@@ -14,16 +14,14 @@ namespace ImageSharp.Tests
         [Fact]
         public void ImageShouldApplyVignetteFilter()
         {
-            string path = CreateOutputDirectory("Vignette");
+            string path = this.CreateOutputDirectory("Vignette");
 
             foreach (TestFile file in Files)
             {
-                Image image = file.CreateImage();
-
+                using (Image image = file.CreateImage())
                 using (FileStream output = File.OpenWrite($"{path}/{file.FileName}"))
                 {
-                    image.Vignette()
-                          .Save(output);
+                    image.Vignette().Save(output);
                 }
             }
         }
@@ -31,17 +29,15 @@ namespace ImageSharp.Tests
         [Fact]
         public void ImageShouldApplyVignetteFilterColor()
         {
-            string path = CreateOutputDirectory("Vignette");
+            string path = this.CreateOutputDirectory("Vignette");
 
             foreach (TestFile file in Files)
             {
                 string filename = file.GetFileName("Color");
-                Image image = file.CreateImage();
-
+                using (Image image = file.CreateImage())
                 using (FileStream output = File.OpenWrite($"{path}/{filename}"))
                 {
-                    image.Vignette(Color.HotPink)
-                          .Save(output);
+                    image.Vignette(Color.HotPink).Save(output);
                 }
             }
         }
@@ -49,17 +45,15 @@ namespace ImageSharp.Tests
         [Fact]
         public void ImageShouldApplyVignetteFilterRadius()
         {
-            string path = CreateOutputDirectory("Vignette");
+            string path = this.CreateOutputDirectory("Vignette");
 
             foreach (TestFile file in Files)
             {
                 string filename = file.GetFileName("Radius");
-                Image image = file.CreateImage();
-
+                using (Image image = file.CreateImage())
                 using (FileStream output = File.OpenWrite($"{path}/{filename}"))
                 {
-                    image.Vignette(image.Width / 4, image.Height / 4)
-                          .Save(output);
+                    image.Vignette(image.Width / 4F, image.Height / 4F).Save(output);
                 }
             }
         }
@@ -67,17 +61,16 @@ namespace ImageSharp.Tests
         [Fact]
         public void ImageShouldApplyVignetteFilterInBox()
         {
-            string path = CreateOutputDirectory("Vignette");
+            string path = this.CreateOutputDirectory("Vignette");
 
             foreach (TestFile file in Files)
             {
                 string filename = file.GetFileName("InBox");
-                Image image = file.CreateImage();
-
+                using (Image image = file.CreateImage())
                 using (FileStream output = File.OpenWrite($"{path}/{filename}"))
                 {
                     image.Vignette(new Rectangle(image.Width / 4, image.Height / 4, image.Width / 2, image.Height / 2))
-                          .Save(output);
+                        .Save(output);
                 }
             }
         }

--- a/tests/ImageSharp.Tests/Profiles/Exif/ExifProfileTests.cs
+++ b/tests/ImageSharp.Tests/Profiles/Exif/ExifProfileTests.cs
@@ -31,6 +31,8 @@ namespace ImageSharp.Tests
 
             ExifValue value = image.ExifProfile.Values.FirstOrDefault(val => val.Tag == ExifTag.Copyright);
             TestValue(value, "Dirk Lemstra");
+
+
         }
 
         [Fact]
@@ -247,6 +249,7 @@ namespace ImageSharp.Tests
             using (MemoryStream memStream = new MemoryStream())
             {
                 image.SaveAsJpeg(memStream);
+                image.Dispose();
 
                 memStream.Position = 0;
                 return new Image(memStream);

--- a/tests/ImageSharp.Tests/Profiles/Exif/ExifTagDescriptionAttributeTests.cs
+++ b/tests/ImageSharp.Tests/Profiles/Exif/ExifTagDescriptionAttributeTests.cs
@@ -10,7 +10,7 @@ namespace ImageSharp.Tests
     public class ExifDescriptionAttributeTests
     {
         [Fact]
-        public void Test_ExifTag()
+        public void TestExifTag()
         {
             var exifProfile = new ExifProfile();
 

--- a/tests/ImageSharp.Tests/Profiles/Exif/ExifValueTests.cs
+++ b/tests/ImageSharp.Tests/Profiles/Exif/ExifValueTests.cs
@@ -12,9 +12,12 @@ namespace ImageSharp.Tests
     {
         private static ExifValue GetExifValue()
         {
-            Image image = TestFile.Create(TestImages.Jpeg.Baseline.Floorplan).CreateImage();
+            ExifProfile profile;
+            using (Image image = TestFile.Create(TestImages.Jpeg.Baseline.Floorplan).CreateImage())
+            {
+                profile = image.ExifProfile;
+            }
 
-            ExifProfile profile = image.ExifProfile;
             Assert.NotNull(profile);
 
             return profile.Values.First();


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/JimBobSquarePants/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practise as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description

This is a biggun' that's been a long time coming. 

The PR changes anything implementing `IImageBase<TColor>` to now also implement `IDisposable`.

There's a little bit of slight of hand going on within `SetPixels` and `ClonePixels` that allows all this to happen. Nothing too fancy though so it should all be easy to follow. The API is still simple but images should now be wrapped in `using` statements.

```
using (FileStream stream = File.OpenRead("foo.jpg"))
using (FileStream output = File.OpenWrite("bar.jpg"))
using (Image image = new Image(stream))
{
    image.Resize(image.Width / 2, image.Height / 2)
         .Grayscale()
         .Save(output);
}
```

Renting and returning of `TColor[]` instances is managed through a single place. `PixelPool<TColor>`. This public static class should always be the single point where all pixel array pooling is managed. (Note, you'll see an empty catch in `ReturnPixels()` that allows us to handle cases where someone doesn't rent from that pool which should be rare enough to not affect performance.)

The memory differences are astounding. Check out the resize benchmark.

```
BenchmarkDotNet=v0.10.1, OS=Microsoft Windows NT 6.2.9200.0
Processor=Intel(R) Core(TM) i7-6600U CPU 2.60GHz, ProcessorCount=4
Frequency=2742188 Hz, Resolution=364.6723 ns, Timer=TSC
  [Host]     : Clr 4.0.30319.42000, 64bit RyuJIT-v4.6.1586.0
  DefaultJob : Clr 4.0.30319.42000, 64bit RyuJIT-v4.6.1586.0
```

### Before

Method |        Mean |    StdErr |    StdDev |      Median | Scaled | Scaled-StdDev |    Gen 0 |    Gen 1 |    Gen 2 | Allocated |
---------------------------- |------------ |---------- |---------- |------------ |------- |-------------- |--------- |--------- |--------- |---------- |
'System.Drawing Resize' |  76.8127 ms | 1.5556 ms | 9.9606 ms |  71.4049 ms |   1.00 |          0.00 |        - |        - |        - |     512 B |
'ImageSharp Resize' |  74.0430 ms | 0.1690 ms | 0.6095 ms |  73.8233 ms |   0.98 |          0.11 | 329.1667 | 266.6667 | 266.6667 |  20.05 MB |
'ImageSharp Compand Resize' | 126.1365 ms | 0.1987 ms | 0.7435 ms | 125.9578 ms |   1.67 |          0.19 | 333.3333 | 270.8333 | 270.8333 |  20.05 MB |

### After

Method |        Mean |    StdDev | Scaled | Scaled-StdDev | Allocated |
---------------------------- |------------ |---------- |------- |-------------- |---------- |
'System.Drawing Resize' |  72.3372 ms | 1.5962 ms |   1.00 |          0.00 |     512 B |
'ImageSharp Resize' |  70.6951 ms | 0.3417 ms |   0.98 |          0.02 | 186.24 kB |
'ImageSharp Compand Resize' | 120.9624 ms | 0.6795 ms |   1.67 |          0.04 | 186.62 kB |


Could you all please go through this with a fine-tooth comb and ensure I haven't missed anything that could lead to memory leaks. All my tests are passing and I can't find any leaks so far.