### PR TITLE
Standardize to netstandard1.6

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -8,7 +8,7 @@
   "tasks": [
     {
       "taskName": "build",
-      "args": [ "src/*/project.json", "-f", "netstandard1.1" ],
+      "args": [ "src/*/project.json", "-f", "netstandard1.6" ],
       "isBuildCommand": true,
       "showOutput": "always",
       "problemMatcher": "$msCompile"

--- a/src/ImageSharp.Drawing.Paths/project.json
+++ b/src/ImageSharp.Drawing.Paths/project.json
@@ -49,28 +49,28 @@
       "version": "1.0.0",
       "type": "build"
     },
-    "System.Buffers": "4.0.0",
-    "System.Runtime.CompilerServices.Unsafe": "4.0.0"
+    "System.Buffers": "4.3.0",
+    "System.Runtime.CompilerServices.Unsafe": "4.3.0"
   },
   "frameworks": {
-    "netstandard1.1": {
+    "netstandard1.6": {
       "dependencies": {
-        "System.Collections": "4.0.11",
-        "System.Diagnostics.Debug": "4.0.11",
-        "System.Diagnostics.Tools": "4.0.1",
-        "System.IO": "4.1.0",
-        "System.IO.Compression": "4.1.0",
-        "System.Linq": "4.1.0",
-        "System.Numerics.Vectors": "4.1.1",
-        "System.ObjectModel": "4.0.12",
-        "System.Resources.ResourceManager": "4.0.1",
-        "System.Runtime.Extensions": "4.1.0",
-        "System.Runtime.InteropServices": "4.1.0",
-        "System.Runtime.Numerics": "4.0.1",
-        "System.Text.Encoding.Extensions": "4.0.11",
-        "System.Threading": "4.0.11",
-        "System.Threading.Tasks": "4.0.11",
-        "System.Threading.Tasks.Parallel": "4.0.1"
+        "System.Collections": "4.3.0",
+        "System.Diagnostics.Debug": "4.3.0",
+        "System.Diagnostics.Tools": "4.3.0",
+        "System.IO": "4.3.0",
+        "System.IO.Compression": "4.3.0",
+        "System.Linq": "4.3.0",
+        "System.Numerics.Vectors": "4.3.0",
+        "System.ObjectModel": "4.3.0",
+        "System.Resources.ResourceManager": "4.3.0",
+        "System.Runtime.Extensions": "4.3.0",
+        "System.Runtime.InteropServices": "4.3.0",
+        "System.Runtime.Numerics": "4.3.0",
+        "System.Text.Encoding.Extensions": "4.3.0",
+        "System.Threading": "4.3.0",
+        "System.Threading.Tasks": "4.3.0",
+        "System.Threading.Tasks.Parallel": "4.3.0"
       }
     },
     "net45": {

--- a/src/ImageSharp.Drawing/project.json
+++ b/src/ImageSharp.Drawing/project.json
@@ -48,28 +48,28 @@
       "version": "1.0.0",
       "type": "build"
     },
-    "System.Buffers": "4.0.0",
-    "System.Runtime.CompilerServices.Unsafe": "4.0.0"
+    "System.Buffers": "4.3.0",
+    "System.Runtime.CompilerServices.Unsafe": "4.3.0"
   },
   "frameworks": {
-    "netstandard1.1": {
+    "netstandard1.6": {
       "dependencies": {
-        "System.Collections": "4.0.11",
-        "System.Diagnostics.Debug": "4.0.11",
-        "System.Diagnostics.Tools": "4.0.1",
-        "System.IO": "4.1.0",
-        "System.IO.Compression": "4.1.0",
-        "System.Linq": "4.1.0",
-        "System.Numerics.Vectors": "4.1.1",
-        "System.ObjectModel": "4.0.12",
-        "System.Resources.ResourceManager": "4.0.1",
-        "System.Runtime.Extensions": "4.1.0",
-        "System.Runtime.InteropServices": "4.1.0",
-        "System.Runtime.Numerics": "4.0.1",
-        "System.Text.Encoding.Extensions": "4.0.11",
-        "System.Threading": "4.0.11",
-        "System.Threading.Tasks": "4.0.11",
-        "System.Threading.Tasks.Parallel": "4.0.1"
+        "System.Collections": "4.3.0",
+        "System.Diagnostics.Debug": "4.3.0",
+        "System.Diagnostics.Tools": "4.3.0",
+        "System.IO": "4.3.0",
+        "System.IO.Compression": "4.3.0",
+        "System.Linq": "4.3.0",
+        "System.Numerics.Vectors": "4.3.0",
+        "System.ObjectModel": "4.3.0",
+        "System.Resources.ResourceManager": "4.3.0",
+        "System.Runtime.Extensions": "4.3.0",
+        "System.Runtime.InteropServices": "4.3.0",
+        "System.Runtime.Numerics": "4.3.0",
+        "System.Text.Encoding.Extensions": "4.3.0",
+        "System.Threading": "4.3.0",
+        "System.Threading.Tasks": "4.3.0",
+        "System.Threading.Tasks.Parallel": "4.3.0"
       }
     },
     "net45": {

--- a/src/ImageSharp.Formats.Bmp/project.json
+++ b/src/ImageSharp.Formats.Bmp/project.json
@@ -46,28 +46,28 @@
       "version": "1.1.0-beta001",
       "type": "build"
     },
-    "System.Buffers": "4.0.0",
-    "System.Runtime.CompilerServices.Unsafe": "4.0.0"
+    "System.Buffers": "4.3.0",
+    "System.Runtime.CompilerServices.Unsafe": "4.3.0"
   },
   "frameworks": {
-    "netstandard1.1": {
+    "netstandard1.6": {
       "dependencies": {
-        "System.Collections": "4.0.11",
-        "System.Diagnostics.Debug": "4.0.11",
-        "System.Diagnostics.Tools": "4.0.1",
-        "System.IO": "4.1.0",
-        "System.IO.Compression": "4.1.0",
-        "System.Linq": "4.1.0",
-        "System.Numerics.Vectors": "4.1.1",
-        "System.ObjectModel": "4.0.12",
-        "System.Resources.ResourceManager": "4.0.1",
-        "System.Runtime.Extensions": "4.1.0",
-        "System.Runtime.InteropServices": "4.1.0",
-        "System.Runtime.Numerics": "4.0.1",
-        "System.Text.Encoding.Extensions": "4.0.11",
-        "System.Threading": "4.0.11",
-        "System.Threading.Tasks": "4.0.11",
-        "System.Threading.Tasks.Parallel": "4.0.1"
+        "System.Collections": "4.3.0",
+        "System.Diagnostics.Debug": "4.3.0",
+        "System.Diagnostics.Tools": "4.3.0",
+        "System.IO": "4.3.0",
+        "System.IO.Compression": "4.3.0",
+        "System.Linq": "4.3.0",
+        "System.Numerics.Vectors": "4.3.0",
+        "System.ObjectModel": "4.3.0",
+        "System.Resources.ResourceManager": "4.3.0",
+        "System.Runtime.Extensions": "4.3.0",
+        "System.Runtime.InteropServices": "4.3.0",
+        "System.Runtime.Numerics": "4.3.0",
+        "System.Text.Encoding.Extensions": "4.3.0",
+        "System.Threading": "4.3.0",
+        "System.Threading.Tasks": "4.3.0",
+        "System.Threading.Tasks.Parallel": "4.3.0"
       }
     },
     "net45": {

--- a/src/ImageSharp.Formats.Gif/project.json
+++ b/src/ImageSharp.Formats.Gif/project.json
@@ -46,28 +46,28 @@
       "version": "1.1.0-beta001",
       "type": "build"
     },
-    "System.Buffers": "4.0.0",
-    "System.Runtime.CompilerServices.Unsafe": "4.0.0"
+    "System.Buffers": "4.3.0",
+    "System.Runtime.CompilerServices.Unsafe": "4.3.0"
   },
   "frameworks": {
-    "netstandard1.1": {
+    "netstandard1.6": {
       "dependencies": {
-        "System.Collections": "4.0.11",
-        "System.Diagnostics.Debug": "4.0.11",
-        "System.Diagnostics.Tools": "4.0.1",
-        "System.IO": "4.1.0",
-        "System.IO.Compression": "4.1.0",
-        "System.Linq": "4.1.0",
-        "System.Numerics.Vectors": "4.1.1",
-        "System.ObjectModel": "4.0.12",
-        "System.Resources.ResourceManager": "4.0.1",
-        "System.Runtime.Extensions": "4.1.0",
-        "System.Runtime.InteropServices": "4.1.0",
-        "System.Runtime.Numerics": "4.0.1",
-        "System.Text.Encoding.Extensions": "4.0.11",
-        "System.Threading": "4.0.11",
-        "System.Threading.Tasks": "4.0.11",
-        "System.Threading.Tasks.Parallel": "4.0.1"
+        "System.Collections": "4.3.0",
+        "System.Diagnostics.Debug": "4.3.0",
+        "System.Diagnostics.Tools": "4.3.0",
+        "System.IO": "4.3.0",
+        "System.IO.Compression": "4.3.0",
+        "System.Linq": "4.3.0",
+        "System.Numerics.Vectors": "4.3.0",
+        "System.ObjectModel": "4.3.0",
+        "System.Resources.ResourceManager": "4.3.0",
+        "System.Runtime.Extensions": "4.3.0",
+        "System.Runtime.InteropServices": "4.3.0",
+        "System.Runtime.Numerics": "4.3.0",
+        "System.Text.Encoding.Extensions": "4.3.0",
+        "System.Threading": "4.3.0",
+        "System.Threading.Tasks": "4.3.0",
+        "System.Threading.Tasks.Parallel": "4.3.0"
       }
     },
     "net45": {

--- a/src/ImageSharp.Formats.Jpeg/project.json
+++ b/src/ImageSharp.Formats.Jpeg/project.json
@@ -46,28 +46,28 @@
       "version": "1.1.0-beta001",
       "type": "build"
     },
-    "System.Buffers": "4.0.0",
-    "System.Runtime.CompilerServices.Unsafe": "4.0.0"
+    "System.Buffers": "4.3.0",
+    "System.Runtime.CompilerServices.Unsafe": "4.3.0"
   },
   "frameworks": {
-    "netstandard1.1": {
+    "netstandard1.6": {
       "dependencies": {
-        "System.Collections": "4.0.11",
-        "System.Diagnostics.Debug": "4.0.11",
-        "System.Diagnostics.Tools": "4.0.1",
-        "System.IO": "4.1.0",
-        "System.IO.Compression": "4.1.0",
-        "System.Linq": "4.1.0",
-        "System.Numerics.Vectors": "4.1.1",
-        "System.ObjectModel": "4.0.12",
-        "System.Resources.ResourceManager": "4.0.1",
-        "System.Runtime.Extensions": "4.1.0",
-        "System.Runtime.InteropServices": "4.1.0",
-        "System.Runtime.Numerics": "4.0.1",
-        "System.Text.Encoding.Extensions": "4.0.11",
-        "System.Threading": "4.0.11",
-        "System.Threading.Tasks": "4.0.11",
-        "System.Threading.Tasks.Parallel": "4.0.1"
+        "System.Collections": "4.3.0",
+        "System.Diagnostics.Debug": "4.3.0",
+        "System.Diagnostics.Tools": "4.3.0",
+        "System.IO": "4.3.0",
+        "System.IO.Compression": "4.3.0",
+        "System.Linq": "4.3.0",
+        "System.Numerics.Vectors": "4.3.0",
+        "System.ObjectModel": "4.3.0",
+        "System.Resources.ResourceManager": "4.3.0",
+        "System.Runtime.Extensions": "4.3.0",
+        "System.Runtime.InteropServices": "4.3.0",
+        "System.Runtime.Numerics": "4.3.0",
+        "System.Text.Encoding.Extensions": "4.3.0",
+        "System.Threading": "4.3.0",
+        "System.Threading.Tasks": "4.3.0",
+        "System.Threading.Tasks.Parallel": "4.3.0"
       }
     },
     "net45": {

--- a/src/ImageSharp.Formats.Png/project.json
+++ b/src/ImageSharp.Formats.Png/project.json
@@ -46,28 +46,28 @@
       "version": "1.1.0-beta001",
       "type": "build"
     },
-    "System.Buffers": "4.0.0",
-    "System.Runtime.CompilerServices.Unsafe": "4.0.0"
+    "System.Buffers": "4.3.0",
+    "System.Runtime.CompilerServices.Unsafe": "4.3.0"
   },
   "frameworks": {
-    "netstandard1.1": {
+    "netstandard1.6": {
       "dependencies": {
-        "System.Collections": "4.0.11",
-        "System.Diagnostics.Debug": "4.0.11",
-        "System.Diagnostics.Tools": "4.0.1",
-        "System.IO": "4.1.0",
-        "System.IO.Compression": "4.1.0",
-        "System.Linq": "4.1.0",
-        "System.Numerics.Vectors": "4.1.1",
-        "System.ObjectModel": "4.0.12",
-        "System.Resources.ResourceManager": "4.0.1",
-        "System.Runtime.Extensions": "4.1.0",
-        "System.Runtime.InteropServices": "4.1.0",
-        "System.Runtime.Numerics": "4.0.1",
-        "System.Text.Encoding.Extensions": "4.0.11",
-        "System.Threading": "4.0.11",
-        "System.Threading.Tasks": "4.0.11",
-        "System.Threading.Tasks.Parallel": "4.0.1"
+        "System.Collections": "4.3.0",
+        "System.Diagnostics.Debug": "4.3.0",
+        "System.Diagnostics.Tools": "4.3.0",
+        "System.IO": "4.3.0",
+        "System.IO.Compression": "4.3.0",
+        "System.Linq": "4.3.0",
+        "System.Numerics.Vectors": "4.3.0",
+        "System.ObjectModel": "4.3.0",
+        "System.Resources.ResourceManager": "4.3.0",
+        "System.Runtime.Extensions": "4.3.0",
+        "System.Runtime.InteropServices": "4.3.0",
+        "System.Runtime.Numerics": "4.3.0",
+        "System.Text.Encoding.Extensions": "4.3.0",
+        "System.Threading": "4.3.0",
+        "System.Threading.Tasks": "4.3.0",
+        "System.Threading.Tasks.Parallel": "4.3.0"
       }
     },
     "net45": {

--- a/src/ImageSharp.Processing/project.json
+++ b/src/ImageSharp.Processing/project.json
@@ -45,28 +45,28 @@
       "version": "1.1.0-beta001",
       "type": "build"
     },
-    "System.Buffers": "4.0.0",
-    "System.Runtime.CompilerServices.Unsafe": "4.0.0"
+    "System.Buffers": "4.3.0",
+    "System.Runtime.CompilerServices.Unsafe": "4.3.0"
   },
   "frameworks": {
-    "netstandard1.1": {
+    "netstandard1.6": {
       "dependencies": {
-        "System.Collections": "4.0.11",
-        "System.Diagnostics.Debug": "4.0.11",
-        "System.Diagnostics.Tools": "4.0.1",
-        "System.IO": "4.1.0",
-        "System.IO.Compression": "4.1.0",
-        "System.Linq": "4.1.0",
-        "System.Numerics.Vectors": "4.1.1",
-        "System.ObjectModel": "4.0.12",
-        "System.Resources.ResourceManager": "4.0.1",
-        "System.Runtime.Extensions": "4.1.0",
-        "System.Runtime.InteropServices": "4.1.0",
-        "System.Runtime.Numerics": "4.0.1",
-        "System.Text.Encoding.Extensions": "4.0.11",
-        "System.Threading": "4.0.11",
-        "System.Threading.Tasks": "4.0.11",
-        "System.Threading.Tasks.Parallel": "4.0.1"
+        "System.Collections": "4.3.0",
+        "System.Diagnostics.Debug": "4.3.0",
+        "System.Diagnostics.Tools": "4.3.0",
+        "System.IO": "4.3.0",
+        "System.IO.Compression": "4.3.0",
+        "System.Linq": "4.3.0",
+        "System.Numerics.Vectors": "4.3.0",
+        "System.ObjectModel": "4.3.0",
+        "System.Resources.ResourceManager": "4.3.0",
+        "System.Runtime.Extensions": "4.3.0",
+        "System.Runtime.InteropServices": "4.3.0",
+        "System.Runtime.Numerics": "4.3.0",
+        "System.Text.Encoding.Extensions": "4.3.0",
+        "System.Threading": "4.3.0",
+        "System.Threading.Tasks": "4.3.0",
+        "System.Threading.Tasks.Parallel": "4.3.0"
       }
     },
     "net45": {

--- a/src/ImageSharp/project.json
+++ b/src/ImageSharp/project.json
@@ -42,49 +42,29 @@
       "version": "1.1.0-beta001",
       "type": "build"
     },
-    "System.Buffers": "4.0.0",
-    "System.Runtime.CompilerServices.Unsafe": "4.0.0"
+    "System.Buffers": "4.3.0",
+    "System.Runtime.CompilerServices.Unsafe": "4.3.0"
   },
   "frameworks": {
-    "netstandard1.3": {
+    "netstandard1.6": {
       "dependencies": {
-        "System.Collections": "4.0.11",
-        "System.Diagnostics.Debug": "4.0.11",
-        "System.Diagnostics.Tools": "4.0.1",
-        "System.IO": "4.1.0",
-        "System.IO.FileSystem": "4.1.0",
-        "System.IO.Compression": "4.1.0",
-        "System.Linq": "4.1.0",
-        "System.Numerics.Vectors": "4.1.1",
-        "System.ObjectModel": "4.0.12",
-        "System.Resources.ResourceManager": "4.0.1",
-        "System.Runtime.Extensions": "4.1.0",
-        "System.Runtime.InteropServices": "4.1.0",
-        "System.Runtime.Numerics": "4.0.1",
-        "System.Text.Encoding.Extensions": "4.0.11",
-        "System.Threading": "4.0.11",
-        "System.Threading.Tasks": "4.0.11",
-        "System.Threading.Tasks.Parallel": "4.0.1"
-      }
-    },
-    "netstandard1.1": {
-      "dependencies": {
-        "System.Collections": "4.0.11",
-        "System.Diagnostics.Debug": "4.0.11",
-        "System.Diagnostics.Tools": "4.0.1",
-        "System.IO": "4.1.0",
-        "System.IO.Compression": "4.1.0",
-        "System.Linq": "4.1.0",
-        "System.Numerics.Vectors": "4.1.1",
-        "System.ObjectModel": "4.0.12",
-        "System.Resources.ResourceManager": "4.0.1",
-        "System.Runtime.Extensions": "4.1.0",
-        "System.Runtime.InteropServices": "4.1.0",
-        "System.Runtime.Numerics": "4.0.1",
-        "System.Text.Encoding.Extensions": "4.0.11",
-        "System.Threading": "4.0.11",
-        "System.Threading.Tasks": "4.0.11",
-        "System.Threading.Tasks.Parallel": "4.0.1"
+        "System.Collections": "4.3.0",
+        "System.Diagnostics.Debug": "4.3.0",
+        "System.Diagnostics.Tools": "4.3.0",
+        "System.IO": "4.3.0",
+        "System.IO.FileSystem": "4.3.0",
+        "System.IO.Compression": "4.3.0",
+        "System.Linq": "4.3.0",
+        "System.Numerics.Vectors": "4.3.0",
+        "System.ObjectModel": "4.3.0",
+        "System.Resources.ResourceManager": "4.3.0",
+        "System.Runtime.Extensions": "4.3.0",
+        "System.Runtime.InteropServices": "4.3.0",
+        "System.Runtime.Numerics": "4.3.0",
+        "System.Text.Encoding.Extensions": "4.3.0",
+        "System.Threading": "4.3.0",
+        "System.Threading.Tasks": "4.3.0",
+        "System.Threading.Tasks.Parallel": "4.3.0"
       }
     },
     "net45": {

--- a/tests/ImageSharp.Benchmarks/project.json
+++ b/tests/ImageSharp.Benchmarks/project.json
@@ -14,7 +14,7 @@
     "allowUnsafe": true
   },
   "dependencies": {
-    "BenchmarkDotNet.Diagnostics.Windows": "0.10.1",
+    "BenchmarkDotNet.Diagnostics.Windows": "0.10.2",
     "ImageSharp": {
       "target": "project"
     },

--- a/tests/ImageSharp.Tests/project.json
+++ b/tests/ImageSharp.Tests/project.json
@@ -54,7 +54,7 @@
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.0.0-*"
+          "version": "1.1.0-*"
         },
         "Microsoft.CodeCoverage": "1.0.2"
       }

--- a/tests/ImageSharp.Tests/project.json
+++ b/tests/ImageSharp.Tests/project.json
@@ -54,7 +54,7 @@
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.1.0-*"
+          "version": "1.0.0-*"
         },
         "Microsoft.CodeCoverage": "1.0.2"
       }


### PR DESCRIPTION
## Suggestion only
I am not sure if this matches your vision of this library. I figured since it is relatively new and targeted at .Net Core and Cross-Platform Development it makes sense to drop older .NetStandard targets and focus on 1.6 or even better 2.0. [This blog](https://blogs.msdn.microsoft.com/dotnet/2016/09/26/introducing-net-standard/) illustrates the topic a little bit.

I noticed a lot of package downgrades and version inconsistencies using the packages in ASP.Net Core on Linux and thought since you have dedicated targets for the full .Net Frameworks you might be interested in an updated version that seamlessly integrates into ASP.Net Core 1.1

I ran all builds and unit tests on my machine, but am curious what your CI has to say about it.

```sh
$ dotnet --version
1.0.0-preview2-1-003177
```

Created:

```sh
Project ImageSharp (.NETStandard,Version=v1.6) was previously compiled. Skipping compilation.
Project ImageSharp.Processing (.NETStandard,Version=v1.6) was previously compiled. Skipping compilation.
Project ImageSharp.Drawing (.NETStandard,Version=v1.6) was previously compiled. Skipping compilation.
Project ImageSharp.Drawing.Paths (.NETStandard,Version=v1.6) was previously compiled. Skipping compilation.
Project ImageSharp.Formats.Png (.NETStandard,Version=v1.6) was previously compiled. Skipping compilation.
Project ImageSharp.Formats.Jpeg (.NETStandard,Version=v1.6) was previously compiled. Skipping compilation.
Project ImageSharp.Formats.Bmp (.NETStandard,Version=v1.6) was previously compiled. Skipping compilation.
Project ImageSharp.Formats.Gif (.NETStandard,Version=v1.6) was previously compiled. Skipping compilation.
Project ImageSharp.Tests (.NETCoreApp,Version=v1.1) was previously compiled. Skipping compilation.
xUnit.net .NET CLI test runner (64-bit .NET Core ubuntu.16.04-x64)
  Discovering: ImageSharp.Tests
  Discovered:  ImageSharp.Tests
  Starting:    ImageSharp.Tests
  Finished:    ImageSharp.Tests
=== TEST EXECUTION SUMMARY ===
   ImageSharp.Tests  Total: 1585, Errors: 0, Failed: 0, Skipped: 0, Time: 307.683s
```

If this does not match your vision or you dislike it for other reasons, don't hesitate to close this.