### PR TITLE
Add NamedColors<TColor> and ColorBuilder<TColor>

### DIFF
--- a/src/ImageSharp.Processing/Overlays/Glow.cs
+++ b/src/ImageSharp.Processing/Overlays/Glow.cs
@@ -23,7 +23,7 @@ namespace ImageSharp
         public static Image<TColor> Glow<TColor>(this Image<TColor> source)
             where TColor : struct, IPackedPixel, IEquatable<TColor>
         {
-            return Glow(source, default(TColor), source.Bounds.Width * .5F, source.Bounds);
+            return Glow(source, NamedColors<TColor>.Black, source.Bounds.Width * .5F, source.Bounds);
         }
 
         /// <summary>
@@ -49,7 +49,7 @@ namespace ImageSharp
         public static Image<TColor> Glow<TColor>(this Image<TColor> source, float radius)
             where TColor : struct, IPackedPixel, IEquatable<TColor>
         {
-            return Glow(source, default(TColor), radius, source.Bounds);
+            return Glow(source, NamedColors<TColor>.Black, radius, source.Bounds);
         }
 
         /// <summary>
@@ -64,7 +64,7 @@ namespace ImageSharp
         public static Image<TColor> Glow<TColor>(this Image<TColor> source, Rectangle rectangle)
             where TColor : struct, IPackedPixel, IEquatable<TColor>
         {
-            return Glow(source, default(TColor), 0, rectangle);
+            return Glow(source, NamedColors<TColor>.Black, 0, rectangle);
         }
 
         /// <summary>
@@ -81,13 +81,7 @@ namespace ImageSharp
         public static Image<TColor> Glow<TColor>(this Image<TColor> source, TColor color, float radius, Rectangle rectangle)
             where TColor : struct, IPackedPixel, IEquatable<TColor>
         {
-            GlowProcessor<TColor> processor = new GlowProcessor<TColor> { Radius = radius, };
-
-            if (!color.Equals(default(TColor)))
-            {
-                processor.GlowColor = color;
-            }
-
+            GlowProcessor<TColor> processor = new GlowProcessor<TColor>(color) { Radius = radius, };
             source.ApplyProcessor(processor, rectangle);
             return source;
         }

--- a/src/ImageSharp.Processing/Overlays/Vignette.cs
+++ b/src/ImageSharp.Processing/Overlays/Vignette.cs
@@ -23,7 +23,7 @@ namespace ImageSharp
         public static Image<TColor> Vignette<TColor>(this Image<TColor> source)
             where TColor : struct, IPackedPixel, IEquatable<TColor>
         {
-            return Vignette(source, default(TColor), source.Bounds.Width * .5F, source.Bounds.Height * .5F, source.Bounds);
+            return Vignette(source, NamedColors<TColor>.Black, source.Bounds.Width * .5F, source.Bounds.Height * .5F, source.Bounds);
         }
 
         /// <summary>
@@ -50,7 +50,7 @@ namespace ImageSharp
         public static Image<TColor> Vignette<TColor>(this Image<TColor> source, float radiusX, float radiusY)
             where TColor : struct, IPackedPixel, IEquatable<TColor>
         {
-            return Vignette(source, default(TColor), radiusX, radiusY, source.Bounds);
+            return Vignette(source, NamedColors<TColor>.Black, radiusX, radiusY, source.Bounds);
         }
 
         /// <summary>
@@ -65,7 +65,7 @@ namespace ImageSharp
         public static Image<TColor> Vignette<TColor>(this Image<TColor> source, Rectangle rectangle)
             where TColor : struct, IPackedPixel, IEquatable<TColor>
         {
-            return Vignette(source, default(TColor), 0, 0, rectangle);
+            return Vignette(source, NamedColors<TColor>.Black, 0, 0, rectangle);
         }
 
         /// <summary>
@@ -83,13 +83,7 @@ namespace ImageSharp
         public static Image<TColor> Vignette<TColor>(this Image<TColor> source, TColor color, float radiusX, float radiusY, Rectangle rectangle)
             where TColor : struct, IPackedPixel, IEquatable<TColor>
         {
-            VignetteProcessor<TColor> processor = new VignetteProcessor<TColor> { RadiusX = radiusX, RadiusY = radiusY };
-
-            if (!color.Equals(default(TColor)))
-            {
-                processor.VignetteColor = color;
-            }
-
+            VignetteProcessor<TColor> processor = new VignetteProcessor<TColor>(color) { RadiusX = radiusX, RadiusY = radiusY };
             source.ApplyProcessor(processor, rectangle);
             return source;
         }

--- a/src/ImageSharp.Processing/Processors/Binarization/BinaryThresholdProcessor.cs
+++ b/src/ImageSharp.Processing/Processors/Binarization/BinaryThresholdProcessor.cs
@@ -27,13 +27,8 @@ namespace ImageSharp.Processing.Processors
             this.Threshold = threshold;
 
             // Default to white/black for upper/lower.
-            TColor upper = default(TColor);
-            upper.PackFromBytes(255, 255, 255, 255);
-            this.UpperColor = upper;
-
-            TColor lower = default(TColor);
-            lower.PackFromBytes(0, 0, 0, 255);
-            this.LowerColor = lower;
+            this.UpperColor = NamedColors<TColor>.White;
+            this.LowerColor = NamedColors<TColor>.Black;
         }
 
         /// <summary>

--- a/src/ImageSharp.Processing/Processors/Binarization/ErrorDiffusionDitherProcessor.cs
+++ b/src/ImageSharp.Processing/Processors/Binarization/ErrorDiffusionDitherProcessor.cs
@@ -29,13 +29,8 @@ namespace ImageSharp.Processing.Processors
             this.Threshold = threshold;
 
             // Default to white/black for upper/lower.
-            TColor upper = default(TColor);
-            upper.PackFromBytes(255, 255, 255, 255);
-            this.UpperColor = upper;
-
-            TColor lower = default(TColor);
-            lower.PackFromBytes(0, 0, 0, 255);
-            this.LowerColor = lower;
+            this.UpperColor = NamedColors<TColor>.White;
+            this.LowerColor = NamedColors<TColor>.Black;
         }
 
         /// <summary>

--- a/src/ImageSharp.Processing/Processors/Binarization/OrderedDitherProcessor.cs
+++ b/src/ImageSharp.Processing/Processors/Binarization/OrderedDitherProcessor.cs
@@ -37,13 +37,8 @@ namespace ImageSharp.Processing.Processors
             this.Index = index;
 
             // Default to white/black for upper/lower.
-            TColor upper = default(TColor);
-            upper.PackFromBytes(255, 255, 255, 255);
-            this.UpperColor = upper;
-
-            TColor lower = default(TColor);
-            lower.PackFromBytes(0, 0, 0, 255);
-            this.LowerColor = lower;
+            this.UpperColor = NamedColors<TColor>.White;
+            this.LowerColor = NamedColors<TColor>.Black;
         }
 
         /// <summary>

--- a/src/ImageSharp.Processing/Processors/ColorMatrix/LomographProcessor.cs
+++ b/src/ImageSharp.Processing/Processors/ColorMatrix/LomographProcessor.cs
@@ -15,6 +15,8 @@ namespace ImageSharp.Processing.Processors
     public class LomographProcessor<TColor> : ColorMatrixFilter<TColor>
         where TColor : struct, IPackedPixel, IEquatable<TColor>
     {
+        private static readonly TColor VeryDarkGreen = ColorBuilder<TColor>.FromRGBA(0, 10, 0, 255);
+
         /// <inheritdoc/>
         public override Matrix4x4 Matrix => new Matrix4x4()
         {
@@ -30,9 +32,7 @@ namespace ImageSharp.Processing.Processors
         /// <inheritdoc/>
         protected override void AfterApply(ImageBase<TColor> source, Rectangle sourceRectangle)
         {
-            TColor packed = default(TColor);
-            packed.PackFromVector4(new Color(0, 10, 0).ToVector4()); // Very dark (mostly black) lime green.
-            new VignetteProcessor<TColor> { VignetteColor = packed }.Apply(source, sourceRectangle);
+            new VignetteProcessor<TColor>(VeryDarkGreen).Apply(source, sourceRectangle);
         }
     }
 }

--- a/src/ImageSharp.Processing/Processors/ColorMatrix/PolaroidProcessor.cs
+++ b/src/ImageSharp.Processing/Processors/ColorMatrix/PolaroidProcessor.cs
@@ -15,6 +15,9 @@ namespace ImageSharp.Processing.Processors
     public class PolaroidProcessor<TColor> : ColorMatrixFilter<TColor>
         where TColor : struct, IPackedPixel, IEquatable<TColor>
     {
+        private static TColor veryDarkOrange = ColorBuilder<TColor>.FromRGB(102, 34, 0);
+        private static TColor lightOrange = ColorBuilder<TColor>.FromRGBA(255, 153, 102, 178);
+
         /// <inheritdoc/>
         public override Matrix4x4 Matrix => new Matrix4x4()
         {
@@ -36,13 +39,8 @@ namespace ImageSharp.Processing.Processors
         /// <inheritdoc/>
         protected override void AfterApply(ImageBase<TColor> source, Rectangle sourceRectangle)
         {
-            TColor packedV = default(TColor);
-            packedV.PackFromVector4(new Color(102, 34, 0).ToVector4()); // Very dark orange [Brown tone]
-            new VignetteProcessor<TColor> { VignetteColor = packedV }.Apply(source, sourceRectangle);
-
-            TColor packedG = default(TColor);
-            packedG.PackFromVector4(new Color(255, 153, 102, 178).ToVector4()); // Light orange
-            new GlowProcessor<TColor> { GlowColor = packedG, Radius = source.Width / 4F }.Apply(source, sourceRectangle);
+            new VignetteProcessor<TColor>(veryDarkOrange).Apply(source, sourceRectangle);
+            new GlowProcessor<TColor>(lightOrange) { Radius = source.Width / 4F }.Apply(source, sourceRectangle);
         }
     }
 }

--- a/src/ImageSharp.Processing/Processors/Overlays/GlowProcessor.cs
+++ b/src/ImageSharp.Processing/Processors/Overlays/GlowProcessor.cs
@@ -17,12 +17,11 @@ namespace ImageSharp.Processing.Processors
         where TColor : struct, IPackedPixel, IEquatable<TColor>
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="GlowProcessor{TColor}"/> class.
+        /// Initializes a new instance of the <see cref="GlowProcessor{TColor}" /> class.
         /// </summary>
-        public GlowProcessor()
+        /// <param name="color">The color or the glow.</param>
+        public GlowProcessor(TColor color)
         {
-            TColor color = default(TColor);
-            color.PackFromVector4(Color.Black.ToVector4());
             this.GlowColor = color;
         }
 

--- a/src/ImageSharp.Processing/Processors/Overlays/VignetteProcessor.cs
+++ b/src/ImageSharp.Processing/Processors/Overlays/VignetteProcessor.cs
@@ -17,12 +17,11 @@ namespace ImageSharp.Processing.Processors
         where TColor : struct, IPackedPixel, IEquatable<TColor>
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="VignetteProcessor{TColor}"/> class.
+        /// Initializes a new instance of the <see cref="VignetteProcessor{TColor}" /> class.
         /// </summary>
-        public VignetteProcessor()
+        /// <param name="color">The color of the vignette.</param>
+        public VignetteProcessor(TColor color)
         {
-            TColor color = default(TColor);
-            color.PackFromVector4(Color.Black.ToVector4());
             this.VignetteColor = color;
         }
 

--- a/src/ImageSharp/Colors/Color.cs
+++ b/src/ImageSharp/Colors/Color.cs
@@ -70,28 +70,6 @@ namespace ImageSharp
         /// <summary>
         /// Initializes a new instance of the <see cref="Color"/> struct.
         /// </summary>
-        /// <param name="hex">
-        /// The hexadecimal representation of the combined color components arranged
-        /// in rgb, rgba, rrggbb, or rrggbbaa format to match web syntax.
-        /// </param>
-        public Color(string hex)
-        {
-            Guard.NotNullOrEmpty(hex, nameof(hex));
-
-            hex = ToRgbaHex(hex);
-
-            if (hex == null || !uint.TryParse(hex, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out this.packedValue))
-            {
-                throw new ArgumentException("Hexadecimal string is not in the correct format.", nameof(hex));
-            }
-
-            // Order parsed from hex string will be backwards, so reverse it.
-            this.packedValue = Pack(this.A, this.B, this.G, this.R);
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Color"/> struct.
-        /// </summary>
         /// <param name="r">The red component.</param>
         /// <param name="g">The green component.</param>
         /// <param name="b">The blue component.</param>
@@ -264,7 +242,7 @@ namespace ImageSharp
         /// </returns>
         public static Color FromHex(string hex)
         {
-            return new Color(hex);
+            return ColorBuilder<Color>.FromHex(hex);
         }
 
         /// <inheritdoc/>
@@ -420,40 +398,6 @@ namespace ImageSharp
         private static uint Pack(byte x, byte y, byte z, byte w)
         {
             return (uint)(x << RedShift | y << GreenShift | z << BlueShift | w << AlphaShift);
-        }
-
-        /// <summary>
-        /// Converts the specified hex value to an rrggbbaa hex value.
-        /// </summary>
-        /// <param name="hex">The hex value to convert.</param>
-        /// <returns>
-        /// A rrggbbaa hex value.
-        /// </returns>
-        private static string ToRgbaHex(string hex)
-        {
-            hex = hex.StartsWith("#") ? hex.Substring(1) : hex;
-
-            if (hex.Length == 8)
-            {
-                return hex;
-            }
-
-            if (hex.Length == 6)
-            {
-                return hex + "FF";
-            }
-
-            if (hex.Length < 3 || hex.Length > 4)
-            {
-                return null;
-            }
-
-            string red = char.ToString(hex[0]);
-            string green = char.ToString(hex[1]);
-            string blue = char.ToString(hex[2]);
-            string alpha = hex.Length == 3 ? "F" : char.ToString(hex[3]);
-
-            return red + red + green + green + blue + blue + alpha + alpha;
         }
     }
 }

--- a/src/ImageSharp/Colors/ColorBuilder{TColor}.cs
+++ b/src/ImageSharp/Colors/ColorBuilder{TColor}.cs
@@ -1,0 +1,110 @@
+﻿// <copyright file="ColorBuilder{TColor}.cs" company="James Jackson-South">
+// Copyright (c) James Jackson-South and contributors.
+// Licensed under the Apache License, Version 2.0.
+// </copyright>
+
+namespace ImageSharp
+{
+    using System;
+    using System.Globalization;
+
+    /// <summary>
+    /// A set of named colors mapped to the provided Color space.
+    /// </summary>
+    /// <typeparam name="TColor">The type of the color.</typeparam>
+    public static class ColorBuilder<TColor>
+        where TColor : struct, IPackedPixel, IEquatable<TColor>
+    {
+        /// <summary>
+        /// Creates a new <typeparamref name="TColor"/> representation from the string representing a color.
+        /// </summary>
+        /// <param name="hex">
+        /// The hexadecimal representation of the combined color components arranged
+        /// in rgb, rgba, rrggbb, or rrggbbaa format to match web syntax.
+        /// </param>
+        /// <returns>Returns a <typeparamref name="TColor"/> that represents the color defined by the provided RGBA heax string.</returns>
+        public static TColor FromHex(string hex)
+        {
+            Guard.NotNullOrEmpty(hex, nameof(hex));
+
+            hex = ToRgbaHex(hex);
+            uint packedValue;
+            if (hex == null || !uint.TryParse(hex, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out packedValue))
+            {
+                throw new ArgumentException("Hexadecimal string is not in the correct format.", nameof(hex));
+            }
+
+            TColor result = default(TColor);
+
+            result.PackFromBytes(
+                (byte)(packedValue >> 24),
+                (byte)(packedValue >> 16),
+                (byte)(packedValue >> 8),
+                (byte)(packedValue >> 0));
+            return result;
+        }
+
+        /// <summary>
+        /// Creates a new <typeparamref name="TColor"/> representation from standard RGB bytes with 100% opacity.
+        /// </summary>
+        /// <param name="red">The red intensity.</param>
+        /// <param name="green">The green intensity.</param>
+        /// <param name="blue">The blue intensity.</param>
+        /// <returns>Returns a <typeparamref name="TColor"/> that represents the color defined by the provided RGB values with 100% opacity.</returns>
+        public static TColor FromRGB(byte red, byte green, byte blue)
+        {
+            TColor color = default(TColor);
+            color.PackFromBytes(red, green, blue, 255);
+            return color;
+        }
+
+        /// <summary>
+        /// Creates a new <typeparamref name="TColor"/> representation from standard RGBA bytes.
+        /// </summary>
+        /// <param name="red">The red intensity.</param>
+        /// <param name="green">The green intensity.</param>
+        /// <param name="blue">The blue intensity.</param>
+        /// <param name="alpha">The alpha intensity.</param>
+        /// <returns>Returns a <typeparamref name="TColor"/> that represents the color defined by the provided RGBA values.</returns>
+        public static TColor FromRGBA(byte red, byte green, byte blue, byte alpha)
+        {
+            TColor color = default(TColor);
+            color.PackFromBytes(red, green, blue, alpha);
+            return color;
+        }
+
+        /// <summary>
+        /// Converts the specified hex value to an rrggbbaa hex value.
+        /// </summary>
+        /// <param name="hex">The hex value to convert.</param>
+        /// <returns>
+        /// A rrggbbaa hex value.
+        /// </returns>
+        private static string ToRgbaHex(string hex)
+        {
+            hex = hex.StartsWith("#") ? hex.Substring(1) : hex;
+
+            if (hex.Length == 8)
+            {
+                return hex;
+            }
+
+            if (hex.Length == 6)
+            {
+                return hex + "FF";
+            }
+
+            if (hex.Length < 3 || hex.Length > 4)
+            {
+                return null;
+            }
+
+            string red = char.ToString(hex[0]);
+            string green = char.ToString(hex[1]);
+            string blue = char.ToString(hex[2]);
+            string alpha = hex.Length == 3 ? "F" : char.ToString(hex[3]);
+
+            return string.Concat(red, red, green, green, blue, blue, alpha, alpha);
+        }
+    }
+}

--- a/src/ImageSharp/Colors/NamedColors{TColor}.cs
+++ b/src/ImageSharp/Colors/NamedColors{TColor}.cs
@@ -1,728 +1,727 @@
-﻿// <copyright file="ColorDefinitions.cs" company="James Jackson-South">
+﻿// <copyright file="NamedColors{TColor}.cs" company="James Jackson-South">
 // Copyright (c) James Jackson-South and contributors.
 // Licensed under the Apache License, Version 2.0.
 // </copyright>
 
 namespace ImageSharp
 {
+    using System;
+
     /// <summary>
-    /// Packed vector type containing four 8-bit unsigned normalized values ranging from 0 to 255.
-    /// The color components are stored in red, green, blue, and alpha order.
+    /// A set of named colors mapped to the provided Color space.
     /// </summary>
-    /// <remarks>
-    /// This struct is fully mutable. This is done (against the guidelines) for the sake of performance,
-    /// as it avoids the need to create new values for modification operations.
-    /// </remarks>
-    public partial struct Color
+    /// <typeparam name="TColor">The type of the color.</typeparam>
+    public static class NamedColors<TColor>
+        where TColor : struct, IPackedPixel, IEquatable<TColor>
     {
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #F0F8FF.
         /// </summary>
-        public static readonly Color AliceBlue = NamedColors<Color>.AliceBlue;
+        public static readonly TColor AliceBlue = ColorBuilder<TColor>.FromRGBA(240, 248, 255, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #FAEBD7.
         /// </summary>
-        public static readonly Color AntiqueWhite = NamedColors<Color>.AntiqueWhite;
+        public static readonly TColor AntiqueWhite = ColorBuilder<TColor>.FromRGBA(250, 235, 215, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #00FFFF.
         /// </summary>
-        public static readonly Color Aqua = NamedColors<Color>.Aqua;
+        public static readonly TColor Aqua = ColorBuilder<TColor>.FromRGBA(0, 255, 255, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #7FFFD4.
         /// </summary>
-        public static readonly Color Aquamarine = NamedColors<Color>.Aquamarine;
+        public static readonly TColor Aquamarine = ColorBuilder<TColor>.FromRGBA(127, 255, 212, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #F0FFFF.
         /// </summary>
-        public static readonly Color Azure = NamedColors<Color>.Azure;
+        public static readonly TColor Azure = ColorBuilder<TColor>.FromRGBA(240, 255, 255, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #F5F5DC.
         /// </summary>
-        public static readonly Color Beige = NamedColors<Color>.Beige;
+        public static readonly TColor Beige = ColorBuilder<TColor>.FromRGBA(245, 245, 220, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #FFE4C4.
         /// </summary>
-        public static readonly Color Bisque = NamedColors<Color>.Bisque;
+        public static readonly TColor Bisque = ColorBuilder<TColor>.FromRGBA(255, 228, 196, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #000000.
         /// </summary>
-        public static readonly Color Black = NamedColors<Color>.Black;
+        public static readonly TColor Black = ColorBuilder<TColor>.FromRGBA(0, 0, 0, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #FFEBCD.
         /// </summary>
-        public static readonly Color BlanchedAlmond = NamedColors<Color>.BlanchedAlmond;
+        public static readonly TColor BlanchedAlmond = ColorBuilder<TColor>.FromRGBA(255, 235, 205, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #0000FF.
         /// </summary>
-        public static readonly Color Blue = NamedColors<Color>.Blue;
+        public static readonly TColor Blue = ColorBuilder<TColor>.FromRGBA(0, 0, 255, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #8A2BE2.
         /// </summary>
-        public static readonly Color BlueViolet = NamedColors<Color>.BlueViolet;
+        public static readonly TColor BlueViolet = ColorBuilder<TColor>.FromRGBA(138, 43, 226, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #A52A2A.
         /// </summary>
-        public static readonly Color Brown = NamedColors<Color>.Brown;
+        public static readonly TColor Brown = ColorBuilder<TColor>.FromRGBA(165, 42, 42, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #DEB887.
         /// </summary>
-        public static readonly Color BurlyWood = NamedColors<Color>.BurlyWood;
+        public static readonly TColor BurlyWood = ColorBuilder<TColor>.FromRGBA(222, 184, 135, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #5F9EA0.
         /// </summary>
-        public static readonly Color CadetBlue = NamedColors<Color>.CadetBlue;
+        public static readonly TColor CadetBlue = ColorBuilder<TColor>.FromRGBA(95, 158, 160, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #7FFF00.
         /// </summary>
-        public static readonly Color Chartreuse = NamedColors<Color>.Chartreuse;
+        public static readonly TColor Chartreuse = ColorBuilder<TColor>.FromRGBA(127, 255, 0, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #D2691E.
         /// </summary>
-        public static readonly Color Chocolate = NamedColors<Color>.Chocolate;
+        public static readonly TColor Chocolate = ColorBuilder<TColor>.FromRGBA(210, 105, 30, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #FF7F50.
         /// </summary>
-        public static readonly Color Coral = NamedColors<Color>.Coral;
+        public static readonly TColor Coral = ColorBuilder<TColor>.FromRGBA(255, 127, 80, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #6495ED.
         /// </summary>
-        public static readonly Color CornflowerBlue = NamedColors<Color>.CornflowerBlue;
+        public static readonly TColor CornflowerBlue = ColorBuilder<TColor>.FromRGBA(100, 149, 237, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #FFF8DC.
         /// </summary>
-        public static readonly Color Cornsilk = NamedColors<Color>.Cornsilk;
+        public static readonly TColor Cornsilk = ColorBuilder<TColor>.FromRGBA(255, 248, 220, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #DC143C.
         /// </summary>
-        public static readonly Color Crimson = NamedColors<Color>.Crimson;
+        public static readonly TColor Crimson = ColorBuilder<TColor>.FromRGBA(220, 20, 60, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #00FFFF.
         /// </summary>
-        public static readonly Color Cyan = NamedColors<Color>.Cyan;
+        public static readonly TColor Cyan = ColorBuilder<TColor>.FromRGBA(0, 255, 255, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #00008B.
         /// </summary>
-        public static readonly Color DarkBlue = NamedColors<Color>.DarkBlue;
+        public static readonly TColor DarkBlue = ColorBuilder<TColor>.FromRGBA(0, 0, 139, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #008B8B.
         /// </summary>
-        public static readonly Color DarkCyan = NamedColors<Color>.DarkCyan;
+        public static readonly TColor DarkCyan = ColorBuilder<TColor>.FromRGBA(0, 139, 139, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #B8860B.
         /// </summary>
-        public static readonly Color DarkGoldenrod = NamedColors<Color>.DarkGoldenrod;
+        public static readonly TColor DarkGoldenrod = ColorBuilder<TColor>.FromRGBA(184, 134, 11, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #A9A9A9.
         /// </summary>
-        public static readonly Color DarkGray = NamedColors<Color>.DarkGray;
+        public static readonly TColor DarkGray = ColorBuilder<TColor>.FromRGBA(169, 169, 169, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #006400.
         /// </summary>
-        public static readonly Color DarkGreen = NamedColors<Color>.DarkGreen;
+        public static readonly TColor DarkGreen = ColorBuilder<TColor>.FromRGBA(0, 100, 0, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #BDB76B.
         /// </summary>
-        public static readonly Color DarkKhaki = NamedColors<Color>.DarkKhaki;
+        public static readonly TColor DarkKhaki = ColorBuilder<TColor>.FromRGBA(189, 183, 107, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #8B008B.
         /// </summary>
-        public static readonly Color DarkMagenta = NamedColors<Color>.DarkMagenta;
+        public static readonly TColor DarkMagenta = ColorBuilder<TColor>.FromRGBA(139, 0, 139, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #556B2F.
         /// </summary>
-        public static readonly Color DarkOliveGreen = NamedColors<Color>.DarkOliveGreen;
+        public static readonly TColor DarkOliveGreen = ColorBuilder<TColor>.FromRGBA(85, 107, 47, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #FF8C00.
         /// </summary>
-        public static readonly Color DarkOrange = NamedColors<Color>.DarkOrange;
+        public static readonly TColor DarkOrange = ColorBuilder<TColor>.FromRGBA(255, 140, 0, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #9932CC.
         /// </summary>
-        public static readonly Color DarkOrchid = NamedColors<Color>.DarkOrchid;
+        public static readonly TColor DarkOrchid = ColorBuilder<TColor>.FromRGBA(153, 50, 204, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #8B0000.
         /// </summary>
-        public static readonly Color DarkRed = NamedColors<Color>.DarkRed;
+        public static readonly TColor DarkRed = ColorBuilder<TColor>.FromRGBA(139, 0, 0, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #E9967A.
         /// </summary>
-        public static readonly Color DarkSalmon = NamedColors<Color>.DarkSalmon;
+        public static readonly TColor DarkSalmon = ColorBuilder<TColor>.FromRGBA(233, 150, 122, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #8FBC8B.
         /// </summary>
-        public static readonly Color DarkSeaGreen = NamedColors<Color>.DarkSeaGreen;
+        public static readonly TColor DarkSeaGreen = ColorBuilder<TColor>.FromRGBA(143, 188, 139, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #483D8B.
         /// </summary>
-        public static readonly Color DarkSlateBlue = NamedColors<Color>.DarkSlateBlue;
+        public static readonly TColor DarkSlateBlue = ColorBuilder<TColor>.FromRGBA(72, 61, 139, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #2F4F4F.
         /// </summary>
-        public static readonly Color DarkSlateGray = NamedColors<Color>.DarkSlateGray;
+        public static readonly TColor DarkSlateGray = ColorBuilder<TColor>.FromRGBA(47, 79, 79, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #00CED1.
         /// </summary>
-        public static readonly Color DarkTurquoise = NamedColors<Color>.DarkTurquoise;
+        public static readonly TColor DarkTurquoise = ColorBuilder<TColor>.FromRGBA(0, 206, 209, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #9400D3.
         /// </summary>
-        public static readonly Color DarkViolet = NamedColors<Color>.DarkViolet;
+        public static readonly TColor DarkViolet = ColorBuilder<TColor>.FromRGBA(148, 0, 211, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #FF1493.
         /// </summary>
-        public static readonly Color DeepPink = NamedColors<Color>.DeepPink;
+        public static readonly TColor DeepPink = ColorBuilder<TColor>.FromRGBA(255, 20, 147, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #00BFFF.
         /// </summary>
-        public static readonly Color DeepSkyBlue = NamedColors<Color>.DeepSkyBlue;
+        public static readonly TColor DeepSkyBlue = ColorBuilder<TColor>.FromRGBA(0, 191, 255, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #696969.
         /// </summary>
-        public static readonly Color DimGray = NamedColors<Color>.DimGray;
+        public static readonly TColor DimGray = ColorBuilder<TColor>.FromRGBA(105, 105, 105, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #1E90FF.
         /// </summary>
-        public static readonly Color DodgerBlue = NamedColors<Color>.DodgerBlue;
+        public static readonly TColor DodgerBlue = ColorBuilder<TColor>.FromRGBA(30, 144, 255, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #B22222.
         /// </summary>
-        public static readonly Color Firebrick = NamedColors<Color>.Firebrick;
+        public static readonly TColor Firebrick = ColorBuilder<TColor>.FromRGBA(178, 34, 34, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #FFFAF0.
         /// </summary>
-        public static readonly Color FloralWhite = NamedColors<Color>.FloralWhite;
+        public static readonly TColor FloralWhite = ColorBuilder<TColor>.FromRGBA(255, 250, 240, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #228B22.
         /// </summary>
-        public static readonly Color ForestGreen = NamedColors<Color>.ForestGreen;
+        public static readonly TColor ForestGreen = ColorBuilder<TColor>.FromRGBA(34, 139, 34, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #FF00FF.
         /// </summary>
-        public static readonly Color Fuchsia = NamedColors<Color>.Fuchsia;
+        public static readonly TColor Fuchsia = ColorBuilder<TColor>.FromRGBA(255, 0, 255, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #DCDCDC.
         /// </summary>
-        public static readonly Color Gainsboro = NamedColors<Color>.Gainsboro;
+        public static readonly TColor Gainsboro = ColorBuilder<TColor>.FromRGBA(220, 220, 220, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #F8F8FF.
         /// </summary>
-        public static readonly Color GhostWhite = NamedColors<Color>.GhostWhite;
+        public static readonly TColor GhostWhite = ColorBuilder<TColor>.FromRGBA(248, 248, 255, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #FFD700.
         /// </summary>
-        public static readonly Color Gold = NamedColors<Color>.Gold;
+        public static readonly TColor Gold = ColorBuilder<TColor>.FromRGBA(255, 215, 0, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #DAA520.
         /// </summary>
-        public static readonly Color Goldenrod = NamedColors<Color>.Goldenrod;
+        public static readonly TColor Goldenrod = ColorBuilder<TColor>.FromRGBA(218, 165, 32, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #808080.
         /// </summary>
-        public static readonly Color Gray = NamedColors<Color>.Gray;
+        public static readonly TColor Gray = ColorBuilder<TColor>.FromRGBA(128, 128, 128, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #008000.
         /// </summary>
-        public static readonly Color Green = NamedColors<Color>.Green;
+        public static readonly TColor Green = ColorBuilder<TColor>.FromRGBA(0, 128, 0, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #ADFF2F.
         /// </summary>
-        public static readonly Color GreenYellow = NamedColors<Color>.GreenYellow;
+        public static readonly TColor GreenYellow = ColorBuilder<TColor>.FromRGBA(173, 255, 47, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #F0FFF0.
         /// </summary>
-        public static readonly Color Honeydew = NamedColors<Color>.Honeydew;
+        public static readonly TColor Honeydew = ColorBuilder<TColor>.FromRGBA(240, 255, 240, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #FF69B4.
         /// </summary>
-        public static readonly Color HotPink = NamedColors<Color>.HotPink;
+        public static readonly TColor HotPink = ColorBuilder<TColor>.FromRGBA(255, 105, 180, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #CD5C5C.
         /// </summary>
-        public static readonly Color IndianRed = NamedColors<Color>.IndianRed;
+        public static readonly TColor IndianRed = ColorBuilder<TColor>.FromRGBA(205, 92, 92, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #4B0082.
         /// </summary>
-        public static readonly Color Indigo = NamedColors<Color>.Indigo;
+        public static readonly TColor Indigo = ColorBuilder<TColor>.FromRGBA(75, 0, 130, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #FFFFF0.
         /// </summary>
-        public static readonly Color Ivory = NamedColors<Color>.Ivory;
+        public static readonly TColor Ivory = ColorBuilder<TColor>.FromRGBA(255, 255, 240, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #F0E68C.
         /// </summary>
-        public static readonly Color Khaki = NamedColors<Color>.Khaki;
+        public static readonly TColor Khaki = ColorBuilder<TColor>.FromRGBA(240, 230, 140, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #E6E6FA.
         /// </summary>
-        public static readonly Color Lavender = NamedColors<Color>.Lavender;
+        public static readonly TColor Lavender = ColorBuilder<TColor>.FromRGBA(230, 230, 250, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #FFF0F5.
         /// </summary>
-        public static readonly Color LavenderBlush = NamedColors<Color>.LavenderBlush;
+        public static readonly TColor LavenderBlush = ColorBuilder<TColor>.FromRGBA(255, 240, 245, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #7CFC00.
         /// </summary>
-        public static readonly Color LawnGreen = NamedColors<Color>.LawnGreen;
+        public static readonly TColor LawnGreen = ColorBuilder<TColor>.FromRGBA(124, 252, 0, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #FFFACD.
         /// </summary>
-        public static readonly Color LemonChiffon = NamedColors<Color>.LemonChiffon;
+        public static readonly TColor LemonChiffon = ColorBuilder<TColor>.FromRGBA(255, 250, 205, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #ADD8E6.
         /// </summary>
-        public static readonly Color LightBlue = NamedColors<Color>.LightBlue;
+        public static readonly TColor LightBlue = ColorBuilder<TColor>.FromRGBA(173, 216, 230, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #F08080.
         /// </summary>
-        public static readonly Color LightCoral = NamedColors<Color>.LightCoral;
+        public static readonly TColor LightCoral = ColorBuilder<TColor>.FromRGBA(240, 128, 128, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #E0FFFF.
         /// </summary>
-        public static readonly Color LightCyan = NamedColors<Color>.LightCyan;
+        public static readonly TColor LightCyan = ColorBuilder<TColor>.FromRGBA(224, 255, 255, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #FAFAD2.
         /// </summary>
-        public static readonly Color LightGoldenrodYellow = NamedColors<Color>.LightGoldenrodYellow;
+        public static readonly TColor LightGoldenrodYellow = ColorBuilder<TColor>.FromRGBA(250, 250, 210, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #D3D3D3.
         /// </summary>
-        public static readonly Color LightGray = NamedColors<Color>.LightGray;
+        public static readonly TColor LightGray = ColorBuilder<TColor>.FromRGBA(211, 211, 211, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #90EE90.
         /// </summary>
-        public static readonly Color LightGreen = NamedColors<Color>.LightGreen;
+        public static readonly TColor LightGreen = ColorBuilder<TColor>.FromRGBA(144, 238, 144, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #FFB6C1.
         /// </summary>
-        public static readonly Color LightPink = NamedColors<Color>.LightPink;
+        public static readonly TColor LightPink = ColorBuilder<TColor>.FromRGBA(255, 182, 193, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #FFA07A.
         /// </summary>
-        public static readonly Color LightSalmon = NamedColors<Color>.LightSalmon;
+        public static readonly TColor LightSalmon = ColorBuilder<TColor>.FromRGBA(255, 160, 122, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #20B2AA.
         /// </summary>
-        public static readonly Color LightSeaGreen = NamedColors<Color>.LightSeaGreen;
+        public static readonly TColor LightSeaGreen = ColorBuilder<TColor>.FromRGBA(32, 178, 170, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #87CEFA.
         /// </summary>
-        public static readonly Color LightSkyBlue = NamedColors<Color>.LightSkyBlue;
+        public static readonly TColor LightSkyBlue = ColorBuilder<TColor>.FromRGBA(135, 206, 250, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #778899.
         /// </summary>
-        public static readonly Color LightSlateGray = NamedColors<Color>.LightSlateGray;
+        public static readonly TColor LightSlateGray = ColorBuilder<TColor>.FromRGBA(119, 136, 153, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #B0C4DE.
         /// </summary>
-        public static readonly Color LightSteelBlue = NamedColors<Color>.LightSteelBlue;
+        public static readonly TColor LightSteelBlue = ColorBuilder<TColor>.FromRGBA(176, 196, 222, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #FFFFE0.
         /// </summary>
-        public static readonly Color LightYellow = NamedColors<Color>.LightYellow;
+        public static readonly TColor LightYellow = ColorBuilder<TColor>.FromRGBA(255, 255, 224, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #00FF00.
         /// </summary>
-        public static readonly Color Lime = NamedColors<Color>.Lime;
+        public static readonly TColor Lime = ColorBuilder<TColor>.FromRGBA(0, 255, 0, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #32CD32.
         /// </summary>
-        public static readonly Color LimeGreen = NamedColors<Color>.LimeGreen;
+        public static readonly TColor LimeGreen = ColorBuilder<TColor>.FromRGBA(50, 205, 50, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #FAF0E6.
         /// </summary>
-        public static readonly Color Linen = NamedColors<Color>.Linen;
+        public static readonly TColor Linen = ColorBuilder<TColor>.FromRGBA(250, 240, 230, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #FF00FF.
         /// </summary>
-        public static readonly Color Magenta = NamedColors<Color>.Magenta;
+        public static readonly TColor Magenta = ColorBuilder<TColor>.FromRGBA(255, 0, 255, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #800000.
         /// </summary>
-        public static readonly Color Maroon = NamedColors<Color>.Maroon;
+        public static readonly TColor Maroon = ColorBuilder<TColor>.FromRGBA(128, 0, 0, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #66CDAA.
         /// </summary>
-        public static readonly Color MediumAquamarine = NamedColors<Color>.MediumAquamarine;
+        public static readonly TColor MediumAquamarine = ColorBuilder<TColor>.FromRGBA(102, 205, 170, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #0000CD.
         /// </summary>
-        public static readonly Color MediumBlue = NamedColors<Color>.MediumBlue;
+        public static readonly TColor MediumBlue = ColorBuilder<TColor>.FromRGBA(0, 0, 205, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #BA55D3.
         /// </summary>
-        public static readonly Color MediumOrchid = NamedColors<Color>.MediumOrchid;
+        public static readonly TColor MediumOrchid = ColorBuilder<TColor>.FromRGBA(186, 85, 211, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #9370DB.
         /// </summary>
-        public static readonly Color MediumPurple = NamedColors<Color>.MediumPurple;
+        public static readonly TColor MediumPurple = ColorBuilder<TColor>.FromRGBA(147, 112, 219, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #3CB371.
         /// </summary>
-        public static readonly Color MediumSeaGreen = NamedColors<Color>.MediumSeaGreen;
+        public static readonly TColor MediumSeaGreen = ColorBuilder<TColor>.FromRGBA(60, 179, 113, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #7B68EE.
         /// </summary>
-        public static readonly Color MediumSlateBlue = NamedColors<Color>.MediumSlateBlue;
+        public static readonly TColor MediumSlateBlue = ColorBuilder<TColor>.FromRGBA(123, 104, 238, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #00FA9A.
         /// </summary>
-        public static readonly Color MediumSpringGreen = NamedColors<Color>.MediumSpringGreen;
+        public static readonly TColor MediumSpringGreen = ColorBuilder<TColor>.FromRGBA(0, 250, 154, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #48D1CC.
         /// </summary>
-        public static readonly Color MediumTurquoise = NamedColors<Color>.MediumTurquoise;
+        public static readonly TColor MediumTurquoise = ColorBuilder<TColor>.FromRGBA(72, 209, 204, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #C71585.
         /// </summary>
-        public static readonly Color MediumVioletRed = NamedColors<Color>.MediumVioletRed;
+        public static readonly TColor MediumVioletRed = ColorBuilder<TColor>.FromRGBA(199, 21, 133, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #191970.
         /// </summary>
-        public static readonly Color MidnightBlue = NamedColors<Color>.MidnightBlue;
+        public static readonly TColor MidnightBlue = ColorBuilder<TColor>.FromRGBA(25, 25, 112, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #F5FFFA.
         /// </summary>
-        public static readonly Color MintCream = NamedColors<Color>.MintCream;
+        public static readonly TColor MintCream = ColorBuilder<TColor>.FromRGBA(245, 255, 250, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #FFE4E1.
         /// </summary>
-        public static readonly Color MistyRose = NamedColors<Color>.MistyRose;
+        public static readonly TColor MistyRose = ColorBuilder<TColor>.FromRGBA(255, 228, 225, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #FFE4B5.
         /// </summary>
-        public static readonly Color Moccasin = NamedColors<Color>.Moccasin;
+        public static readonly TColor Moccasin = ColorBuilder<TColor>.FromRGBA(255, 228, 181, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #FFDEAD.
         /// </summary>
-        public static readonly Color NavajoWhite = NamedColors<Color>.NavajoWhite;
+        public static readonly TColor NavajoWhite = ColorBuilder<TColor>.FromRGBA(255, 222, 173, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #000080.
         /// </summary>
-        public static readonly Color Navy = NamedColors<Color>.Navy;
+        public static readonly TColor Navy = ColorBuilder<TColor>.FromRGBA(0, 0, 128, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #FDF5E6.
         /// </summary>
-        public static readonly Color OldLace = NamedColors<Color>.OldLace;
+        public static readonly TColor OldLace = ColorBuilder<TColor>.FromRGBA(253, 245, 230, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #808000.
         /// </summary>
-        public static readonly Color Olive = NamedColors<Color>.Olive;
+        public static readonly TColor Olive = ColorBuilder<TColor>.FromRGBA(128, 128, 0, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #6B8E23.
         /// </summary>
-        public static readonly Color OliveDrab = NamedColors<Color>.OliveDrab;
+        public static readonly TColor OliveDrab = ColorBuilder<TColor>.FromRGBA(107, 142, 35, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #FFA500.
         /// </summary>
-        public static readonly Color Orange = NamedColors<Color>.Orange;
+        public static readonly TColor Orange = ColorBuilder<TColor>.FromRGBA(255, 165, 0, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #FF4500.
         /// </summary>
-        public static readonly Color OrangeRed = NamedColors<Color>.OrangeRed;
+        public static readonly TColor OrangeRed = ColorBuilder<TColor>.FromRGBA(255, 69, 0, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #DA70D6.
         /// </summary>
-        public static readonly Color Orchid = NamedColors<Color>.Orchid;
+        public static readonly TColor Orchid = ColorBuilder<TColor>.FromRGBA(218, 112, 214, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #EEE8AA.
         /// </summary>
-        public static readonly Color PaleGoldenrod = NamedColors<Color>.PaleGoldenrod;
+        public static readonly TColor PaleGoldenrod = ColorBuilder<TColor>.FromRGBA(238, 232, 170, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #98FB98.
         /// </summary>
-        public static readonly Color PaleGreen = NamedColors<Color>.PaleGreen;
+        public static readonly TColor PaleGreen = ColorBuilder<TColor>.FromRGBA(152, 251, 152, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #AFEEEE.
         /// </summary>
-        public static readonly Color PaleTurquoise = NamedColors<Color>.PaleTurquoise;
+        public static readonly TColor PaleTurquoise = ColorBuilder<TColor>.FromRGBA(175, 238, 238, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #DB7093.
         /// </summary>
-        public static readonly Color PaleVioletRed = NamedColors<Color>.PaleVioletRed;
+        public static readonly TColor PaleVioletRed = ColorBuilder<TColor>.FromRGBA(219, 112, 147, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #FFEFD5.
         /// </summary>
-        public static readonly Color PapayaWhip = NamedColors<Color>.PapayaWhip;
+        public static readonly TColor PapayaWhip = ColorBuilder<TColor>.FromRGBA(255, 239, 213, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #FFDAB9.
         /// </summary>
-        public static readonly Color PeachPuff = NamedColors<Color>.PeachPuff;
+        public static readonly TColor PeachPuff = ColorBuilder<TColor>.FromRGBA(255, 218, 185, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #CD853F.
         /// </summary>
-        public static readonly Color Peru = NamedColors<Color>.Peru;
+        public static readonly TColor Peru = ColorBuilder<TColor>.FromRGBA(205, 133, 63, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #FFC0CB.
         /// </summary>
-        public static readonly Color Pink = NamedColors<Color>.Pink;
+        public static readonly TColor Pink = ColorBuilder<TColor>.FromRGBA(255, 192, 203, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #DDA0DD.
         /// </summary>
-        public static readonly Color Plum = NamedColors<Color>.Plum;
+        public static readonly TColor Plum = ColorBuilder<TColor>.FromRGBA(221, 160, 221, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #B0E0E6.
         /// </summary>
-        public static readonly Color PowderBlue = NamedColors<Color>.PowderBlue;
+        public static readonly TColor PowderBlue = ColorBuilder<TColor>.FromRGBA(176, 224, 230, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #800080.
         /// </summary>
-        public static readonly Color Purple = NamedColors<Color>.Purple;
+        public static readonly TColor Purple = ColorBuilder<TColor>.FromRGBA(128, 0, 128, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #663399.
         /// </summary>
-        public static readonly Color RebeccaPurple = NamedColors<Color>.RebeccaPurple;
+        public static readonly TColor RebeccaPurple = ColorBuilder<TColor>.FromRGBA(102, 51, 153, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #FF0000.
         /// </summary>
-        public static readonly Color Red = NamedColors<Color>.Red;
+        public static readonly TColor Red = ColorBuilder<TColor>.FromRGBA(255, 0, 0, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #BC8F8F.
         /// </summary>
-        public static readonly Color RosyBrown = NamedColors<Color>.RosyBrown;
+        public static readonly TColor RosyBrown = ColorBuilder<TColor>.FromRGBA(188, 143, 143, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #4169E1.
         /// </summary>
-        public static readonly Color RoyalBlue = NamedColors<Color>.RoyalBlue;
+        public static readonly TColor RoyalBlue = ColorBuilder<TColor>.FromRGBA(65, 105, 225, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #8B4513.
         /// </summary>
-        public static readonly Color SaddleBrown = NamedColors<Color>.SaddleBrown;
+        public static readonly TColor SaddleBrown = ColorBuilder<TColor>.FromRGBA(139, 69, 19, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #FA8072.
         /// </summary>
-        public static readonly Color Salmon = NamedColors<Color>.Salmon;
+        public static readonly TColor Salmon = ColorBuilder<TColor>.FromRGBA(250, 128, 114, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #F4A460.
         /// </summary>
-        public static readonly Color SandyBrown = NamedColors<Color>.SandyBrown;
+        public static readonly TColor SandyBrown = ColorBuilder<TColor>.FromRGBA(244, 164, 96, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #2E8B57.
         /// </summary>
-        public static readonly Color SeaGreen = NamedColors<Color>.SeaGreen;
+        public static readonly TColor SeaGreen = ColorBuilder<TColor>.FromRGBA(46, 139, 87, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #FFF5EE.
         /// </summary>
-        public static readonly Color SeaShell = NamedColors<Color>.SeaShell;
+        public static readonly TColor SeaShell = ColorBuilder<TColor>.FromRGBA(255, 245, 238, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #A0522D.
         /// </summary>
-        public static readonly Color Sienna = NamedColors<Color>.Sienna;
+        public static readonly TColor Sienna = ColorBuilder<TColor>.FromRGBA(160, 82, 45, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #C0C0C0.
         /// </summary>
-        public static readonly Color Silver = NamedColors<Color>.Silver;
+        public static readonly TColor Silver = ColorBuilder<TColor>.FromRGBA(192, 192, 192, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #87CEEB.
         /// </summary>
-        public static readonly Color SkyBlue = NamedColors<Color>.SkyBlue;
+        public static readonly TColor SkyBlue = ColorBuilder<TColor>.FromRGBA(135, 206, 235, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #6A5ACD.
         /// </summary>
-        public static readonly Color SlateBlue = NamedColors<Color>.SlateBlue;
+        public static readonly TColor SlateBlue = ColorBuilder<TColor>.FromRGBA(106, 90, 205, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #708090.
         /// </summary>
-        public static readonly Color SlateGray = NamedColors<Color>.SlateGray;
+        public static readonly TColor SlateGray = ColorBuilder<TColor>.FromRGBA(112, 128, 144, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #FFFAFA.
         /// </summary>
-        public static readonly Color Snow = NamedColors<Color>.Snow;
+        public static readonly TColor Snow = ColorBuilder<TColor>.FromRGBA(255, 250, 250, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #00FF7F.
         /// </summary>
-        public static readonly Color SpringGreen = NamedColors<Color>.SpringGreen;
+        public static readonly TColor SpringGreen = ColorBuilder<TColor>.FromRGBA(0, 255, 127, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #4682B4.
         /// </summary>
-        public static readonly Color SteelBlue = NamedColors<Color>.SteelBlue;
+        public static readonly TColor SteelBlue = ColorBuilder<TColor>.FromRGBA(70, 130, 180, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #D2B48C.
         /// </summary>
-        public static readonly Color Tan = NamedColors<Color>.Tan;
+        public static readonly TColor Tan = ColorBuilder<TColor>.FromRGBA(210, 180, 140, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #008080.
         /// </summary>
-        public static readonly Color Teal = NamedColors<Color>.Teal;
+        public static readonly TColor Teal = ColorBuilder<TColor>.FromRGBA(0, 128, 128, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #D8BFD8.
         /// </summary>
-        public static readonly Color Thistle = NamedColors<Color>.Thistle;
+        public static readonly TColor Thistle = ColorBuilder<TColor>.FromRGBA(216, 191, 216, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #FF6347.
         /// </summary>
-        public static readonly Color Tomato = NamedColors<Color>.Tomato;
+        public static readonly TColor Tomato = ColorBuilder<TColor>.FromRGBA(255, 99, 71, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #FFFFFF.
         /// </summary>
-        public static readonly Color Transparent = NamedColors<Color>.Transparent;
+        public static readonly TColor Transparent = ColorBuilder<TColor>.FromRGBA(255, 255, 255, 0);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #40E0D0.
         /// </summary>
-        public static readonly Color Turquoise = NamedColors<Color>.Turquoise;
+        public static readonly TColor Turquoise = ColorBuilder<TColor>.FromRGBA(64, 224, 208, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #EE82EE.
         /// </summary>
-        public static readonly Color Violet = NamedColors<Color>.Violet;
+        public static readonly TColor Violet = ColorBuilder<TColor>.FromRGBA(238, 130, 238, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #F5DEB3.
         /// </summary>
-        public static readonly Color Wheat = NamedColors<Color>.Wheat;
+        public static readonly TColor Wheat = ColorBuilder<TColor>.FromRGBA(245, 222, 179, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #FFFFFF.
         /// </summary>
-        public static readonly Color White = NamedColors<Color>.White;
+        public static readonly TColor White = ColorBuilder<TColor>.FromRGBA(255, 255, 255, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #F5F5F5.
         /// </summary>
-        public static readonly Color WhiteSmoke = NamedColors<Color>.WhiteSmoke;
+        public static readonly TColor WhiteSmoke = ColorBuilder<TColor>.FromRGBA(245, 245, 245, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #FFFF00.
         /// </summary>
-        public static readonly Color Yellow = NamedColors<Color>.Yellow;
+        public static readonly TColor Yellow = ColorBuilder<TColor>.FromRGBA(255, 255, 0, 255);
 
         /// <summary>
         /// Represents a <see cref="Color"/> matching the W3C definition that has an hex value of #9ACD32.
         /// </summary>
-        public static readonly Color YellowGreen = NamedColors<Color>.YellowGreen;
+        public static readonly TColor YellowGreen = ColorBuilder<TColor>.FromRGBA(154, 205, 50, 255);
     }
 }

--- a/tests/ImageSharp.Tests/Colors/ColorDefinitionTests.cs
+++ b/tests/ImageSharp.Tests/Colors/ColorDefinitionTests.cs
@@ -1,0 +1,38 @@
+﻿// <copyright file="ColorDefinitionTests.cs" company="James Jackson-South">
+// Copyright (c) James Jackson-South and contributors.
+// Licensed under the Apache License, Version 2.0.
+// </copyright>
+
+namespace ImageSharp.Tests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics.CodeAnalysis;
+    using System.Linq;
+    using System.Reflection;
+
+    using ImageSharp.Colors.Spaces;
+    using Xunit;
+    public class ColorDefinitionTests
+    {
+        public static IEnumerable<string[]> ColorNames => typeof(NamedColors<Color>).GetTypeInfo().GetFields().Select(x => new[] { x.Name });
+
+        [Theory]
+        [MemberData(nameof(ColorNames))]
+        public void AllColorsAreOnGenericAndBaseColor(string name)
+        {
+            FieldInfo generic = typeof(NamedColors<Color>).GetTypeInfo().GetField(name);
+            FieldInfo specific = typeof(Color).GetTypeInfo().GetField(name);
+
+            Assert.NotNull(specific);
+            Assert.NotNull(generic);
+            Assert.True(specific.Attributes.HasFlag(FieldAttributes.Public), "specific must be public");
+            Assert.True(specific.Attributes.HasFlag(FieldAttributes.Static), "specific must be static");
+            Assert.True(generic.Attributes.HasFlag(FieldAttributes.Public), "generic must be public");
+            Assert.True(generic.Attributes.HasFlag(FieldAttributes.Static), "generic must be static");
+            Color expected = (Color)generic.GetValue(null);
+            Color actual = (Color)specific.GetValue(null);
+            Assert.Equal(expected, actual);
+        }
+    }
+}

--- a/tests/ImageSharp.Tests/Colors/ColorTests.cs
+++ b/tests/ImageSharp.Tests/Colors/ColorTests.cs
@@ -23,10 +23,10 @@ namespace ImageSharp.Tests
         {
             Color color1 = new Color(0, 0, 0);
             Color color2 = new Color(0, 0, 0, 1F);
-            Color color3 = new Color("#000");
-            Color color4 = new Color("#000F");
-            Color color5 = new Color("#000000");
-            Color color6 = new Color("#000000FF");
+            Color color3 = Color.FromHex("#000");
+            Color color4 = Color.FromHex("#000F");
+            Color color5 = Color.FromHex("#000000");
+            Color color6 = Color.FromHex("#000000FF");
 
             Assert.Equal(color1, color2);
             Assert.Equal(color1, color3);
@@ -43,9 +43,9 @@ namespace ImageSharp.Tests
         {
             Color color1 = new Color(255, 0, 0, 255);
             Color color2 = new Color(0, 0, 0, 255);
-            Color color3 = new Color("#000");
-            Color color4 = new Color("#000000");
-            Color color5 = new Color("#FF000000");
+            Color color3 = Color.FromHex("#000");
+            Color color4 = Color.FromHex("#000000");
+            Color color5 = Color.FromHex("#FF000000");
 
             Assert.NotEqual(color1, color2);
             Assert.NotEqual(color1, color3);
@@ -70,12 +70,6 @@ namespace ImageSharp.Tests
             Assert.Equal(Math.Round(.1f * 255), color2.G);
             Assert.Equal(Math.Round(.133f * 255), color2.B);
             Assert.Equal(255, color2.A);
-
-            Color color3 = new Color("#FF0000");
-            Assert.Equal(255, color3.R);
-            Assert.Equal(0, color3.G);
-            Assert.Equal(0, color3.B);
-            Assert.Equal(255, color3.A);
 
             Color color4 = new Color(new Vector3(1, .1f, .133f));
             Assert.Equal(255, color4.R);

--- a/tests/ImageSharp.Tests/Image/PixelAccessorTests.cs
+++ b/tests/ImageSharp.Tests/Image/PixelAccessorTests.cs
@@ -91,17 +91,12 @@ namespace ImageSharp.Tests
         [WithBlankImages(16, 16, PixelTypes.All, ComponentOrder.Zyxw)]
         public void CopyToThenCopyFromWithOffset<TColor>(TestImageProvider<TColor> provider, ComponentOrder order)
             where TColor : struct, IPackedPixel, IEquatable<TColor>
-
         {
             using (Image<TColor> destImage = new Image<TColor>(8, 8))
             {
-                TColor color;
                 using (Image<TColor> srcImage = provider.GetImage())
                 {
-                    color = default(TColor);
-                    color.PackFromBytes(255, 0, 0, 255);
-
-                    Fill(srcImage, new Rectangle(4, 4, 8, 8), color);
+                    Fill(srcImage, new Rectangle(4, 4, 8, 8), NamedColors<TColor>.Red);
                     using (PixelAccessor<TColor> srcPixels = srcImage.Lock())
                     {
                         using (PixelArea<TColor> area = new PixelArea<TColor>(8, 8, order))
@@ -119,7 +114,7 @@ namespace ImageSharp.Tests
                 provider.Utility.SourceFileOrDescription = order.ToString();
                 provider.Utility.SaveTestOutputFile(destImage, "bmp");
 
-                using (Image<TColor> expectedImage = new Image<TColor>(8, 8).Fill(color))
+                using (Image<TColor> expectedImage = new Image<TColor>(8, 8).Fill(NamedColors<TColor>.Red))
                 {
                     Assert.True(destImage.IsEquivalentTo(expectedImage));
                 }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/JimBobSquarePants/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practise as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
I noticed during the dithering PR that we had usages of the below patter for wellknown colors.
```c#
TColor packed = default(TColor);
packed.PackFromBytes(255, 255, 255, 255);
```
I've added 2 new classes, and fix up all the places that are using the above syntax where I can find them to use the improved syntax.

Additionally fixed up the Glow & Vignette usages to remove the usage of passing a default(TColor) around and then trying to compare to it, it seemed dangerous to me as whatever color default(TColor) actually ends up as could be what you want the glow to be and as it stood you could never use it.

#### `ColorBuild<TColor>`
Provides convenience methods for creating new `TColor`s from RGB byte and Hex strings allowing users to create any color using those mechanisms. 

#### `NamedColors<TColor>`
provides static readonly representations of wellknown colors.


<!-- Thanks for contributing to ImageSharp! -->
