### PR TITLE
Added file path based APIs to Image & Image<TColor>

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,16 @@ Many `Image` methods are also fluent.
 
 Here's an example of the code required to resize an image using the default Bicubic resampler then turn the colors into their grayscale equivalent using the BT709 standard matrix.
 
+On platforms supporting netstandard 1.3+
+```csharp
+using (Image image = new Image("foo.jpg"))
+{
+    image.Resize(image.Width / 2, image.Height / 2)
+         .Grayscale()
+         .Save("bar.jpg"); // automatic encoder selected based on extension.
+}
+```
+on netstandard 1.1 - 1.2
 ```csharp
 using (FileStream stream = File.OpenRead("foo.jpg"))
 using (FileStream output = File.OpenWrite("bar.jpg"))

--- a/src/ImageSharp/Image.cs
+++ b/src/ImageSharp/Image.cs
@@ -44,6 +44,23 @@ namespace ImageSharp
         {
         }
 
+#if !NO_FILE_IO
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Image"/> class.
+        /// </summary>
+        /// <param name="filePath">
+        /// A file path to read image information.
+        /// </param>
+        /// <param name="configuration">
+        /// The configuration providing initialization code which allows extending the library.
+        /// </param>
+        /// <exception cref="System.ArgumentNullException">Thrown if the <paramref name="filePath"/> is null.</exception>
+        public Image(string filePath, Configuration configuration = null)
+            : base(filePath, configuration)
+        {
+        }
+#endif
+
         /// <summary>
         /// Initializes a new instance of the <see cref="Image"/> class.
         /// </summary>

--- a/src/ImageSharp/Image.cs
+++ b/src/ImageSharp/Image.cs
@@ -44,7 +44,7 @@ namespace ImageSharp
         {
         }
 
-#if !NETSTANDARD11
+#if !NETSTANDARD1_1
         /// <summary>
         /// Initializes a new instance of the <see cref="Image"/> class.
         /// </summary>

--- a/src/ImageSharp/Image.cs
+++ b/src/ImageSharp/Image.cs
@@ -44,7 +44,7 @@ namespace ImageSharp
         {
         }
 
-#if !NO_FILE_IO
+#if !NETSTANDARD11
         /// <summary>
         /// Initializes a new instance of the <see cref="Image"/> class.
         /// </summary>

--- a/src/ImageSharp/Image/Image{TColor}.cs
+++ b/src/ImageSharp/Image/Image{TColor}.cs
@@ -63,7 +63,7 @@ namespace ImageSharp
             this.Load(stream);
         }
 
-#if !NETSTANDARD11
+#if !NETSTANDARD1_1
         /// <summary>
         /// Initializes a new instance of the <see cref="Image{TColor}"/> class.
         /// </summary>
@@ -245,7 +245,7 @@ namespace ImageSharp
             return this;
         }
 
-#if !NETSTANDARD11
+#if !NETSTANDARD1_1
         /// <summary>
         /// Saves the image to the given stream using the currently loaded image format.
         /// </summary>

--- a/src/ImageSharp/Image/Image{TColor}.cs
+++ b/src/ImageSharp/Image/Image{TColor}.cs
@@ -254,8 +254,8 @@ namespace ImageSharp
         /// <returns>The <see cref="Image{TColor}"/></returns>
         public Image<TColor> Save(string filePath)
         {
-            var ext = Path.GetExtension(filePath).Trim('.');
-            var format = this.Configuration.ImageFormats.SingleOrDefault(f => f.SupportedExtensions.Contains(ext, StringComparer.OrdinalIgnoreCase));
+            string ext = Path.GetExtension(filePath).Trim('.');
+            IImageFormat format = this.Configuration.ImageFormats.SingleOrDefault(f => f.SupportedExtensions.Contains(ext, StringComparer.OrdinalIgnoreCase));
             if (format == null)
             {
                 throw new InvalidOperationException($"No image formats have been registered for the file extension '{ext}'.");
@@ -274,7 +274,7 @@ namespace ImageSharp
         public Image<TColor> Save(string filePath, IImageFormat format)
         {
             Guard.NotNull(format, nameof(format));
-            using (var fs = File.Create(filePath))
+            using (FileStream fs = File.Create(filePath))
             {
                 return this.Save(fs, format);
             }
@@ -290,7 +290,7 @@ namespace ImageSharp
         public Image<TColor> Save(string filePath, IImageEncoder encoder)
         {
             Guard.NotNull(encoder, nameof(encoder));
-            using (var fs = File.Create(filePath))
+            using (FileStream fs = File.Create(filePath))
             {
                 return this.Save(fs, encoder);
             }

--- a/src/ImageSharp/Image/Image{TColor}.cs
+++ b/src/ImageSharp/Image/Image{TColor}.cs
@@ -63,7 +63,7 @@ namespace ImageSharp
             this.Load(stream);
         }
 
-#if !NO_FILE_IO
+#if !NETSTANDARD11
         /// <summary>
         /// Initializes a new instance of the <see cref="Image{TColor}"/> class.
         /// </summary>
@@ -245,7 +245,7 @@ namespace ImageSharp
             return this;
         }
 
-#if !NO_FILE_IO
+#if !NETSTANDARD11
         /// <summary>
         /// Saves the image to the given stream using the currently loaded image format.
         /// </summary>

--- a/src/ImageSharp/project.json
+++ b/src/ImageSharp/project.json
@@ -69,7 +69,7 @@
     },
     "netstandard1.1": {
       "buildOptions": {
-        "define": [ "NO_FILE_IO" ]
+        "define": [ "NETSTANDARD11" ]
       },
       "dependencies": {
         "System.Collections": "4.0.11",

--- a/src/ImageSharp/project.json
+++ b/src/ImageSharp/project.json
@@ -68,9 +68,6 @@
       }
     },
     "netstandard1.1": {
-      "buildOptions": {
-        "define": [ "NETSTANDARD11" ]
-      },
       "dependencies": {
         "System.Collections": "4.0.11",
         "System.Diagnostics.Debug": "4.0.11",

--- a/src/ImageSharp/project.json
+++ b/src/ImageSharp/project.json
@@ -46,7 +46,31 @@
     "System.Runtime.CompilerServices.Unsafe": "4.0.0"
   },
   "frameworks": {
+    "netstandard1.3": {
+      "dependencies": {
+        "System.Collections": "4.0.11",
+        "System.Diagnostics.Debug": "4.0.11",
+        "System.Diagnostics.Tools": "4.0.1",
+        "System.IO": "4.1.0",
+        "System.IO.FileSystem": "4.1.0",
+        "System.IO.Compression": "4.1.0",
+        "System.Linq": "4.1.0",
+        "System.Numerics.Vectors": "4.1.1",
+        "System.ObjectModel": "4.0.12",
+        "System.Resources.ResourceManager": "4.0.1",
+        "System.Runtime.Extensions": "4.1.0",
+        "System.Runtime.InteropServices": "4.1.0",
+        "System.Runtime.Numerics": "4.0.1",
+        "System.Text.Encoding.Extensions": "4.0.11",
+        "System.Threading": "4.0.11",
+        "System.Threading.Tasks": "4.0.11",
+        "System.Threading.Tasks.Parallel": "4.0.1"
+      }
+    },
     "netstandard1.1": {
+      "buildOptions": {
+        "define": [ "NO_FILE_IO" ]
+      },
       "dependencies": {
         "System.Collections": "4.0.11",
         "System.Diagnostics.Debug": "4.0.11",

--- a/tests/ImageSharp.Tests/Formats/Bmp/BitmapTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Bmp/BitmapTests.cs
@@ -31,10 +31,7 @@ namespace ImageSharp.Tests
                 string filename = file.GetFileNameWithoutExtension(bitsPerPixel);
                 using (Image image = file.CreateImage())
                 {
-                    using (FileStream output = File.OpenWrite($"{path}/{filename}.bmp"))
-                    {
-                        image.Save(output, new BmpEncoder { BitsPerPixel = bitsPerPixel });
-                    }
+                    image.Save($"{path}/{filename}.bmp", new BmpEncoder { BitsPerPixel = bitsPerPixel });
                 }
             }
         }

--- a/tests/ImageSharp.Tests/Image/ImageTests.cs
+++ b/tests/ImageSharp.Tests/Image/ImageTests.cs
@@ -29,5 +29,36 @@ namespace ImageSharp.Tests
                 Assert.Equal(450, image.Height);
             }
         }
+
+        [Fact]
+        public void ConstructorFileSystem()
+        {
+            TestFile file = TestFile.Create(TestImages.Bmp.Car);
+            using (Image image = new Image(file.FilePath))
+            {
+                Assert.Equal(600, image.Width);
+                Assert.Equal(450, image.Height);
+            }
+        }
+
+        [Fact]
+        public void ConstructorFileSystem_FileNotFound()
+        {
+            System.IO.FileNotFoundException ex = Assert.Throws<System.IO.FileNotFoundException>(
+                () =>
+                {
+                    new Image(Guid.NewGuid().ToString());
+                });
+        }
+
+        [Fact]
+        public void ConstructorFileSystem_NullPath()
+        {
+            ArgumentNullException ex = Assert.Throws<ArgumentNullException>(
+                () =>
+                {
+                    new Image(null);
+                });
+        }
     }
 }

--- a/tests/ImageSharp.Tests/Image/ImageTests.cs
+++ b/tests/ImageSharp.Tests/Image/ImageTests.cs
@@ -7,6 +7,8 @@ namespace ImageSharp.Tests
 {
     using System;
 
+    using ImageSharp.Formats;
+
     using Xunit;
 
     /// <summary>
@@ -59,6 +61,71 @@ namespace ImageSharp.Tests
                 {
                     new Image(null);
                 });
+        }
+
+        [Fact]
+        public void Save_DetecedEncoding()
+        {
+            string file = TestFile.GetPath("../../TestOutput/Save_DetecedEncoding.png");
+            var dir = System.IO.Directory.CreateDirectory(System.IO.Path.GetDirectoryName(file));
+            using (Image image = new Image(10, 10))
+            {
+                image.Save(file);
+            }
+
+            var c = TestFile.Create("../../TestOutput/Save_DetecedEncoding.png");
+            using (var img = c.CreateImage())
+            {
+                Assert.IsType<PngFormat>(img.CurrentImageFormat);
+            }
+        }
+
+        [Fact]
+        public void Save_UnknownExtensionsEncoding()
+        {
+            string file = TestFile.GetPath("../../TestOutput/Save_DetecedEncoding.tmp");
+            var ex = Assert.Throws<InvalidOperationException>(
+                () =>
+                    {
+                        using (Image image = new Image(10, 10))
+                        {
+                            image.Save(file);
+                        }
+                    });
+        }
+
+        [Fact]
+        public void Save_SetFormat()
+        {
+            string file = TestFile.GetPath("../../TestOutput/Save_SetFormat.dat");
+            var dir = System.IO.Directory.CreateDirectory(System.IO.Path.GetDirectoryName(file));
+            using (Image image = new Image(10, 10))
+            {
+                image.Save(file, new PngFormat());
+            }
+
+            var c = TestFile.Create("../../TestOutput/Save_SetFormat.dat");
+            using (var img = c.CreateImage())
+            {
+                Assert.IsType<PngFormat>(img.CurrentImageFormat);
+            }
+        }
+
+        [Fact]
+        public void Save_SetEncoding()
+        {
+            string file = TestFile.GetPath("../../TestOutput/Save_SetEncoding.dat");
+            var dir = System.IO.Directory.CreateDirectory(System.IO.Path.GetDirectoryName(file));
+            using (Image image = new Image(10, 10))
+            {
+                image.Save(file, new PngEncoder());
+            }
+
+            var c = TestFile.Create("../../TestOutput/Save_SetEncoding.dat");
+            using (var img = c.CreateImage())
+            {
+                Assert.IsType<PngFormat>(img.CurrentImageFormat);
+            }
         }
     }
 }

--- a/tests/ImageSharp.Tests/TestFile.cs
+++ b/tests/ImageSharp.Tests/TestFile.cs
@@ -57,6 +57,11 @@ namespace ImageSharp.Tests
         /// <summary>
         /// The file name.
         /// </summary>
+        public string FilePath => this.file;
+
+        /// <summary>
+        /// The file name.
+        /// </summary>
         public string FileName => Path.GetFileName(this.file);
 
         /// <summary>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/JimBobSquarePants/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practise as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->

The change entails adding a new target to the core ImageSharp package targeting netstandard .3, and adding a define to the netstandard1.1 target to allow conditional compilation.

In netstandard1.3+ we now have a dependency on `System.IO.FileSystem` this allows us to add a constructors to Image that take in a file path instead of a stream simplifying the boiler plate required to creating a file. It additionally allows us to add `Image.Save(path)` as an API that saves the file to the named path (looking up the correct image format, based on file's extension, from the formats loaded in to the `Configuration`)

This will simplify how a proportion of users will make use of the API but doesn't break compatibility with netstandard1.1 just doesn't have the nice path based APIs available.

How the API will change:
#### Stream Only API 
The API you can use today and will continue to be able to use when targeting netstandard < 1.3
```csharp
using (FileStream stream = File.OpenRead("foo.jpg"))
using (FileStream output = File.OpenWrite("bar.jpg"))
using (Image image = new Image(stream))
{
    image.Resize(image.Width / 2, image.Height / 2)
         .Grayscale()
         .Save(output);
}
```
#### File path API
Added APIs to dealing with file paths and not having to deal with streams directly.
```csharp
using (Image image = new Image("foo.jpg")) // file only locked while loading data into memory not during entire lifetime of Image
{
    image.Resize(image.Width / 2, image.Height / 2)
         .Grayscale()
         .Save("bar.jpg"); // automatic encoder selected based on extension.
}
```