### PR TITLE
Support for VSCode

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,24 @@
+{
+  // See https://go.microsoft.com/fwlink/?LinkId=733558
+  // for the documentation about the tasks.json format
+  "version": "0.1.0",
+  "command": "dotnet",
+  "isShellCommand": true,
+  "args": [],
+  "tasks": [
+    {
+      "taskName": "build",
+      "args": [ "src/*/project.json", "-f", "netstandard1.1" ],
+      "isBuildCommand": true,
+      "showOutput": "always",
+      "problemMatcher": "$msCompile"
+    },
+    {
+      "taskName": "test",
+      "args": ["tests/ImageSharp.Tests/project.json", "-f", "netcoreapp1.1"],
+      "isTestCommand": true,
+      "showOutput": "always",
+      "problemMatcher": "$msCompile"
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -56,6 +56,11 @@ If you prefer, you can compile ImageSharp yourself (please do and help!), you'll
 - [Visual Studio 2015 with Update 3 (or above)](https://www.visualstudio.com/news/releasenotes/vs2015-update3-vs)
 - The [.NET Core 1.0 SDK Installer](https://www.microsoft.com/net/core#windows) - Non VSCode link.
 
+Alternatively on Linux you can use:
+
+- [Visual Studio Code](https://code.visualstudio.com/) with [C# Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.csharp)
+- [.Net Core 1.1](https://www.microsoft.com/net/core#linuxubuntu)
+
 To clone it locally click the "Clone in Windows" button above or run the following git commands.
 
 ```bash


### PR DESCRIPTION
Because I develop on Linux I noticed the library builds, but came without support for the Linux .Net Core IDE. I added two tasks: _build_ and _test_ and linked it to `ctrl + shift + b`.
