### PR TITLE
improve vector/glyph rendering quality using a sub-pixel rendering techinique

### DIFF
--- a/src/ImageSharp.Drawing/Brushes/Brushes{TColor}.cs
+++ b/src/ImageSharp.Drawing/Brushes/Brushes{TColor}.cs
@@ -18,10 +18,9 @@ namespace ImageSharp.Drawing.Brushes
         /// <summary>
         /// Percent10 Hatch Pattern
         /// </summary>
-        /// note 2d arrays when configured using initalizer look inverted
-        /// ---> Y axis
+        /// ---> x axis
         /// ^
-        /// | X - axis
+        /// | y - axis
         /// |
         /// see PatternBrush for details about how to make new patterns work
         private static readonly bool[,] Percent10Pattern =
@@ -37,32 +36,16 @@ namespace ImageSharp.Drawing.Brushes
         /// </summary>
         private static readonly bool[,] Percent20Pattern =
         {
-            { true, false, true, false },
-            { false, false, false, false },
-            { false, true, false, true },
-            { false, false, false, false }
+            { true,  false, false, false },
+            { false, false, true,  false },
+            { true,  false, false, false },
+            { false, false, true,  false }
         };
 
         /// <summary>
         /// Horizontal Hatch Pattern
         /// </summary>
         private static readonly bool[,] HorizontalPattern =
-        {
-            { false, true, false, false },
-        };
-
-        /// <summary>
-        /// Min Pattern
-        /// </summary>
-        private static readonly bool[,] MinPattern =
-        {
-            { false, false, false, true },
-        };
-
-        /// <summary>
-        /// Vertical Pattern
-        /// </summary>
-        private static readonly bool[,] VerticalPattern =
         {
             { false },
             { true },
@@ -71,14 +54,33 @@ namespace ImageSharp.Drawing.Brushes
         };
 
         /// <summary>
+        /// Min Pattern
+        /// </summary>
+        private static readonly bool[,] MinPattern =
+        {
+            { false },
+            { false },
+            { false },
+            { true }
+        };
+
+        /// <summary>
+        /// Vertical Pattern
+        /// </summary>
+        private static readonly bool[,] VerticalPattern =
+        {
+            { false, true, false, false },
+        };
+
+        /// <summary>
         /// Forward Diagonal Pattern
         /// </summary>
         private static readonly bool[,] ForwardDiagonalPattern =
         {
-            { true, false, false, false },
-            { false, true, false, false },
+            { false, false, false, true },
             { false, false, true, false },
-            { false, false, false, true }
+            { false, true, false, false },
+            { true,  false, false, false }
         };
 
         /// <summary>
@@ -86,10 +88,10 @@ namespace ImageSharp.Drawing.Brushes
         /// </summary>
         private static readonly bool[,] BackwardDiagonalPattern =
         {
-            { false, false, false, true },
-            { false, false, true, false },
+            { true, false, false, false },
             { false, true, false, false },
-            { true,  false, false, false }
+            { false, false, true, false },
+            { false, false, false, true }
         };
 
         /// <summary>

--- a/src/ImageSharp.Drawing/Brushes/ImageBrush{TColor}.cs
+++ b/src/ImageSharp.Drawing/Brushes/ImageBrush{TColor}.cs
@@ -116,9 +116,9 @@ namespace ImageSharp.Drawing.Brushes
             {
                 using (PinnedBuffer<float> buffer = new PinnedBuffer<float>(scanline))
                 {
-                    var slice = buffer.Slice(offset);
+                    BufferPointer<float> slice = buffer.Slice(offset);
 
-                    for (var xPos = 0; xPos < scanlineWidth; xPos++)
+                    for (int xPos = 0; xPos < scanlineWidth; xPos++)
                     {
                         int targetX = xPos + x;
                         int targetY = y;

--- a/src/ImageSharp.Drawing/Brushes/ImageBrush{TColor}.cs
+++ b/src/ImageSharp.Drawing/Brushes/ImageBrush{TColor}.cs
@@ -112,9 +112,12 @@ namespace ImageSharp.Drawing.Brushes
                 this.source.Dispose();
             }
 
-            internal override void Apply(float[] scanline, int scanlineWidth, int offset, int x, int y)
+            /// <inheritdoc />
+            internal override void Apply(float[] scanlineBuffer, int scanlineWidth, int offset, int x, int y)
             {
-                using (PinnedBuffer<float> buffer = new PinnedBuffer<float>(scanline))
+                DebugGuard.MustBeGreaterThanOrEqualTo(scanlineBuffer.Length, offset + scanlineWidth, nameof(scanlineWidth));
+
+                using (PinnedBuffer<float> buffer = new PinnedBuffer<float>(scanlineBuffer))
                 {
                     BufferPointer<float> slice = buffer.Slice(offset);
 

--- a/src/ImageSharp.Drawing/Brushes/ImageBrush{TColor}.cs
+++ b/src/ImageSharp.Drawing/Brushes/ImageBrush{TColor}.cs
@@ -34,7 +34,7 @@ namespace ImageSharp.Drawing.Brushes
         /// <inheritdoc />
         public BrushApplicator<TColor> CreateApplicator(PixelAccessor<TColor> sourcePixels, RectangleF region)
         {
-            return new ImageBrushApplicator(this.image, region);
+            return new ImageBrushApplicator(sourcePixels, this.image, region);
         }
 
         /// <summary>
@@ -71,7 +71,11 @@ namespace ImageSharp.Drawing.Brushes
             /// <param name="region">
             /// The region.
             /// </param>
-            public ImageBrushApplicator(IImageBase<TColor> image, RectangleF region)
+            /// <param name="sourcePixels">
+            /// The sourcePixels.
+            /// </param>
+            public ImageBrushApplicator(PixelAccessor<TColor> sourcePixels, IImageBase<TColor> image, RectangleF region)
+                : base(sourcePixels)
             {
                 this.source = image.Lock();
                 this.xLength = image.Width;
@@ -87,7 +91,7 @@ namespace ImageSharp.Drawing.Brushes
             /// <returns>
             /// The color
             /// </returns>
-            public override TColor this[int x, int y]
+            internal override TColor this[int x, int y]
             {
                 get
                 {
@@ -95,10 +99,10 @@ namespace ImageSharp.Drawing.Brushes
 
                     // Offset the requested pixel by the value in the rectangle (the shapes position)
                     point = point - this.offset;
-                    x = (int)point.X % this.xLength;
-                    y = (int)point.Y % this.yLength;
+                    int srcX = (int)point.X % this.xLength;
+                    int srcY = (int)point.Y % this.yLength;
 
-                    return this.source[x, y];
+                    return this.source[srcX, srcY];
                 }
             }
 
@@ -106,6 +110,34 @@ namespace ImageSharp.Drawing.Brushes
             public override void Dispose()
             {
                 this.source.Dispose();
+            }
+
+            internal override void Apply(float[] scanline, int scanlineWidth, int offset, int x, int y)
+            {
+                using (PinnedBuffer<float> buffer = new PinnedBuffer<float>(scanline))
+                {
+                    var slice = buffer.Slice(offset);
+
+                    for (var xPos = 0; xPos < scanlineWidth; xPos++)
+                    {
+                        int targetX = xPos + x;
+                        int targetY = y;
+
+                        float opacity = slice[xPos];
+                        if (opacity > Constants.Epsilon)
+                        {
+                            Vector4 backgroundVector = this.Target[targetX, targetY].ToVector4();
+
+                            Vector4 sourceVector = this[targetX, targetY].ToVector4();
+
+                            Vector4 finalColor = Vector4BlendTransforms.PremultipliedLerp(backgroundVector, sourceVector, opacity);
+
+                            TColor packed = default(TColor);
+                            packed.PackFromVector4(finalColor);
+                            this.Target[targetX, targetY] = packed;
+                        }
+                    }
+                }
             }
         }
     }

--- a/src/ImageSharp.Drawing/Brushes/ImageBrush{TColor}.cs
+++ b/src/ImageSharp.Drawing/Brushes/ImageBrush{TColor}.cs
@@ -115,7 +115,7 @@ namespace ImageSharp.Drawing.Brushes
             /// <inheritdoc />
             internal override void Apply(float[] scanlineBuffer, int scanlineWidth, int offset, int x, int y)
             {
-                DebugGuard.MustBeGreaterThanOrEqualTo(scanlineBuffer.Length, offset + scanlineWidth, nameof(scanlineWidth));
+                Guard.MustBeGreaterThanOrEqualTo(scanlineBuffer.Length, offset + scanlineWidth, nameof(scanlineWidth));
 
                 using (PinnedBuffer<float> buffer = new PinnedBuffer<float>(scanlineBuffer))
                 {

--- a/src/ImageSharp.Drawing/Brushes/PatternBrush{TColor}.cs
+++ b/src/ImageSharp.Drawing/Brushes/PatternBrush{TColor}.cs
@@ -128,8 +128,8 @@ namespace ImageSharp.Drawing.Brushes
             {
                 get
                 {
-                    x = x % this.pattern.Height;
-                    y = y % this.pattern.Width;
+                    x = x % this.pattern.Width;
+                    y = y % this.pattern.Height;
 
                     return this.pattern[x, y];
                 }

--- a/src/ImageSharp.Drawing/Brushes/PatternBrush{TColor}.cs
+++ b/src/ImageSharp.Drawing/Brushes/PatternBrush{TColor}.cs
@@ -30,15 +30,6 @@ namespace ImageSharp.Drawing.Brushes
     ///  0
     ///  0
     /// </para>
-    /// Warning when use array initializer across multiple lines the bools look inverted i.e.
-    /// new bool[,]{
-    ///     {true, false, false},
-    ///     {false,true, false}
-    /// }
-    /// would be
-    /// 10
-    /// 01
-    /// 00
     /// </remarks>
     /// <typeparam name="TColor">The pixel format.</typeparam>
     public class PatternBrush<TColor> : IBrush<TColor>
@@ -56,7 +47,18 @@ namespace ImageSharp.Drawing.Brushes
         /// <param name="foreColor">Color of the fore.</param>
         /// <param name="backColor">Color of the back.</param>
         /// <param name="pattern">The pattern.</param>
-        public PatternBrush(TColor foreColor, TColor backColor, Fast2DArray<bool> pattern)
+        public PatternBrush(TColor foreColor, TColor backColor, bool[,] pattern)
+            : this(foreColor, backColor, new Fast2DArray<bool>(pattern))
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PatternBrush{TColor}"/> class.
+        /// </summary>
+        /// <param name="foreColor">Color of the fore.</param>
+        /// <param name="backColor">Color of the back.</param>
+        /// <param name="pattern">The pattern.</param>
+        internal PatternBrush(TColor foreColor, TColor backColor, Fast2DArray<bool> pattern)
         {
             Vector4 foreColorVector = foreColor.ToVector4();
             Vector4 backColorVector = backColor.ToVector4();
@@ -131,7 +133,8 @@ namespace ImageSharp.Drawing.Brushes
                     x = x % this.pattern.Width;
                     y = y % this.pattern.Height;
 
-                    return this.pattern[x, y];
+                    // 2d array index at row/column
+                    return this.pattern[y, x];
                 }
             }
 
@@ -156,7 +159,9 @@ namespace ImageSharp.Drawing.Brushes
                         if (opacity > Constants.Epsilon)
                         {
                             Vector4 backgroundVector = this.Target[targetX, targetY].ToVector4();
-                            Vector4 sourceVector = this.patternVector[targetX % this.pattern.Height, targetX % this.pattern.Width];
+
+                            // 2d array index at row/column
+                            Vector4 sourceVector = this.patternVector[targetY % this.pattern.Height, targetX % this.pattern.Width];
 
                             Vector4 finalColor = Vector4BlendTransforms.PremultipliedLerp(backgroundVector, sourceVector, opacity);
 

--- a/src/ImageSharp.Drawing/Brushes/PatternBrush{TColor}.cs
+++ b/src/ImageSharp.Drawing/Brushes/PatternBrush{TColor}.cs
@@ -148,9 +148,9 @@ namespace ImageSharp.Drawing.Brushes
             {
                 using (PinnedBuffer<float> buffer = new PinnedBuffer<float>(scanline))
                 {
-                    var slice = buffer.Slice(offset);
+                    BufferPointer<float> slice = buffer.Slice(offset);
 
-                    for (var xPos = 0; xPos < scanlineWidth; xPos++)
+                    for (int xPos = 0; xPos < scanlineWidth; xPos++)
                     {
                         int targetX = xPos + x;
                         int targetY = y;

--- a/src/ImageSharp.Drawing/Brushes/PatternBrush{TColor}.cs
+++ b/src/ImageSharp.Drawing/Brushes/PatternBrush{TColor}.cs
@@ -144,9 +144,12 @@ namespace ImageSharp.Drawing.Brushes
                 // noop
             }
 
-            internal override void Apply(float[] scanline, int scanlineWidth, int offset, int x, int y)
+            /// <inheritdoc />
+            internal override void Apply(float[] scanlineBuffer, int scanlineWidth, int offset, int x, int y)
             {
-                using (PinnedBuffer<float> buffer = new PinnedBuffer<float>(scanline))
+                DebugGuard.MustBeGreaterThanOrEqualTo(scanlineBuffer.Length, offset + scanlineWidth, nameof(scanlineWidth));
+
+                using (PinnedBuffer<float> buffer = new PinnedBuffer<float>(scanlineBuffer))
                 {
                     BufferPointer<float> slice = buffer.Slice(offset);
 

--- a/src/ImageSharp.Drawing/Brushes/PatternBrush{TColor}.cs
+++ b/src/ImageSharp.Drawing/Brushes/PatternBrush{TColor}.cs
@@ -86,6 +86,7 @@ namespace ImageSharp.Drawing.Brushes
         internal PatternBrush(PatternBrush<TColor> brush)
         {
             this.pattern = brush.pattern;
+            this.patternVector = brush.patternVector;
         }
 
         /// <inheritdoc />
@@ -112,7 +113,7 @@ namespace ImageSharp.Drawing.Brushes
             /// <param name="pattern">The pattern.</param>
             /// <param name="patternVector">The patternVector.</param>
             public PatternBrushApplicator(PixelAccessor<TColor> sourcePixels, Fast2DArray<TColor> pattern, Fast2DArray<Vector4> patternVector)
-            : base(sourcePixels)
+                : base(sourcePixels)
             {
                 this.pattern = pattern;
                 this.patternVector = patternVector;
@@ -147,7 +148,7 @@ namespace ImageSharp.Drawing.Brushes
             /// <inheritdoc />
             internal override void Apply(float[] scanlineBuffer, int scanlineWidth, int offset, int x, int y)
             {
-                DebugGuard.MustBeGreaterThanOrEqualTo(scanlineBuffer.Length, offset + scanlineWidth, nameof(scanlineWidth));
+                Guard.MustBeGreaterThanOrEqualTo(scanlineBuffer.Length, offset + scanlineWidth, nameof(scanlineWidth));
 
                 using (PinnedBuffer<float> buffer = new PinnedBuffer<float>(scanlineBuffer))
                 {
@@ -164,7 +165,7 @@ namespace ImageSharp.Drawing.Brushes
                             Vector4 backgroundVector = this.Target[targetX, targetY].ToVector4();
 
                             // 2d array index at row/column
-                            Vector4 sourceVector = this.patternVector[targetY % this.pattern.Height, targetX % this.pattern.Width];
+                            Vector4 sourceVector = this.patternVector[targetY % this.patternVector.Height, targetX % this.patternVector.Width];
 
                             Vector4 finalColor = Vector4BlendTransforms.PremultipliedLerp(backgroundVector, sourceVector, opacity);
 

--- a/src/ImageSharp.Drawing/Brushes/Processors/BrushApplicator.cs
+++ b/src/ImageSharp.Drawing/Brushes/Processors/BrushApplicator.cs
@@ -54,9 +54,9 @@ namespace ImageSharp.Drawing.Processors
         {
             using (PinnedBuffer<float> buffer = new PinnedBuffer<float>(scanline))
             {
-                var slice = buffer.Slice(offset);
+                BufferPointer<float> slice = buffer.Slice(offset);
 
-                for (var xPos = 0; xPos < scanlineWidth; xPos++)
+                for (int xPos = 0; xPos < scanlineWidth; xPos++)
                 {
                     int targetX = xPos + x;
                     int targetY = y;

--- a/src/ImageSharp.Drawing/Brushes/Processors/BrushApplicator.cs
+++ b/src/ImageSharp.Drawing/Brushes/Processors/BrushApplicator.cs
@@ -7,6 +7,7 @@ namespace ImageSharp.Drawing.Processors
 {
     using System;
     using System.Numerics;
+    using System.Runtime.CompilerServices;
 
     /// <summary>
     /// primitive that converts a point in to a color for discovering the fill color based on an implementation
@@ -17,14 +18,64 @@ namespace ImageSharp.Drawing.Processors
         where TColor : struct, IPixel<TColor>
     {
         /// <summary>
+        /// Initializes a new instance of the <see cref="BrushApplicator{TColor}"/> class.
+        /// </summary>
+        /// <param name="target">The target.</param>
+        internal BrushApplicator(PixelAccessor<TColor> target)
+        {
+            this.Target = target;
+        }
+
+        /// <summary>
+        /// The destinaion
+        /// </summary>
+        protected PixelAccessor<TColor> Target { get; }
+
+        /// <summary>
         /// Gets the color for a single pixel.
         /// </summary>
         /// <param name="x">The x cordinate.</param>
         /// <param name="y">The y cordinate.</param>
         /// <returns>The a <typeparamref name="TColor"/> that should be applied to the pixel.</returns>
-        public abstract TColor this[int x, int y] { get; }
+        internal abstract TColor this[int x, int y] { get; }
 
         /// <inheritdoc/>
         public abstract void Dispose();
+
+        /// <summary>
+        /// Applies the opactiy weighting for each pixel in a scanline to the target based on the pattern contained in the brush.
+        /// </summary>
+        /// <param name="scanline">The a collection of opacity values between 0 and 1 to be merged with the burshed color value before being applied to the target.</param>
+        /// <param name="scanlineWidth">The number of pixels effected by this scanline.</param>
+        /// <param name="offset">The offset fromthe begining of <paramref name="scanline" /> the opacity data starts.</param>
+        /// <param name="x">The x position in the target pixel space that the start of the scanline data corresponds to.</param>
+        /// <param name="y">The y position in  the target pixel space that whole scanline corresponds to.</param>
+        internal virtual void Apply(float[] scanline, int scanlineWidth, int offset, int x, int y)
+        {
+            using (PinnedBuffer<float> buffer = new PinnedBuffer<float>(scanline))
+            {
+                var slice = buffer.Slice(offset);
+
+                for (var xPos = 0; xPos < scanlineWidth; xPos++)
+                {
+                    int targetX = xPos + x;
+                    int targetY = y;
+
+                    float opacity = slice[xPos];
+                    if (opacity > Constants.Epsilon)
+                    {
+                        Vector4 backgroundVector = this.Target[targetX, targetY].ToVector4();
+
+                        Vector4 sourceVector = this[targetX, targetY].ToVector4();
+
+                        Vector4 finalColor = Vector4BlendTransforms.PremultipliedLerp(backgroundVector, sourceVector, opacity);
+
+                        TColor packed = default(TColor);
+                        packed.PackFromVector4(finalColor);
+                        this.Target[targetX, targetY] = packed;
+                    }
+                }
+            }
+        }
     }
 }

--- a/src/ImageSharp.Drawing/Brushes/Processors/BrushApplicator.cs
+++ b/src/ImageSharp.Drawing/Brushes/Processors/BrushApplicator.cs
@@ -47,7 +47,7 @@ namespace ImageSharp.Drawing.Processors
         /// </summary>
         /// <param name="scanlineBuffer">The a collection of opacity values between 0 and 1 to be merged with the brushed color value before being applied to the target.</param>
         /// <param name="scanlineWidth">The number of pixels effected by this scanline.</param>
-        /// <param name="offset">The offset fromthe begining of <paramref name="scanline" /> the opacity data starts.</param>
+        /// <param name="offset">The offset fromthe begining of <paramref name="scanlineBuffer" /> the opacity data starts.</param>
         /// <param name="x">The x position in the target pixel space that the start of the scanline data corresponds to.</param>
         /// <param name="y">The y position in  the target pixel space that whole scanline corresponds to.</param>
         /// <remarks>scanlineBuffer will be > scanlineWidth but provide and offset in case we want to share a larger buffer across runs.</remarks>

--- a/src/ImageSharp.Drawing/Brushes/Processors/BrushApplicator.cs
+++ b/src/ImageSharp.Drawing/Brushes/Processors/BrushApplicator.cs
@@ -27,7 +27,7 @@ namespace ImageSharp.Drawing.Processors
         }
 
         /// <summary>
-        /// The destinaion
+        /// Gets the destinaion
         /// </summary>
         protected PixelAccessor<TColor> Target { get; }
 

--- a/src/ImageSharp.Drawing/Brushes/Processors/BrushApplicator.cs
+++ b/src/ImageSharp.Drawing/Brushes/Processors/BrushApplicator.cs
@@ -45,14 +45,17 @@ namespace ImageSharp.Drawing.Processors
         /// <summary>
         /// Applies the opactiy weighting for each pixel in a scanline to the target based on the pattern contained in the brush.
         /// </summary>
-        /// <param name="scanline">The a collection of opacity values between 0 and 1 to be merged with the burshed color value before being applied to the target.</param>
+        /// <param name="scanlineBuffer">The a collection of opacity values between 0 and 1 to be merged with the brushed color value before being applied to the target.</param>
         /// <param name="scanlineWidth">The number of pixels effected by this scanline.</param>
         /// <param name="offset">The offset fromthe begining of <paramref name="scanline" /> the opacity data starts.</param>
         /// <param name="x">The x position in the target pixel space that the start of the scanline data corresponds to.</param>
         /// <param name="y">The y position in  the target pixel space that whole scanline corresponds to.</param>
-        internal virtual void Apply(float[] scanline, int scanlineWidth, int offset, int x, int y)
+        /// <remarks>scanlineBuffer will be > scanlineWidth but provide and offset in case we want to share a larger buffer across runs.</remarks>
+        internal virtual void Apply(float[] scanlineBuffer, int scanlineWidth, int offset, int x, int y)
         {
-            using (PinnedBuffer<float> buffer = new PinnedBuffer<float>(scanline))
+            DebugGuard.MustBeGreaterThanOrEqualTo(scanlineBuffer.Length, offset + scanlineWidth, nameof(scanlineWidth));
+
+            using (PinnedBuffer<float> buffer = new PinnedBuffer<float>(scanlineBuffer))
             {
                 BufferPointer<float> slice = buffer.Slice(offset);
 

--- a/src/ImageSharp.Drawing/Brushes/RecolorBrush{TColor}.cs
+++ b/src/ImageSharp.Drawing/Brushes/RecolorBrush{TColor}.cs
@@ -136,9 +136,12 @@ namespace ImageSharp.Drawing.Brushes
             {
             }
 
-            internal override void Apply(float[] scanline, int scanlineWidth, int offset, int x, int y)
+            /// <inheritdoc />
+            internal override void Apply(float[] scanlineBuffer, int scanlineWidth, int offset, int x, int y)
             {
-                using (PinnedBuffer<float> buffer = new PinnedBuffer<float>(scanline))
+                DebugGuard.MustBeGreaterThanOrEqualTo(scanlineBuffer.Length, offset + scanlineWidth, nameof(scanlineWidth));
+
+                using (PinnedBuffer<float> buffer = new PinnedBuffer<float>(scanlineBuffer))
                 {
                     BufferPointer<float> slice = buffer.Slice(offset);
 

--- a/src/ImageSharp.Drawing/Brushes/RecolorBrush{TColor}.cs
+++ b/src/ImageSharp.Drawing/Brushes/RecolorBrush{TColor}.cs
@@ -139,7 +139,7 @@ namespace ImageSharp.Drawing.Brushes
             /// <inheritdoc />
             internal override void Apply(float[] scanlineBuffer, int scanlineWidth, int offset, int x, int y)
             {
-                DebugGuard.MustBeGreaterThanOrEqualTo(scanlineBuffer.Length, offset + scanlineWidth, nameof(scanlineWidth));
+                Guard.MustBeGreaterThanOrEqualTo(scanlineBuffer.Length, offset + scanlineWidth, nameof(scanlineWidth));
 
                 using (PinnedBuffer<float> buffer = new PinnedBuffer<float>(scanlineBuffer))
                 {

--- a/src/ImageSharp.Drawing/Brushes/RecolorBrush{TColor}.cs
+++ b/src/ImageSharp.Drawing/Brushes/RecolorBrush{TColor}.cs
@@ -140,9 +140,9 @@ namespace ImageSharp.Drawing.Brushes
             {
                 using (PinnedBuffer<float> buffer = new PinnedBuffer<float>(scanline))
                 {
-                    var slice = buffer.Slice(offset);
+                    BufferPointer<float> slice = buffer.Slice(offset);
 
-                    for (var xPos = 0; xPos < scanlineWidth; xPos++)
+                    for (int xPos = 0; xPos < scanlineWidth; xPos++)
                     {
                         int targetX = xPos + x;
                         int targetY = y;

--- a/src/ImageSharp.Drawing/Brushes/SolidBrush{TColor}.cs
+++ b/src/ImageSharp.Drawing/Brushes/SolidBrush{TColor}.cs
@@ -84,9 +84,12 @@ namespace ImageSharp.Drawing.Brushes
                 // noop
             }
 
-            internal override void Apply(float[] scanline, int scanlineWidth, int offset, int x, int y)
+            /// <inheritdoc />
+            internal override void Apply(float[] scanlineBuffer, int scanlineWidth, int offset, int x, int y)
             {
-                using (PinnedBuffer<float> buffer = new PinnedBuffer<float>(scanline))
+                DebugGuard.MustBeGreaterThanOrEqualTo(scanlineBuffer.Length, offset + scanlineWidth, nameof(scanlineWidth));
+
+                using (PinnedBuffer<float> buffer = new PinnedBuffer<float>(scanlineBuffer))
                 {
                     BufferPointer<float> slice = buffer.Slice(offset);
 

--- a/src/ImageSharp.Drawing/Brushes/SolidBrush{TColor}.cs
+++ b/src/ImageSharp.Drawing/Brushes/SolidBrush{TColor}.cs
@@ -87,7 +87,7 @@ namespace ImageSharp.Drawing.Brushes
             /// <inheritdoc />
             internal override void Apply(float[] scanlineBuffer, int scanlineWidth, int offset, int x, int y)
             {
-                DebugGuard.MustBeGreaterThanOrEqualTo(scanlineBuffer.Length, offset + scanlineWidth, nameof(scanlineWidth));
+                Guard.MustBeGreaterThanOrEqualTo(scanlineBuffer.Length, offset + scanlineWidth, nameof(scanlineWidth));
 
                 using (PinnedBuffer<float> buffer = new PinnedBuffer<float>(scanlineBuffer))
                 {

--- a/src/ImageSharp.Drawing/Brushes/SolidBrush{TColor}.cs
+++ b/src/ImageSharp.Drawing/Brushes/SolidBrush{TColor}.cs
@@ -88,9 +88,9 @@ namespace ImageSharp.Drawing.Brushes
             {
                 using (PinnedBuffer<float> buffer = new PinnedBuffer<float>(scanline))
                 {
-                    var slice = buffer.Slice(offset);
+                    BufferPointer<float> slice = buffer.Slice(offset);
 
-                    for (var xPos = 0; xPos < scanlineWidth; xPos++)
+                    for (int xPos = 0; xPos < scanlineWidth; xPos++)
                     {
                         int targetX = xPos + x;
                         int targetY = y;

--- a/src/ImageSharp.Drawing/GraphicsOptions.cs
+++ b/src/ImageSharp.Drawing/GraphicsOptions.cs
@@ -21,12 +21,18 @@ namespace ImageSharp.Drawing
         public bool Antialias;
 
         /// <summary>
+        /// The number of subpixels to use while rendering with antialiasing enabled.
+        /// </summary>
+        public int AntialiasSubpixelDepth;
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="GraphicsOptions"/> struct.
         /// </summary>
         /// <param name="enableAntialiasing">If set to <c>true</c> [enable antialiasing].</param>
         public GraphicsOptions(bool enableAntialiasing)
         {
             this.Antialias = enableAntialiasing;
+            this.AntialiasSubpixelDepth = 16;
         }
     }
 }

--- a/src/ImageSharp.Drawing/ImageSharp.Drawing.csproj
+++ b/src/ImageSharp.Drawing/ImageSharp.Drawing.csproj
@@ -40,7 +40,7 @@
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="SixLabors.Fonts" Version="0.1.0-alpha0002" />
-    <PackageReference Include="SixLabors.Shapes" Version="0.1.0-alpha0008" />
+    <PackageReference Include="SixLabors.Shapes" Version="0.1.0-alpha0009" />
   </ItemGroup>
   <PropertyGroup>
     <CodeAnalysisRuleSet>..\..\ImageSharp.ruleset</CodeAnalysisRuleSet>

--- a/src/ImageSharp.Drawing/Paths/ShapeRegion.cs
+++ b/src/ImageSharp.Drawing/Paths/ShapeRegion.cs
@@ -5,6 +5,7 @@
 
 namespace ImageSharp.Drawing
 {
+    using System;
     using System.Buffers;
     using System.Numerics;
 
@@ -39,7 +40,7 @@ namespace ImageSharp.Drawing
         public override Rectangle Bounds { get; }
 
         /// <inheritdoc/>
-        public override int ScanX(int x, float[] buffer, int length, int offset)
+        public override int ScanX(float x, float[] buffer, int length, int offset)
         {
             Vector2 start = new Vector2(x, this.Bounds.Top - 1);
             Vector2 end = new Vector2(x, this.Bounds.Bottom + 1);
@@ -62,7 +63,7 @@ namespace ImageSharp.Drawing
         }
 
         /// <inheritdoc/>
-        public override int ScanY(int y, float[] buffer, int length, int offset)
+        public override int ScanY(float y, float[] buffer, int length, int offset)
         {
             Vector2 start = new Vector2(this.Bounds.Left - 1, y);
             Vector2 end = new Vector2(this.Bounds.Right + 1, y);

--- a/src/ImageSharp.Drawing/Paths/ShapeRegion.cs
+++ b/src/ImageSharp.Drawing/Paths/ShapeRegion.cs
@@ -40,30 +40,7 @@ namespace ImageSharp.Drawing
         public override Rectangle Bounds { get; }
 
         /// <inheritdoc/>
-        public override int ScanX(float x, float[] buffer, int length, int offset)
-        {
-            Vector2 start = new Vector2(x, this.Bounds.Top - 1);
-            Vector2 end = new Vector2(x, this.Bounds.Bottom + 1);
-            Vector2[] innerbuffer = ArrayPool<Vector2>.Shared.Rent(length);
-            try
-            {
-                int count = this.Shape.FindIntersections(start, end, innerbuffer, length, 0);
-
-                for (int i = 0; i < count; i++)
-                {
-                    buffer[i + offset] = innerbuffer[i].Y;
-                }
-
-                return count;
-            }
-            finally
-            {
-                ArrayPool<Vector2>.Shared.Return(innerbuffer);
-            }
-        }
-
-        /// <inheritdoc/>
-        public override int ScanY(float y, float[] buffer, int length, int offset)
+        public override int Scan(float y, float[] buffer, int length, int offset)
         {
             Vector2 start = new Vector2(this.Bounds.Left - 1, y);
             Vector2 end = new Vector2(this.Bounds.Right + 1, y);

--- a/src/ImageSharp.Drawing/Processors/FillRegionProcessor.cs
+++ b/src/ImageSharp.Drawing/Processors/FillRegionProcessor.cs
@@ -57,315 +57,116 @@ namespace ImageSharp.Drawing.Processors
         /// <inheritdoc/>
         protected override void OnApply(ImageBase<TColor> source, Rectangle sourceRectangle)
         {
-            Rectangle rect = this.Region.Bounds;
-
-            int polyStartY = sourceRectangle.Y - DrawPadding;
-            int polyEndY = sourceRectangle.Bottom + DrawPadding;
-            int startX = sourceRectangle.X - DrawPadding;
-            int endX = sourceRectangle.Right + DrawPadding;
-
-            int minX = Math.Max(sourceRectangle.Left, startX);
-            int maxX = Math.Min(sourceRectangle.Right - 1, endX);
-            int minY = Math.Max(sourceRectangle.Top, polyStartY);
-            int maxY = Math.Min(sourceRectangle.Bottom - 1, polyEndY);
+            Region region = this.Region;
+            Rectangle rect = region.Bounds;
 
             // Align start/end positions.
-            minX = Math.Max(0, minX);
-            maxX = Math.Min(source.Width, maxX);
-            minY = Math.Max(0, minY);
-            maxY = Math.Min(source.Height, maxY);
+            int minX = Math.Max(0, rect.Left);
+            int maxX = Math.Min(source.Width, rect.Right);
+            int minY = Math.Max(0, rect.Top);
+            int maxY = Math.Min(source.Height, rect.Bottom);
 
             ArrayPool<float> arrayPool = ArrayPool<float>.Shared;
 
-            int maxIntersections = this.Region.MaxIntersections;
+            int maxIntersections = region.MaxIntersections;
+            float subpixelCount = 4;
+            if (this.Options.Antialias)
+            {
+                subpixelCount = this.Options.AntialiasSubpixelDepth;
+                if (subpixelCount < 4)
+                {
+                    subpixelCount = 4;
+                }
+            }
 
             using (PixelAccessor<TColor> sourcePixels = source.Lock())
             using (BrushApplicator<TColor> applicator = this.Brush.CreateApplicator(sourcePixels, rect))
             {
-                Parallel.For(
-                minY,
-                maxY,
-                this.ParallelOptions,
-                (int y) =>
+                float[] buffer = arrayPool.Rent(maxIntersections);
+                int scanlineWidth = maxX - minX;
+                float[] scanline = ArrayPool<float>.Shared.Rent(scanlineWidth);
+                try
                 {
-                    float[] buffer = arrayPool.Rent(maxIntersections);
-
-                    try
+                    bool scanlineDirty = true;
+                    for (var y = minY; y < maxY; y++)
                     {
-                        float right = endX;
-
-                        // foreach line we get all the points where this line crosses the polygon
-                        int pointsFound = this.Region.ScanY(y, buffer, maxIntersections, 0);
-                        if (pointsFound == 0)
+                        if (scanlineDirty)
                         {
-                            // nothing on this line skip
-                            return;
+                            // clear the buffer
+                            for (int x = 0; x < scanlineWidth; x++)
+                            {
+                                scanline[x] = 0;
+                            }
+
+                            scanlineDirty = false;
                         }
 
-                        QuickSort(buffer, pointsFound);
-
-                        int currentIntersection = 0;
-                        float nextPoint = buffer[0];
-                        float lastPoint = float.MinValue;
-                        bool isInside = false;
-
-                        for (int x = minX; x < maxX; x++)
+                        float subpixelFraction = 1f / subpixelCount;
+                        float subpixelFractionPoint = subpixelFraction / subpixelCount;
+                        for (float subPixel = (float)y; subPixel < y + 1; subPixel += subpixelFraction)
                         {
-                            if (!isInside)
-                            {
-                                if (x < (nextPoint - DrawPadding) && x > (lastPoint + DrawPadding))
-                                {
-                                    if (nextPoint == right)
-                                    {
-                                        // we are in the ends run skip it
-                                        x = maxX;
-                                        continue;
-                                    }
-
-                                    // lets just jump forward
-                                    x = (int)Math.Floor(nextPoint) - DrawPadding;
-                                }
-                            }
-
-                            bool onCorner = false;
-
-                            // there seems to be some issue with this switch.
-                            if (x >= nextPoint)
-                            {
-                                currentIntersection++;
-                                lastPoint = nextPoint;
-                                if (currentIntersection == pointsFound)
-                                {
-                                    nextPoint = right;
-                                }
-                                else
-                                {
-                                    nextPoint = buffer[currentIntersection];
-
-                                    // double point from a corner flip the bit back and move on again
-                                    if (nextPoint == lastPoint)
-                                    {
-                                        onCorner = true;
-                                        isInside ^= true;
-                                        currentIntersection++;
-                                        if (currentIntersection == pointsFound)
-                                        {
-                                            nextPoint = right;
-                                        }
-                                        else
-                                        {
-                                            nextPoint = buffer[currentIntersection];
-                                        }
-                                    }
-                                }
-
-                                isInside ^= true;
-                            }
-
-                            float opacity = 1;
-                            if (!isInside && !onCorner)
-                            {
-                                if (this.Options.Antialias)
-                                {
-                                    float distance = float.MaxValue;
-                                    if (x == lastPoint || x == nextPoint)
-                                    {
-                                        // we are to far away from the line
-                                        distance = 0;
-                                    }
-                                    else if (nextPoint - AntialiasFactor < x)
-                                    {
-                                        // we are near the left of the line
-                                        distance = nextPoint - x;
-                                    }
-                                    else if (lastPoint + AntialiasFactor > x)
-                                    {
-                                        // we are near the right of the line
-                                        distance = x - lastPoint;
-                                    }
-                                    else
-                                    {
-                                        // we are to far away from the line
-                                        continue;
-                                    }
-                                    opacity = 1 - (distance / AntialiasFactor);
-                                }
-                                else
-                                {
-                                    continue;
-                                }
-                            }
-
-                            if (opacity > Constants.Epsilon)
-                            {
-                                Vector4 backgroundVector = sourcePixels[x, y].ToVector4();
-                                Vector4 sourceVector = applicator[x, y].ToVector4();
-
-                                Vector4 finalColor = Vector4BlendTransforms.PremultipliedLerp(backgroundVector, sourceVector, opacity);
-
-                                TColor packed = default(TColor);
-                                packed.PackFromVector4(finalColor);
-                                sourcePixels[x, y] = packed;
-                            }
-                        }
-                    }
-                    finally
-                    {
-                        arrayPool.Return(buffer);
-                    }
-                });
-
-                if (this.Options.Antialias)
-                {
-                    // we only need to do the X can for antialiasing purposes
-                    Parallel.For(
-                    minX,
-                    maxX,
-                    this.ParallelOptions,
-                    (int x) =>
-                    {
-                        float[] buffer = arrayPool.Rent(maxIntersections);
-
-                        try
-                        {
-                            float left = polyStartY;
-                            float right = polyEndY;
-
-                            // foreach line we get all the points where this line crosses the polygon
-                            int pointsFound = this.Region.ScanX(x, buffer, maxIntersections, 0);
+                            int pointsFound = region.ScanY(subPixel, buffer, maxIntersections, 0);
                             if (pointsFound == 0)
                             {
-                                // nothign on this line skip
-                                return;
+                                // nothing on this line skip
+                                continue;
                             }
 
                             QuickSort(buffer, pointsFound);
 
-                            int currentIntersection = 0;
-                            float nextPoint = buffer[0];
-                            float lastPoint = left;
-                            bool isInside = false;
-
-                            for (int y = minY; y < maxY; y++)
+                            for (int point = 0; point < pointsFound; point += 2)
                             {
-                                if (!isInside)
-                                {
-                                    if (y < (nextPoint - DrawPadding) && y > (lastPoint + DrawPadding))
-                                    {
-                                        if (nextPoint == right)
-                                        {
-                                            // we are in the ends run skip it
-                                            y = maxY;
-                                            continue;
-                                        }
+                                // points will be paired up
+                                float scanStart = buffer[point] - minX;
+                                float scanEnd = buffer[point + 1] - minX;
+                                int startX = (int)Math.Floor(scanStart);
+                                int endX = (int)Math.Floor(scanEnd);
 
-                                        // lets just jump forward
-                                        y = (int)Math.Floor(nextPoint) - DrawPadding;
-                                    }
-                                }
-                                else
+                                for (float x = scanStart; x < startX + 1; x += subpixelFraction)
                                 {
-                                    if (y < nextPoint - DrawPadding)
-                                    {
-                                        if (nextPoint == right)
-                                        {
-                                            // we are in the ends run skip it
-                                            y = maxY;
-                                            continue;
-                                        }
-
-                                        // lets just jump forward
-                                        y = (int)Math.Floor(nextPoint);
-                                    }
+                                    scanline[startX] += subpixelFractionPoint;
+                                    scanlineDirty = true;
                                 }
 
-                                bool onCorner = false;
-
-                                if (y >= nextPoint)
+                                for (float x = endX; x < scanEnd; x += subpixelFraction)
                                 {
-                                    currentIntersection++;
-                                    lastPoint = nextPoint;
-                                    if (currentIntersection == pointsFound)
-                                    {
-                                        nextPoint = right;
-                                    }
-                                    else
-                                    {
-                                        nextPoint = buffer[currentIntersection];
-
-                                        // double point from a corner flip the bit back and move on again
-                                        if (nextPoint == lastPoint)
-                                        {
-                                            onCorner = true;
-                                            isInside ^= true;
-                                            currentIntersection++;
-                                            if (currentIntersection == pointsFound)
-                                            {
-                                                nextPoint = right;
-                                            }
-                                            else
-                                            {
-                                                nextPoint = buffer[currentIntersection];
-                                            }
-                                        }
-                                    }
-
-                                    isInside ^= true;
+                                    scanline[endX] += subpixelFractionPoint;
+                                    scanlineDirty = true;
                                 }
 
-                                float opacity = 1;
-                                if (!isInside && !onCorner)
+                                for (int x = startX + 1; x < endX; x++)
                                 {
-                                    if (this.Options.Antialias)
-                                    {
-                                        float distance = float.MaxValue;
-                                        if (y == lastPoint || y == nextPoint)
-                                        {
-                                            // we are to far away from the line
-                                            distance = 0;
-                                        }
-                                        else if (nextPoint - AntialiasFactor < y)
-                                        {
-                                            // we are near the left of the line
-                                            distance = nextPoint - y;
-                                        }
-                                        else if (lastPoint + AntialiasFactor > y)
-                                        {
-                                            // we are near the right of the line
-                                            distance = y - lastPoint;
-                                        }
-                                        else
-                                        {
-                                            // we are to far away from the line
-                                            continue;
-                                        }
-                                        opacity = 1 - (distance / AntialiasFactor);
-                                    }
-                                    else
-                                    {
-                                        continue;
-                                    }
-                                }
-
-                                // don't set full opactiy color as it will have been gotten by the first scan
-                                if (opacity > Constants.Epsilon && opacity < 1)
-                                {
-                                    Vector4 backgroundVector = sourcePixels[x, y].ToVector4();
-                                    Vector4 sourceVector = applicator[x, y].ToVector4();
-                                    Vector4 finalColor = Vector4BlendTransforms.PremultipliedLerp(backgroundVector, sourceVector, opacity);
-                                    finalColor.W = backgroundVector.W;
-
-                                    TColor packed = default(TColor);
-                                    packed.PackFromVector4(finalColor);
-                                    sourcePixels[x, y] = packed;
+                                    scanline[x] += subpixelFraction;
+                                    scanlineDirty = true;
                                 }
                             }
                         }
-                        finally
+
+                        if (scanlineDirty)
                         {
-                            arrayPool.Return(buffer);
+                            if (!this.Options.Antialias)
+                            {
+                                for (int x = 0; x < scanlineWidth; x++)
+                                {
+                                    if (scanline[x] > 0.5)
+                                    {
+                                        scanline[x] = 1;
+                                    }
+                                    else
+                                    {
+                                        scanline[x] = 0;
+                                    }
+                                }
+                            }
+
+                            applicator.Apply(scanline, scanlineWidth, 0, minX, y);
                         }
-                    });
+                    }
+                }
+                finally
+                {
+                    arrayPool.Return(buffer);
+                    ArrayPool<float>.Shared.Return(scanline);
                 }
             }
         }

--- a/src/ImageSharp.Drawing/Processors/FillRegionProcessor.cs
+++ b/src/ImageSharp.Drawing/Processors/FillRegionProcessor.cs
@@ -88,7 +88,7 @@ namespace ImageSharp.Drawing.Processors
                 try
                 {
                     bool scanlineDirty = true;
-                    for (var y = minY; y < maxY; y++)
+                    for (int y = minY; y < maxY; y++)
                     {
                         if (scanlineDirty)
                         {
@@ -105,7 +105,7 @@ namespace ImageSharp.Drawing.Processors
                         float subpixelFractionPoint = subpixelFraction / subpixelCount;
                         for (float subPixel = (float)y; subPixel < y + 1; subPixel += subpixelFraction)
                         {
-                            int pointsFound = region.ScanY(subPixel, buffer, maxIntersections, 0);
+                            int pointsFound = region.Scan(subPixel, buffer, maxIntersections, 0);
                             if (pointsFound == 0)
                             {
                                 // nothing on this line skip

--- a/src/ImageSharp.Drawing/Region.cs
+++ b/src/ImageSharp.Drawing/Region.cs
@@ -19,7 +19,7 @@ namespace ImageSharp.Drawing
         /// Gets the bounding box that entirely surrounds this region.
         /// </summary>
         /// <remarks>
-        /// This should always contains all possible points returned from either <see cref="ScanX(int, float[], int, int)"/> or <see cref="ScanY(int, float[], int, int)"/>.
+        /// This should always contains all possible points returned from either <see cref="ScanX(float, float[], int, int)"/> or <see cref="ScanY(float, float[], int, int)"/>.
         /// </remarks>
         public abstract Rectangle Bounds { get; }
 
@@ -31,7 +31,7 @@ namespace ImageSharp.Drawing
         /// <param name="length">The length.</param>
         /// <param name="offset">The offset.</param>
         /// <returns>The number of intersections found.</returns>
-        public abstract int ScanX(int x, float[] buffer, int length, int offset);
+        public abstract int ScanX(float x, float[] buffer, int length, int offset);
 
         /// <summary>
         /// Scans the Y axis for intersections.
@@ -41,6 +41,6 @@ namespace ImageSharp.Drawing
         /// <param name="length">The length.</param>
         /// <param name="offset">The offset.</param>
         /// <returns>The number of intersections found.</returns>
-        public abstract int ScanY(int y, float[] buffer, int length, int offset);
+        public abstract int ScanY(float y, float[] buffer, int length, int offset);
     }
 }

--- a/src/ImageSharp.Drawing/Region.cs
+++ b/src/ImageSharp.Drawing/Region.cs
@@ -19,28 +19,18 @@ namespace ImageSharp.Drawing
         /// Gets the bounding box that entirely surrounds this region.
         /// </summary>
         /// <remarks>
-        /// This should always contains all possible points returned from either <see cref="ScanX(float, float[], int, int)"/> or <see cref="ScanY(float, float[], int, int)"/>.
+        /// This should always contains all possible points returned from <see cref="Scan(float, float[], int, int)"/>.
         /// </remarks>
         public abstract Rectangle Bounds { get; }
 
         /// <summary>
-        /// Scans the X axis for intersections.
-        /// </summary>
-        /// <param name="x">The position along the X axis to find intersections.</param>
-        /// <param name="buffer">The buffer.</param>
-        /// <param name="length">The length.</param>
-        /// <param name="offset">The offset.</param>
-        /// <returns>The number of intersections found.</returns>
-        public abstract int ScanX(float x, float[] buffer, int length, int offset);
-
-        /// <summary>
-        /// Scans the Y axis for intersections.
+        /// Scans the X axis for intersections at the Y axis position.
         /// </summary>
         /// <param name="y">The position along the y axis to find intersections.</param>
         /// <param name="buffer">The buffer.</param>
         /// <param name="length">The length.</param>
         /// <param name="offset">The offset.</param>
         /// <returns>The number of intersections found.</returns>
-        public abstract int ScanY(float y, float[] buffer, int length, int offset);
+        public abstract int Scan(float y, float[] buffer, int length, int offset);
     }
 }

--- a/src/ImageSharp.Drawing/Text/TextGraphicsOptions.cs
+++ b/src/ImageSharp.Drawing/Text/TextGraphicsOptions.cs
@@ -21,6 +21,11 @@ namespace ImageSharp.Drawing
         public bool Antialias;
 
         /// <summary>
+        /// The number of subpixels to use while rendering with antialiasing enabled.
+        /// </summary>
+        public int AntialiasSubpixelDepth;
+
+        /// <summary>
         /// Whether the text should be drawing with kerning enabled.
         /// </summary>
         public bool ApplyKerning;
@@ -39,6 +44,7 @@ namespace ImageSharp.Drawing
             this.Antialias = enableAntialiasing;
             this.ApplyKerning = true;
             this.TabWidth = 4;
+            this.AntialiasSubpixelDepth = 16;
         }
 
         /// <summary>
@@ -50,7 +56,10 @@ namespace ImageSharp.Drawing
         /// </returns>
         public static implicit operator TextGraphicsOptions(GraphicsOptions options)
         {
-            return new TextGraphicsOptions(options.Antialias);
+            return new TextGraphicsOptions(options.Antialias)
+            {
+                AntialiasSubpixelDepth = options.AntialiasSubpixelDepth
+            };
         }
 
         /// <summary>
@@ -62,7 +71,10 @@ namespace ImageSharp.Drawing
         /// </returns>
         public static explicit operator GraphicsOptions(TextGraphicsOptions options)
         {
-            return new GraphicsOptions(options.Antialias);
+            return new GraphicsOptions(options.Antialias)
+            {
+                AntialiasSubpixelDepth = options.AntialiasSubpixelDepth
+            };
         }
     }
 }

--- a/src/ImageSharp/Common/Memory/BufferPointer{T}.cs
+++ b/src/ImageSharp/Common/Memory/BufferPointer{T}.cs
@@ -73,16 +73,16 @@ namespace ImageSharp
         /// </summary>
         public IntPtr PointerAtOffset { get; private set; }
 
-          /// <summary>
-        /// Gets or sets the pixel at the specified position.
+        /// <summary>
+        /// Gets the element at the specified position.
         /// </summary>
-        /// <param name="x">The x-coordinate of the pixel. Must be greater than or equal to zero and less than the width of the image.</param>
-        /// <returns>The <see typeparam="TColor"/> at the specified position.</returns>
-        public T this[int x]
+        /// <param name="index">The index from the start of this Pointer to the required element.</param>
+        /// <returns>The <see typeparam="T"/> at the specified position.</returns>
+        public T this[int index]
         {
             get
             {
-                void* ptr = ((byte*)this.PointerAtOffset) + (x * Unsafe.SizeOf<T>());
+                byte* ptr = ((byte*)this.PointerAtOffset) + BufferPointer.SizeOf<T>(index);
                 return Unsafe.Read<T>(ptr);
             }
         }

--- a/src/ImageSharp/Common/Memory/BufferPointer{T}.cs
+++ b/src/ImageSharp/Common/Memory/BufferPointer{T}.cs
@@ -73,6 +73,20 @@ namespace ImageSharp
         /// </summary>
         public IntPtr PointerAtOffset { get; private set; }
 
+          /// <summary>
+        /// Gets or sets the pixel at the specified position.
+        /// </summary>
+        /// <param name="x">The x-coordinate of the pixel. Must be greater than or equal to zero and less than the width of the image.</param>
+        /// <returns>The <see typeparam="TColor"/> at the specified position.</returns>
+        public T this[int x]
+        {
+            get
+            {
+                void* ptr = ((byte*)this.PointerAtOffset) + (x * Unsafe.SizeOf<T>());
+                return Unsafe.Read<T>(ptr);
+            }
+        }
+
         /// <summary>
         /// Convertes <see cref="BufferPointer{T}"/> instance to a raw 'void*' pointer
         /// </summary>

--- a/tests/ImageSharp.Benchmarks/Drawing/FillPolygon.cs
+++ b/tests/ImageSharp.Benchmarks/Drawing/FillPolygon.cs
@@ -9,6 +9,7 @@ namespace ImageSharp.Benchmarks
     using System.Drawing.Drawing2D;
     using System.IO;
     using System.Numerics;
+    using SixLabors.Shapes;
 
     using BenchmarkDotNet.Attributes;
 
@@ -17,6 +18,15 @@ namespace ImageSharp.Benchmarks
 
     public class FillPolygon : BenchmarkBase
     {
+        private readonly Polygon shape;
+
+        public FillPolygon()
+        {
+            this.shape = new SixLabors.Shapes.Polygon(new LinearLineSegment(new Vector2(10, 10),
+                        new Vector2(550, 50),
+                        new Vector2(200, 400)));
+        }
+
         [Benchmark(Baseline = true, Description = "System.Drawing Fill Polygon")]
         public void DrawSolidPolygonSystemDrawing()
         {
@@ -53,6 +63,22 @@ namespace ImageSharp.Benchmarks
                         new Vector2(550, 50),
                         new Vector2(200, 400)
                     });
+
+                using (MemoryStream ms = new MemoryStream())
+                {
+                    image.SaveAsBmp(ms);
+                }
+            }
+        }
+
+        [Benchmark(Description = "ImageSharp Fill Polygon - cached shape")]
+        public void DrawSolidPolygonCoreCahced()
+        {
+            using (CoreImage image = new CoreImage(800, 800))
+            {
+                image.Fill(
+                    CoreColor.HotPink,
+                    this.shape);
 
                 using (MemoryStream ms = new MemoryStream())
                 {

--- a/tests/ImageSharp.Tests/Drawing/FillPatternTests.cs
+++ b/tests/ImageSharp.Tests/Drawing/FillPatternTests.cs
@@ -33,8 +33,9 @@ namespace ImageSharp.Tests.Drawing
                 {
                     // lets pick random spots to start checking
                     Random r = new Random();
-                    int xStride = expectedPattern.GetLength(1);
-                    int yStride = expectedPattern.GetLength(0);
+                    var expectedPatternFast = new Fast2DArray<Color>(expectedPattern);
+                    int xStride = expectedPatternFast.Width;
+                    int yStride = expectedPatternFast.Height;
                     int offsetX = r.Next(image.Width / xStride) * xStride;
                     int offsetY = r.Next(image.Height / yStride) * yStride;
                     for (int x = 0; x < xStride; x++)
@@ -43,7 +44,7 @@ namespace ImageSharp.Tests.Drawing
                         {
                             int actualX = x + offsetX;
                             int actualY = y + offsetY;
-                            Color expected = expectedPattern[y, x]; // inverted pattern
+                            Color expected = expectedPatternFast[y, x]; // inverted pattern
                             Color actual = sourcePixels[actualX, actualY];
                             if (expected != actual)
                             {
@@ -187,30 +188,6 @@ namespace ImageSharp.Tests.Drawing
         {
             Test("ForwardDiagonal", Color.Blue, Brushes.ForwardDiagonal(Color.HotPink, Color.LimeGreen),
            new Color[,] {
-                { Color.HotPink, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen},
-                { Color.LimeGreen, Color.HotPink, Color.LimeGreen, Color.LimeGreen},
-                { Color.LimeGreen, Color.LimeGreen, Color.HotPink, Color.LimeGreen},
-                { Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.HotPink}
-           });
-        }
-
-        [Fact]
-        public void ImageShouldBeFloodFilledWithForwardDiagonal_transparent()
-        {
-            Test("ForwardDiagonal_Transparent", Color.Blue, Brushes.ForwardDiagonal(Color.HotPink),
-           new Color[,] {
-                { Color.HotPink, Color.Blue,    Color.Blue,    Color.Blue},
-                { Color.Blue,    Color.HotPink, Color.Blue,    Color.Blue},
-                { Color.Blue,    Color.Blue,    Color.HotPink, Color.Blue},
-                { Color.Blue,    Color.Blue,    Color.Blue,    Color.HotPink}
-           });
-        }
-
-        [Fact]
-        public void ImageShouldBeFloodFilledWithBackwardDiagonal()
-        {
-            Test("BackwardDiagonal", Color.Blue, Brushes.BackwardDiagonal(Color.HotPink, Color.LimeGreen),
-           new Color[,] {
                 { Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.HotPink},
                 { Color.LimeGreen, Color.LimeGreen, Color.HotPink, Color.LimeGreen},
                 { Color.LimeGreen, Color.HotPink, Color.LimeGreen, Color.LimeGreen},
@@ -219,17 +196,39 @@ namespace ImageSharp.Tests.Drawing
         }
 
         [Fact]
+        public void ImageShouldBeFloodFilledWithForwardDiagonal_transparent()
+        {
+            Test("ForwardDiagonal_Transparent", Color.Blue, Brushes.ForwardDiagonal(Color.HotPink),
+           new Color[,] {
+                { Color.Blue,    Color.Blue,    Color.Blue,    Color.HotPink},
+                { Color.Blue,    Color.Blue,    Color.HotPink, Color.Blue},
+                { Color.Blue,    Color.HotPink, Color.Blue,    Color.Blue},
+                { Color.HotPink, Color.Blue,    Color.Blue,    Color.Blue}
+           });
+        }
+
+        [Fact]
+        public void ImageShouldBeFloodFilledWithBackwardDiagonal()
+        {
+            Test("BackwardDiagonal", Color.Blue, Brushes.BackwardDiagonal(Color.HotPink, Color.LimeGreen),
+           new Color[,] {
+                { Color.HotPink,   Color.LimeGreen, Color.LimeGreen, Color.LimeGreen},
+                { Color.LimeGreen, Color.HotPink,   Color.LimeGreen, Color.LimeGreen},
+                { Color.LimeGreen, Color.LimeGreen, Color.HotPink,   Color.LimeGreen},
+                { Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.HotPink}
+           });
+        }
+
+        [Fact]
         public void ImageShouldBeFloodFilledWithBackwardDiagonal_transparent()
         {
             Test("BackwardDiagonal_Transparent", Color.Blue, Brushes.BackwardDiagonal(Color.HotPink),
            new Color[,] {
-                { Color.Blue, Color.Blue,    Color.Blue,    Color.HotPink},
-                { Color.Blue,    Color.Blue, Color.HotPink,    Color.Blue},
-                { Color.Blue,    Color.HotPink,    Color.Blue, Color.Blue},
-                { Color.HotPink,    Color.Blue,    Color.Blue,    Color.Blue}
+                { Color.HotPink, Color.Blue,    Color.Blue,    Color.Blue},
+                { Color.Blue,    Color.HotPink, Color.Blue,    Color.Blue},
+                { Color.Blue,    Color.Blue,    Color.HotPink, Color.Blue},
+                { Color.Blue,    Color.Blue,    Color.Blue,    Color.HotPink}
            });
         }
-
-
     }
 }

--- a/tests/ImageSharp.Tests/Drawing/FillPatternTests.cs
+++ b/tests/ImageSharp.Tests/Drawing/FillPatternTests.cs
@@ -33,7 +33,7 @@ namespace ImageSharp.Tests.Drawing
                 {
                     // lets pick random spots to start checking
                     Random r = new Random();
-                    var expectedPatternFast = new Fast2DArray<Color>(expectedPattern);
+                    Fast2DArray<Color> expectedPatternFast = new Fast2DArray<Color>(expectedPattern);
                     int xStride = expectedPatternFast.Width;
                     int yStride = expectedPatternFast.Height;
                     int offsetX = r.Next(image.Width / xStride) * xStride;

--- a/tests/ImageSharp.Tests/Drawing/FillRegionProcessorTests.cs
+++ b/tests/ImageSharp.Tests/Drawing/FillRegionProcessorTests.cs
@@ -1,0 +1,46 @@
+﻿
+namespace ImageSharp.Tests.Drawing
+{
+    using System;
+    using System.IO;
+    using ImageSharp;
+    using ImageSharp.Drawing.Brushes;
+    using Processing;
+    using System.Collections.Generic;
+    using Xunit;
+    using ImageSharp.Drawing;
+    using System.Numerics;
+    using SixLabors.Shapes;
+    using ImageSharp.Drawing.Processors;
+    using ImageSharp.Drawing.Pens;
+    using Moq;
+    using System.Collections.Immutable;
+
+    public class FillRegionProcessorTests
+    {
+        [Theory]
+        [InlineData(true, 1, 4)]
+        [InlineData(true, 2, 4)]
+        [InlineData(true, 5, 5)]
+        [InlineData(true, 8, 8)]
+        [InlineData(false, 8, 4)] 
+        [InlineData(false, 16, 4)] // we always do 4 sub=pixels when antialising is off.
+        public void MinimumAntialiasSubpixelDepth(bool antialias, int antialiasSubpixelDepth, int expectedAntialiasSubpixelDepth)
+        {
+            var bounds = new ImageSharp.Rectangle(0, 0, 1, 1);
+
+            Mock<IBrush<Color>> brush = new Mock<IBrush<Color>>();
+            Mock<Region> region = new Mock<Region>();
+            region.Setup(x => x.Bounds).Returns(bounds);
+
+            GraphicsOptions options = new GraphicsOptions(antialias) {
+                AntialiasSubpixelDepth = 1
+            };
+            FillRegionProcessor<Color> processor = new FillRegionProcessor<Color>(brush.Object, region.Object, options);
+            Image img = new Image(1, 1);
+            processor.Apply(img, bounds);
+
+            region.Verify(x => x.Scan(It.IsAny<float>(), It.IsAny<float[]>(), It.IsAny<int>(), It.IsAny<int>()), Times.Exactly(4));
+        }
+    }
+}

--- a/tests/ImageSharp.Tests/Drawing/Paths/ShapeRegionTests.cs
+++ b/tests/ImageSharp.Tests/Drawing/Paths/ShapeRegionTests.cs
@@ -68,25 +68,6 @@ namespace ImageSharp.Tests.Drawing.Paths
         }
 
         [Fact]
-        public void ShapeRegionFromPathScanXProxyToShape()
-        {
-            int xToScan = 10;
-            ShapeRegion region = new ShapeRegion(pathMock.Object);
-
-            pathMock.Setup(x => x.FindIntersections(It.IsAny<Vector2>(), It.IsAny<Vector2>(), It.IsAny<Vector2[]>(), It.IsAny<int>(), It.IsAny<int>()))
-                .Callback<Vector2, Vector2, Vector2[], int, int>((s, e, b, c, o) => {
-                    Assert.Equal(xToScan, s.X);
-                    Assert.Equal(xToScan, e.X);
-                    Assert.True(s.Y < bounds.Top);
-                    Assert.True(e.Y > bounds.Bottom);
-                }).Returns(0);
-
-            int i = region.ScanX(xToScan, new float[0], 0, 0);
-
-            pathMock.Verify(x => x.FindIntersections(It.IsAny<Vector2>(), It.IsAny<Vector2>(), It.IsAny<Vector2[]>(), It.IsAny<int>(), It.IsAny<int>()), Times.Once);
-        }
-
-        [Fact]
         public void ShapeRegionFromPathScanYProxyToShape()
         {
             int yToScan = 10;
@@ -100,27 +81,7 @@ namespace ImageSharp.Tests.Drawing.Paths
                     Assert.True(e.X > bounds.Right);
                 }).Returns(0);
 
-            int i = region.ScanY(yToScan, new float[0], 0, 0);
-
-            pathMock.Verify(x => x.FindIntersections(It.IsAny<Vector2>(), It.IsAny<Vector2>(), It.IsAny<Vector2[]>(), It.IsAny<int>(), It.IsAny<int>()), Times.Once);
-        }
-
-
-        [Fact]
-        public void ShapeRegionFromShapeScanXProxyToShape()
-        {
-            int xToScan = 10;
-            ShapeRegion region = new ShapeRegion(pathMock.Object);
-
-            pathMock.Setup(x => x.FindIntersections(It.IsAny<Vector2>(), It.IsAny<Vector2>(), It.IsAny<Vector2[]>(), It.IsAny<int>(), It.IsAny<int>()))
-                .Callback<Vector2, Vector2, Vector2[], int, int>((s, e, b, c, o) => {
-                    Assert.Equal(xToScan, s.X);
-                    Assert.Equal(xToScan, e.X);
-                    Assert.True(s.Y < bounds.Top);
-                    Assert.True(e.Y > bounds.Bottom);
-                }).Returns(0);
-
-            int i = region.ScanX(xToScan, new float[0], 0, 0);
+            int i = region.Scan(yToScan, new float[0], 0, 0);
 
             pathMock.Verify(x => x.FindIntersections(It.IsAny<Vector2>(), It.IsAny<Vector2>(), It.IsAny<Vector2[]>(), It.IsAny<int>(), It.IsAny<int>()), Times.Once);
         }
@@ -139,7 +100,7 @@ namespace ImageSharp.Tests.Drawing.Paths
                     Assert.True(e.X > bounds.Right);
                 }).Returns(0);
 
-            int i = region.ScanY(yToScan, new float[0], 0, 0);
+            int i = region.Scan(yToScan, new float[0], 0, 0);
 
             pathMock.Verify(x => x.FindIntersections(It.IsAny<Vector2>(), It.IsAny<Vector2>(), It.IsAny<Vector2[]>(), It.IsAny<int>(), It.IsAny<int>()), Times.Once);
         }

--- a/tests/ImageSharp.Tests/Drawing/SolidBezierTests.cs
+++ b/tests/ImageSharp.Tests/Drawing/SolidBezierTests.cs
@@ -36,15 +36,9 @@ namespace ImageSharp.Tests.Drawing
 
                 using (PixelAccessor<Color> sourcePixels = image.Lock())
                 {
-                    //top of curve
-                    Assert.Equal(Color.HotPink, sourcePixels[138, 116]);
-
-                    //start points
-                    Assert.Equal(Color.HotPink, sourcePixels[10, 400]);
-                    Assert.Equal(Color.HotPink, sourcePixels[300, 400]);
+                    Assert.Equal(Color.HotPink, sourcePixels[150, 300]);
 
                     //curve points should not be never be set
-                    Assert.Equal(Color.Blue, sourcePixels[30, 10]);
                     Assert.Equal(Color.Blue, sourcePixels[240, 30]);
 
                     // inside shape should not be empty
@@ -83,12 +77,7 @@ namespace ImageSharp.Tests.Drawing
                     //top of curve
                     Assert.Equal(mergedColor, sourcePixels[138, 116]);
 
-                    //start points
-                    Assert.Equal(mergedColor, sourcePixels[10, 400]);
-                    Assert.Equal(mergedColor, sourcePixels[300, 400]);
-
                     //curve points should not be never be set
-                    Assert.Equal(Color.Blue, sourcePixels[30, 10]);
                     Assert.Equal(Color.Blue, sourcePixels[240, 30]);
 
                     // inside shape should not be empty

--- a/tests/ImageSharp.Tests/Drawing/SolidComplexPolygonTests.cs
+++ b/tests/ImageSharp.Tests/Drawing/SolidComplexPolygonTests.cs
@@ -42,20 +42,10 @@ namespace ImageSharp.Tests.Drawing
 
                 using (PixelAccessor<Color> sourcePixels = image.Lock())
                 {
-                    Assert.Equal(Color.HotPink, sourcePixels[11, 11]);
-
-                    Assert.Equal(Color.HotPink, sourcePixels[200, 150]);
-
-                    Assert.Equal(Color.HotPink, sourcePixels[70, 137]);
-
-                    Assert.Equal(Color.HotPink, sourcePixels[50, 50]);
-
-                    Assert.Equal(Color.HotPink, sourcePixels[35, 100]);
-
-                    Assert.Equal(Color.Blue, sourcePixels[2, 2]);
+                    Assert.Equal(Color.HotPink, sourcePixels[20, 35]);
 
                     //inside hole
-                    Assert.Equal(Color.Blue, sourcePixels[57, 99]);
+                    Assert.Equal(Color.Blue, sourcePixels[60, 100]);
                 }
             }
         }
@@ -87,18 +77,10 @@ namespace ImageSharp.Tests.Drawing
 
                 using (PixelAccessor<Color> sourcePixels = image.Lock())
                 {
-                    Assert.Equal(Color.HotPink, sourcePixels[11, 11]);
-
-                    Assert.Equal(Color.HotPink, sourcePixels[200, 150]);
-
-                    Assert.Equal(Color.HotPink, sourcePixels[50, 50]);
-
-                    Assert.Equal(Color.HotPink, sourcePixels[35, 100]);
-
-                    Assert.Equal(Color.Blue, sourcePixels[2, 2]);
+                    Assert.Equal(Color.HotPink, sourcePixels[20, 35]);
 
                     //inside hole
-                    Assert.Equal(Color.Blue, sourcePixels[57, 99]);
+                    Assert.Equal(Color.Blue, sourcePixels[60, 100]);
                 }
             }
         }
@@ -133,18 +115,10 @@ namespace ImageSharp.Tests.Drawing
 
                 using (PixelAccessor<Color> sourcePixels = image.Lock())
                 {
-                    Assert.Equal(mergedColor, sourcePixels[11, 11]);
-
-                    Assert.Equal(mergedColor, sourcePixels[200, 150]);
-
-                    Assert.Equal(mergedColor, sourcePixels[50, 50]);
-
-                    Assert.Equal(mergedColor, sourcePixels[35, 100]);
-
-                    Assert.Equal(Color.Blue, sourcePixels[2, 2]);
+                    Assert.Equal(mergedColor, sourcePixels[20, 35]);
 
                     //inside hole
-                    Assert.Equal(Color.Blue, sourcePixels[57, 99]);
+                    Assert.Equal(Color.Blue, sourcePixels[60, 100]);
                 }
             }
         }

--- a/tests/ImageSharp.Tests/Drawing/SolidPolygonTests.cs
+++ b/tests/ImageSharp.Tests/Drawing/SolidPolygonTests.cs
@@ -44,6 +44,32 @@ namespace ImageSharp.Tests.Drawing
         }
 
         [Fact]
+        public void ImageShouldBeOverlayedByFilledPolygonWithPattern()
+        {
+            string path = this.CreateOutputDirectory("Drawing", "FilledPolygons");
+            Vector2[] simplePath = new[] {
+                            new Vector2(10, 10),
+                            new Vector2(200, 150),
+                            new Vector2(50, 300)
+            };
+
+            using (Image image = new Image(500, 500))
+            {
+                using (FileStream output = File.OpenWrite($"{path}/Pattern.png"))
+                {
+                    image
+                        .FillPolygon(Brushes.Horizontal(Color.HotPink), simplePath, new GraphicsOptions(true))
+                        .Save(output);
+                }
+
+                using (PixelAccessor<Color> sourcePixels = image.Lock())
+                {
+                    Assert.Equal(Color.HotPink, sourcePixels[81, 145]);
+                }
+            }
+        }
+
+        [Fact]
         public void ImageShouldBeOverlayedByFilledPolygonNoAntialias()
         {
             string path = this.CreateOutputDirectory("Drawing", "FilledPolygons");

--- a/tests/ImageSharp.Tests/Drawing/SolidPolygonTests.cs
+++ b/tests/ImageSharp.Tests/Drawing/SolidPolygonTests.cs
@@ -38,13 +38,7 @@ namespace ImageSharp.Tests.Drawing
 
                 using (PixelAccessor<Color> sourcePixels = image.Lock())
                 {
-                    Assert.Equal(Color.HotPink, sourcePixels[11, 11]);
-
-                    Assert.Equal(Color.HotPink, sourcePixels[200, 150]);
-
-                    Assert.Equal(Color.HotPink, sourcePixels[50, 50]);
-
-                    Assert.NotEqual(Color.HotPink, sourcePixels[2, 2]);
+                    Assert.Equal(Color.HotPink, sourcePixels[81, 145]);
                 }
             }
         }
@@ -129,12 +123,6 @@ namespace ImageSharp.Tests.Drawing
 
                 using (PixelAccessor<Color> sourcePixels = image.Lock())
                 {
-                    Assert.Equal(mergedColor, sourcePixels[11, 11]);
-
-                    Assert.Equal(mergedColor, sourcePixels[200, 150]);
-
-                    Assert.Equal(mergedColor, sourcePixels[50, 50]);
-
                     Assert.Equal(Color.Blue, sourcePixels[2, 2]);
                 }
             }
@@ -187,19 +175,9 @@ namespace ImageSharp.Tests.Drawing
 
                 using (PixelAccessor<Color> sourcePixels = image.Lock())
                 {
-                    Assert.Equal(Color.HotPink, sourcePixels[25, 35]);
-
-                    Assert.Equal(Color.HotPink, sourcePixels[50, 79]);
-
-                    Assert.Equal(Color.HotPink, sourcePixels[75, 35]);
+                    Assert.Equal(Color.Blue, sourcePixels[30, 65]);
 
                     Assert.Equal(Color.HotPink, sourcePixels[50, 50]);
-
-                    Assert.Equal(Color.Blue, sourcePixels[2, 2]);
-
-                    Assert.Equal(Color.Blue, sourcePixels[28, 60]);
-
-                    Assert.Equal(Color.Blue, sourcePixels[67, 67]);
                 }
             }
         }

--- a/tests/ImageSharp.Tests/Drawing/Text/TextGraphicsOptionsTests.cs
+++ b/tests/ImageSharp.Tests/Drawing/Text/TextGraphicsOptionsTests.cs
@@ -1,0 +1,43 @@
+﻿
+namespace ImageSharp.Tests.Drawing.Text
+{
+    using ImageSharp.Drawing;
+    using SixLabors.Fonts;
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Numerics;
+    using System.Threading.Tasks;
+    using Xunit;
+
+    public class TextGraphicsOptionsTests
+    {
+        [Fact]
+        public void ExplicitCastOfGraphicsOptions()
+        {
+            GraphicsOptions opt = new GraphicsOptions(false)
+            {
+                AntialiasSubpixelDepth = 99
+            };
+
+            TextGraphicsOptions textOptions = opt;
+
+            Assert.Equal(false, textOptions.Antialias);
+            Assert.Equal(99, textOptions.AntialiasSubpixelDepth);
+        }
+
+        [Fact]
+        public void ImplicitCastToGraphicsOptions()
+        {
+            TextGraphicsOptions textOptions = new TextGraphicsOptions(false)
+            {
+                AntialiasSubpixelDepth = 99
+            };
+
+            GraphicsOptions opt = (GraphicsOptions)textOptions;
+
+            Assert.Equal(false, opt.Antialias);
+            Assert.Equal(99, opt.AntialiasSubpixelDepth);
+        }
+    }
+}


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/JimBobSquarePants/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practise as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
Swap out the fill region processor to use a much more accurate sub-pixel rendering technique.

This new renderer is a tiny bit slower than the old one, but (and its a big but) it totally removes the Parrallel looping making it entirely single threaded.

#### New Sub-pixel renderer
![new](https://cloud.githubusercontent.com/assets/166440/24059207/0a73df04-0b46-11e7-8de2-26c7000a0163.png)
``` ini

BenchmarkDotNet=v0.10.1, OS=Microsoft Windows NT 6.2.9200.0
Processor=Intel(R) Core(TM) i5-6200U CPU 2.30GHz, ProcessorCount=4
Frequency=2343752 Hz, Resolution=426.6663 ns, Timer=TSC
  [Host]     : Clr 4.0.30319.42000, 64bit RyuJIT-v4.6.1637.0 [AttachedDebugger]
  DefaultJob : Clr 4.0.30319.42000, 64bit RyuJIT-v4.6.1637.0


```
|                        Method |       Mean |    StdErr |    StdDev | Scaled | Scaled-StdDev |     Gen 0 |    Gen 1 |    Gen 2 | Allocated |
|------------------------------ |----------- |---------- |---------- |------- |-------------- |---------- |--------- |--------- |---------- |
| 'System.Drawing Fill Polygon' |  4.0584 ms | 0.0485 ms | 0.1879 ms |   1.00 |          0.00 | 2069.5043 | 428.8793 | 428.8793 |   5.15 MB |
|     'ImageSharp Fill Polygon' | 13.4327 ms | 0.1318 ms | 0.7220 ms |   3.32 |          0.22 |  512.5000 | 262.5000 | 262.5000 |    5.3 MB |


#### Old renderer
![old](https://cloud.githubusercontent.com/assets/166440/24059208/0a74a948-0b46-11e7-87ab-188c3a8ff937.png)
``` ini

BenchmarkDotNet=v0.10.1, OS=Microsoft Windows NT 6.2.9200.0
Processor=Intel(R) Core(TM) i5-6200U CPU 2.30GHz, ProcessorCount=4
Frequency=2343752 Hz, Resolution=426.6663 ns, Timer=TSC
  [Host]     : Clr 4.0.30319.42000, 64bit RyuJIT-v4.6.1637.0 [AttachedDebugger]
  DefaultJob : Clr 4.0.30319.42000, 64bit RyuJIT-v4.6.1637.0


```
|                        Method |      Mean |    StdErr |    StdDev | Scaled | Scaled-StdDev |     Gen 0 |    Gen 1 |    Gen 2 | Allocated |
|------------------------------ |---------- |---------- |---------- |------- |-------------- |---------- |--------- |--------- |---------- |
| 'System.Drawing Fill Polygon' | 4.0581 ms | 0.0440 ms | 0.2108 ms |   1.00 |          0.00 | 2003.1250 | 362.5000 | 362.5000 |   5.15 MB |
|     'ImageSharp Fill Polygon' | 9.2461 ms | 0.0911 ms | 0.4988 ms |   2.28 |          0.16 |  765.6250 | 640.6250 | 640.6250 |   5.11 MB |
