### PR TITLE
Move image loading out of constructors and into static methods

### DIFF
--- a/ImageSharp.sln
+++ b/ImageSharp.sln
@@ -22,6 +22,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "SolutionItems", "SolutionIt
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Source", "Source", "{815C0625-CD3D-440F-9F80-2D83856AB7AE}"
+	ProjectSection(SolutionItems) = preProject
+		src\README.md = src\README.md
+	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{56801022-D71A-4FBE-BC5B-CBA08E2284EC}"
 EndProject

--- a/ImageSharp.sln
+++ b/ImageSharp.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26228.4
+VisualStudioVersion = 15.0.26228.9
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "SolutionItems", "SolutionItems", "{C317F1B1-D75E-4C6D-83EB-80367343E0D7}"
 	ProjectSection(SolutionItems) = preProject

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Here's an example of the code required to resize an image using the default Bicu
 
 On platforms supporting netstandard 1.3+
 ```csharp
-using (Image image = new Image("foo.jpg"))
+using (Image image = Image.Load("foo.jpg"))
 {
     image.Resize(image.Width / 2, image.Height / 2)
          .Grayscale()
@@ -85,7 +85,7 @@ on netstandard 1.1 - 1.2
 ```csharp
 using (FileStream stream = File.OpenRead("foo.jpg"))
 using (FileStream output = File.OpenWrite("bar.jpg"))
-using (Image image = new Image(stream))
+using (Image image = Image.Load(stream))
 {
     image.Resize(image.Width / 2, image.Height / 2)
          .Grayscale()

--- a/src/ImageSharp.Drawing/ImageSharp.Drawing.csproj
+++ b/src/ImageSharp.Drawing/ImageSharp.Drawing.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Description>An extension to ImageSharp that allows the drawing of images, paths, and text.</Description>
     <AssemblyTitle>ImageSharp.Drawing</AssemblyTitle>
-    <VersionPrefix>1.0.0-alpha4</VersionPrefix>
+    <VersionPrefix>1.0.0-alpha5</VersionPrefix>
     <Authors>James Jackson-South and contributors</Authors>
     <TargetFramework>netstandard1.1</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/src/ImageSharp/Formats/Bmp/BmpDecoder.cs
+++ b/src/ImageSharp/Formats/Bmp/BmpDecoder.cs
@@ -26,7 +26,7 @@ namespace ImageSharp.Formats
     public class BmpDecoder : IImageDecoder
     {
         /// <inheritdoc/>
-        public Image<TColor> Decode<TColor>(Stream stream, IDecoderOptions options, Configuration configuration)
+        public Image<TColor> Decode<TColor>(Configuration configuration, Stream stream, IDecoderOptions options)
 
             where TColor : struct, IPixel<TColor>
         {

--- a/src/ImageSharp/Formats/Bmp/BmpDecoder.cs
+++ b/src/ImageSharp/Formats/Bmp/BmpDecoder.cs
@@ -26,12 +26,13 @@ namespace ImageSharp.Formats
     public class BmpDecoder : IImageDecoder
     {
         /// <inheritdoc/>
-        public Image<TColor> Decode<TColor>(Stream stream, IDecoderOptions options)
+        public Image<TColor> Decode<TColor>(Stream stream, IDecoderOptions options, Configuration configuration)
+
             where TColor : struct, IPixel<TColor>
         {
             Guard.NotNull(stream, "stream");
 
-            return new BmpDecoderCore().Decode<TColor>(stream);
+            return new BmpDecoderCore(configuration).Decode<TColor>(stream);
         }
     }
 }

--- a/src/ImageSharp/Formats/Bmp/BmpDecoder.cs
+++ b/src/ImageSharp/Formats/Bmp/BmpDecoder.cs
@@ -26,13 +26,12 @@ namespace ImageSharp.Formats
     public class BmpDecoder : IImageDecoder
     {
         /// <inheritdoc/>
-        public void Decode<TColor>(Image<TColor> image, Stream stream, IDecoderOptions options)
+        public Image<TColor> Decode<TColor>(Stream stream, IDecoderOptions options)
             where TColor : struct, IPixel<TColor>
         {
-            Guard.NotNull(image, "image");
             Guard.NotNull(stream, "stream");
 
-            new BmpDecoderCore().Decode(image, stream);
+            return new BmpDecoderCore().Decode<TColor>(stream);
         }
     }
 }

--- a/src/ImageSharp/Formats/Bmp/BmpDecoderCore.cs
+++ b/src/ImageSharp/Formats/Bmp/BmpDecoderCore.cs
@@ -43,6 +43,17 @@ namespace ImageSharp.Formats
         /// </summary>
         private BmpInfoHeader infoHeader;
 
+        private Configuration configuration;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BmpDecoderCore"/> class.
+        /// </summary>
+        /// <param name="configuration">The configuration.</param>
+        public BmpDecoderCore(Configuration configuration)
+        {
+            this.configuration = configuration;
+        }
+
         /// <summary>
         /// Decodes the image from the specified this._stream and sets
         /// the data to image.
@@ -114,8 +125,7 @@ namespace ImageSharp.Formats
                         + $"bigger then the max allowed size '{Image<TColor>.MaxWidth}x{Image<TColor>.MaxHeight}'");
                 }
 
-                Image<TColor> image = new Image<TColor>(this.infoHeader.Width, this.infoHeader.Height);
-
+                Image<TColor> image = Image.Create<TColor>(this.infoHeader.Width, this.infoHeader.Height, this.configuration);
                 using (PixelAccessor<TColor> pixels = image.Lock())
                 {
                     switch (this.infoHeader.Compression)

--- a/src/ImageSharp/Formats/Bmp/BmpDecoderCore.cs
+++ b/src/ImageSharp/Formats/Bmp/BmpDecoderCore.cs
@@ -48,16 +48,13 @@ namespace ImageSharp.Formats
         /// the data to image.
         /// </summary>
         /// <typeparam name="TColor">The pixel format.</typeparam>
-        /// <param name="image">The image, where the data should be set to.
-        /// Cannot be null (Nothing in Visual Basic).</param>
         /// <param name="stream">The stream, where the image should be
         /// decoded from. Cannot be null (Nothing in Visual Basic).</param>
         /// <exception cref="System.ArgumentNullException">
-        ///    <para><paramref name="image"/> is null.</para>
-        ///    <para>- or -</para>
         ///    <para><paramref name="stream"/> is null.</para>
         /// </exception>
-        public void Decode<TColor>(Image<TColor> image, Stream stream)
+        /// <returns>The decoded image.</returns>
+        public Image<TColor> Decode<TColor>(Stream stream)
             where TColor : struct, IPixel<TColor>
         {
             this.currentStream = stream;
@@ -110,14 +107,14 @@ namespace ImageSharp.Formats
                     this.currentStream.Read(palette, 0, colorMapSize);
                 }
 
-                if (this.infoHeader.Width > image.MaxWidth || this.infoHeader.Height > image.MaxHeight)
+                if (this.infoHeader.Width > Image<TColor>.MaxWidth || this.infoHeader.Height > Image<TColor>.MaxHeight)
                 {
                     throw new ArgumentOutOfRangeException(
                         $"The input bitmap '{this.infoHeader.Width}x{this.infoHeader.Height}' is "
-                        + $"bigger then the max allowed size '{image.MaxWidth}x{image.MaxHeight}'");
+                        + $"bigger then the max allowed size '{Image<TColor>.MaxWidth}x{Image<TColor>.MaxHeight}'");
                 }
 
-                image.InitPixels(this.infoHeader.Width, this.infoHeader.Height);
+                Image<TColor> image = new Image<TColor>(this.infoHeader.Width, this.infoHeader.Height);
 
                 using (PixelAccessor<TColor> pixels = image.Lock())
                 {
@@ -151,6 +148,8 @@ namespace ImageSharp.Formats
                             throw new NotSupportedException("Does not support this kind of bitmap files.");
                     }
                 }
+
+                return image;
             }
             catch (IndexOutOfRangeException e)
             {

--- a/src/ImageSharp/Formats/Gif/GifDecoder.cs
+++ b/src/ImageSharp/Formats/Gif/GifDecoder.cs
@@ -14,24 +14,24 @@ namespace ImageSharp.Formats
     public class GifDecoder : IImageDecoder
     {
         /// <inheritdoc/>
-        public Image<TColor> Decode<TColor>(Stream stream, IDecoderOptions options, Configuration configuration)
+        public Image<TColor> Decode<TColor>(Configuration configuration, Stream stream, IDecoderOptions options)
 
             where TColor : struct, IPixel<TColor>
         {
             IGifDecoderOptions gifOptions = GifDecoderOptions.Create(options);
 
-            return this.Decode<TColor>(stream, gifOptions, configuration);
+            return this.Decode<TColor>(configuration, stream, gifOptions);
         }
 
         /// <summary>
         /// Decodes the image from the specified stream to the <see cref="ImageBase{TColor}"/>.
         /// </summary>
         /// <typeparam name="TColor">The pixel format.</typeparam>
+        /// <param name="configuration">The configuration.</param>
         /// <param name="stream">The <see cref="Stream"/> containing image data.</param>
         /// <param name="options">The options for the decoder.</param>
-        /// <param name="configuration">The configuration.</param>
         /// <returns>The image thats been decoded.</returns>
-        public Image<TColor> Decode<TColor>(Stream stream, IGifDecoderOptions options, Configuration configuration)
+        public Image<TColor> Decode<TColor>(Configuration configuration, Stream stream, IGifDecoderOptions options)
             where TColor : struct, IPixel<TColor>
         {
             return new GifDecoderCore<TColor>(options, configuration).Decode(stream);

--- a/src/ImageSharp/Formats/Gif/GifDecoder.cs
+++ b/src/ImageSharp/Formats/Gif/GifDecoder.cs
@@ -14,12 +14,13 @@ namespace ImageSharp.Formats
     public class GifDecoder : IImageDecoder
     {
         /// <inheritdoc/>
-        public Image<TColor> Decode<TColor>(Stream stream, IDecoderOptions options)
+        public Image<TColor> Decode<TColor>(Stream stream, IDecoderOptions options, Configuration configuration)
+
             where TColor : struct, IPixel<TColor>
         {
             IGifDecoderOptions gifOptions = GifDecoderOptions.Create(options);
 
-            return this.Decode<TColor>(stream, gifOptions);
+            return this.Decode<TColor>(stream, gifOptions, configuration);
         }
 
         /// <summary>
@@ -28,11 +29,12 @@ namespace ImageSharp.Formats
         /// <typeparam name="TColor">The pixel format.</typeparam>
         /// <param name="stream">The <see cref="Stream"/> containing image data.</param>
         /// <param name="options">The options for the decoder.</param>
+        /// <param name="configuration">The configuration.</param>
         /// <returns>The image thats been decoded.</returns>
-        public Image<TColor> Decode<TColor>(Stream stream, IGifDecoderOptions options)
+        public Image<TColor> Decode<TColor>(Stream stream, IGifDecoderOptions options, Configuration configuration)
             where TColor : struct, IPixel<TColor>
         {
-            return new GifDecoderCore<TColor>(options).Decode(stream);
+            return new GifDecoderCore<TColor>(options, configuration).Decode(stream);
         }
     }
 }

--- a/src/ImageSharp/Formats/Gif/GifDecoder.cs
+++ b/src/ImageSharp/Formats/Gif/GifDecoder.cs
@@ -14,25 +14,25 @@ namespace ImageSharp.Formats
     public class GifDecoder : IImageDecoder
     {
         /// <inheritdoc/>
-        public void Decode<TColor>(Image<TColor> image, Stream stream, IDecoderOptions options)
+        public Image<TColor> Decode<TColor>(Stream stream, IDecoderOptions options)
             where TColor : struct, IPixel<TColor>
         {
             IGifDecoderOptions gifOptions = GifDecoderOptions.Create(options);
 
-            this.Decode(image, stream, gifOptions);
+            return this.Decode<TColor>(stream, gifOptions);
         }
 
         /// <summary>
         /// Decodes the image from the specified stream to the <see cref="ImageBase{TColor}"/>.
         /// </summary>
         /// <typeparam name="TColor">The pixel format.</typeparam>
-        /// <param name="image">The <see cref="ImageBase{TColor}"/> to decode to.</param>
         /// <param name="stream">The <see cref="Stream"/> containing image data.</param>
         /// <param name="options">The options for the decoder.</param>
-        public void Decode<TColor>(Image<TColor> image, Stream stream, IGifDecoderOptions options)
+        /// <returns>The image thats been decoded.</returns>
+        public Image<TColor> Decode<TColor>(Stream stream, IGifDecoderOptions options)
             where TColor : struct, IPixel<TColor>
         {
-            new GifDecoderCore<TColor>(options).Decode(image, stream);
+            return new GifDecoderCore<TColor>(options).Decode(stream);
         }
     }
 }

--- a/src/ImageSharp/Formats/Gif/GifDecoderCore.cs
+++ b/src/ImageSharp/Formats/Gif/GifDecoderCore.cs
@@ -362,8 +362,7 @@ namespace ImageSharp.Formats
                 this.metaData.Quality = colorTableLength / 3;
 
                 // This initializes the image to become fully transparent because the alpha channel is zero.
-                this.image = Image.Create<TColor>(imageWidth, imageHeight, this.configuration);
-                this.image.MetaData.LoadFrom(this.metaData);
+                this.image = Image.Create<TColor>(imageWidth, imageHeight, this.metaData, this.configuration);
 
                 this.SetFrameDelay(this.metaData);
 

--- a/src/ImageSharp/Formats/Gif/GifDecoderCore.cs
+++ b/src/ImageSharp/Formats/Gif/GifDecoderCore.cs
@@ -28,11 +28,6 @@ namespace ImageSharp.Formats
         private readonly IGifDecoderOptions options;
 
         /// <summary>
-        /// The image to decode the information to.
-        /// </summary>
-        private Image<TColor> decodedImage;
-
-        /// <summary>
         /// The currently loaded stream.
         /// </summary>
         private Stream currentStream;
@@ -68,6 +63,16 @@ namespace ImageSharp.Formats
         private GifGraphicsControlExtension graphicsControlExtension;
 
         /// <summary>
+        /// The metadata
+        /// </summary>
+        private ImageMetaData metaData;
+
+        /// <summary>
+        /// The image to decode the information to.
+        /// </summary>
+        private Image<TColor> image;
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="GifDecoderCore{TColor}"/> class.
         /// </summary>
         /// <param name="options">The decoder options.</param>
@@ -79,13 +84,13 @@ namespace ImageSharp.Formats
         /// <summary>
         /// Decodes the stream to the image.
         /// </summary>
-        /// <param name="image">The image to decode to.</param>
         /// <param name="stream">The stream containing image data. </param>
-        public void Decode(Image<TColor> image, Stream stream)
+        /// <returns>The decoded image</returns>
+        public Image<TColor> Decode(Stream stream)
         {
             try
             {
-                this.decodedImage = image;
+                this.metaData = new ImageMetaData();
 
                 this.currentStream = stream;
 
@@ -144,6 +149,8 @@ namespace ImageSharp.Formats
                     ArrayPool<byte>.Shared.Return(this.globalColorTable);
                 }
             }
+
+            return this.image;
         }
 
         /// <summary>
@@ -212,11 +219,13 @@ namespace ImageSharp.Formats
                 throw new ImageFormatException($"Invalid gif colormap size '{this.logicalScreenDescriptor.GlobalColorTableSize}'");
             }
 
-            if (this.logicalScreenDescriptor.Width > this.decodedImage.MaxWidth || this.logicalScreenDescriptor.Height > this.decodedImage.MaxHeight)
+            /* // No point doing this as the max width/height is always int.Max and that always bigger than the max size of a gif which is stored in a short.
+            if (this.logicalScreenDescriptor.Width > Image<TColor>.MaxWidth || this.logicalScreenDescriptor.Height > Image<TColor>.MaxHeight)
             {
                 throw new ArgumentOutOfRangeException(
-                    $"The input gif '{this.logicalScreenDescriptor.Width}x{this.logicalScreenDescriptor.Height}' is bigger then the max allowed size '{this.decodedImage.MaxWidth}x{this.decodedImage.MaxHeight}'");
+                    $"The input gif '{this.logicalScreenDescriptor.Width}x{this.logicalScreenDescriptor.Height}' is bigger then the max allowed size '{Image<TColor>.MaxWidth}x{Image<TColor>.MaxHeight}'");
             }
+            */
         }
 
         /// <summary>
@@ -261,7 +270,7 @@ namespace ImageSharp.Formats
                 {
                     this.currentStream.Read(commentsBuffer, 0, length);
                     string comments = this.options.TextEncoding.GetString(commentsBuffer, 0, length);
-                    this.decodedImage.MetaData.Properties.Add(new ImageProperty(GifConstants.Comments, comments));
+                    this.metaData.Properties.Add(new ImageProperty(GifConstants.Comments, comments));
                 }
                 finally
                 {
@@ -343,14 +352,15 @@ namespace ImageSharp.Formats
 
             if (this.previousFrame == null)
             {
-                this.decodedImage.MetaData.Quality = colorTableLength / 3;
+                this.metaData.Quality = colorTableLength / 3;
 
                 // This initializes the image to become fully transparent because the alpha channel is zero.
-                this.decodedImage.InitPixels(imageWidth, imageHeight);
+                this.image = new Image<TColor>(imageWidth, imageHeight);
+                this.image.MetaData.LoadFrom(this.metaData);
 
-                this.SetFrameDelay(this.decodedImage.MetaData);
+                this.SetFrameDelay(this.metaData);
 
-                image = this.decodedImage;
+                image = this.image;
             }
             else
             {
@@ -368,7 +378,7 @@ namespace ImageSharp.Formats
 
                 this.RestoreToBackground(image);
 
-                this.decodedImage.Frames.Add(currentFrame);
+                this.image.Frames.Add(currentFrame);
             }
 
             int i = 0;
@@ -441,7 +451,7 @@ namespace ImageSharp.Formats
                 return;
             }
 
-            this.previousFrame = currentFrame == null ? this.decodedImage.ToFrame() : currentFrame;
+            this.previousFrame = currentFrame == null ? this.image.ToFrame() : currentFrame;
 
             if (this.graphicsControlExtension != null &&
                 this.graphicsControlExtension.DisposalMethod == DisposalMethod.RestoreToBackground)
@@ -462,8 +472,8 @@ namespace ImageSharp.Formats
             }
 
             // Optimization for when the size of the frame is the same as the image size.
-            if (this.restoreArea.Value.Width == this.decodedImage.Width &&
-                this.restoreArea.Value.Height == this.decodedImage.Height)
+            if (this.restoreArea.Value.Width == this.image.Width &&
+                this.restoreArea.Value.Height == this.image.Height)
             {
                 using (PixelAccessor<TColor> pixelAccessor = frame.Lock())
                 {

--- a/src/ImageSharp/Formats/Gif/GifDecoderCore.cs
+++ b/src/ImageSharp/Formats/Gif/GifDecoderCore.cs
@@ -28,6 +28,11 @@ namespace ImageSharp.Formats
         private readonly IGifDecoderOptions options;
 
         /// <summary>
+        /// The global configuration.
+        /// </summary>
+        private readonly Configuration configuration;
+
+        /// <summary>
         /// The currently loaded stream.
         /// </summary>
         private Stream currentStream;
@@ -76,9 +81,11 @@ namespace ImageSharp.Formats
         /// Initializes a new instance of the <see cref="GifDecoderCore{TColor}"/> class.
         /// </summary>
         /// <param name="options">The decoder options.</param>
-        public GifDecoderCore(IGifDecoderOptions options)
+        /// <param name="configuration">The configuration.</param>
+        public GifDecoderCore(IGifDecoderOptions options, Configuration configuration)
         {
             this.options = options ?? new GifDecoderOptions();
+            this.configuration = configuration ?? Configuration.Default;
         }
 
         /// <summary>
@@ -355,7 +362,7 @@ namespace ImageSharp.Formats
                 this.metaData.Quality = colorTableLength / 3;
 
                 // This initializes the image to become fully transparent because the alpha channel is zero.
-                this.image = new Image<TColor>(imageWidth, imageHeight);
+                this.image = Image.Create<TColor>(imageWidth, imageHeight, this.configuration);
                 this.image.MetaData.LoadFrom(this.metaData);
 
                 this.SetFrameDelay(this.metaData);

--- a/src/ImageSharp/Formats/IImageDecoder.cs
+++ b/src/ImageSharp/Formats/IImageDecoder.cs
@@ -19,8 +19,9 @@ namespace ImageSharp.Formats
         /// <typeparam name="TColor">The pixel format.</typeparam>
         /// <param name="stream">The <see cref="Stream"/> containing image data.</param>
         /// <param name="options">The options for the decoder.</param>
+        /// <param name="configuration">The configuration for the image.</param>
         /// <returns>The decoded image</returns>
-        Image<TColor> Decode<TColor>(Stream stream, IDecoderOptions options)
+        Image<TColor> Decode<TColor>(Stream stream, IDecoderOptions options, Configuration configuration)
             where TColor : struct, IPixel<TColor>;
     }
 }

--- a/src/ImageSharp/Formats/IImageDecoder.cs
+++ b/src/ImageSharp/Formats/IImageDecoder.cs
@@ -17,11 +17,11 @@ namespace ImageSharp.Formats
         /// Decodes the image from the specified stream to the <see cref="ImageBase{TColor}"/>.
         /// </summary>
         /// <typeparam name="TColor">The pixel format.</typeparam>
+        /// <param name="configuration">The configuration for the image.</param>
         /// <param name="stream">The <see cref="Stream"/> containing image data.</param>
         /// <param name="options">The options for the decoder.</param>
-        /// <param name="configuration">The configuration for the image.</param>
         /// <returns>The decoded image</returns>
-        Image<TColor> Decode<TColor>(Stream stream, IDecoderOptions options, Configuration configuration)
+        Image<TColor> Decode<TColor>(Configuration configuration, Stream stream, IDecoderOptions options)
             where TColor : struct, IPixel<TColor>;
     }
 }

--- a/src/ImageSharp/Formats/IImageDecoder.cs
+++ b/src/ImageSharp/Formats/IImageDecoder.cs
@@ -17,10 +17,10 @@ namespace ImageSharp.Formats
         /// Decodes the image from the specified stream to the <see cref="ImageBase{TColor}"/>.
         /// </summary>
         /// <typeparam name="TColor">The pixel format.</typeparam>
-        /// <param name="image">The <see cref="ImageBase{TColor}"/> to decode to.</param>
         /// <param name="stream">The <see cref="Stream"/> containing image data.</param>
         /// <param name="options">The options for the decoder.</param>
-        void Decode<TColor>(Image<TColor> image, Stream stream, IDecoderOptions options)
+        /// <returns>The decoded image</returns>
+        Image<TColor> Decode<TColor>(Stream stream, IDecoderOptions options)
             where TColor : struct, IPixel<TColor>;
     }
 }

--- a/src/ImageSharp/Formats/Jpeg/JpegDecoder.cs
+++ b/src/ImageSharp/Formats/Jpeg/JpegDecoder.cs
@@ -14,7 +14,7 @@ namespace ImageSharp.Formats
     public class JpegDecoder : IImageDecoder
     {
         /// <inheritdoc/>
-        public Image<TColor> Decode<TColor>(Stream stream, IDecoderOptions options, Configuration configuration)
+        public Image<TColor> Decode<TColor>(Configuration configuration, Stream stream, IDecoderOptions options)
             where TColor : struct, IPixel<TColor>
         {
             Guard.NotNull(stream, "stream");

--- a/src/ImageSharp/Formats/Jpeg/JpegDecoder.cs
+++ b/src/ImageSharp/Formats/Jpeg/JpegDecoder.cs
@@ -14,15 +14,14 @@ namespace ImageSharp.Formats
     public class JpegDecoder : IImageDecoder
     {
         /// <inheritdoc/>
-        public void Decode<TColor>(Image<TColor> image, Stream stream, IDecoderOptions options)
+        public Image<TColor> Decode<TColor>(Stream stream, IDecoderOptions options)
             where TColor : struct, IPixel<TColor>
         {
-            Guard.NotNull(image, "image");
             Guard.NotNull(stream, "stream");
 
             using (JpegDecoderCore decoder = new JpegDecoderCore(options))
             {
-                decoder.Decode(image, stream, false);
+                return decoder.Decode<TColor>(stream);
             }
         }
     }

--- a/src/ImageSharp/Formats/Jpeg/JpegDecoder.cs
+++ b/src/ImageSharp/Formats/Jpeg/JpegDecoder.cs
@@ -14,12 +14,12 @@ namespace ImageSharp.Formats
     public class JpegDecoder : IImageDecoder
     {
         /// <inheritdoc/>
-        public Image<TColor> Decode<TColor>(Stream stream, IDecoderOptions options)
+        public Image<TColor> Decode<TColor>(Stream stream, IDecoderOptions options, Configuration configuration)
             where TColor : struct, IPixel<TColor>
         {
             Guard.NotNull(stream, "stream");
 
-            using (JpegDecoderCore decoder = new JpegDecoderCore(options))
+            using (JpegDecoderCore decoder = new JpegDecoderCore(options, configuration))
             {
                 return decoder.Decode<TColor>(stream);
             }

--- a/src/ImageSharp/Formats/Jpeg/JpegDecoderCore.cs
+++ b/src/ImageSharp/Formats/Jpeg/JpegDecoderCore.cs
@@ -194,19 +194,6 @@ namespace ImageSharp.Formats
         }
 
         /// <summary>
-        /// Decodes the image from the specified <see cref="Stream"/>  and sets
-        /// the data to image.
-        /// </summary>
-        /// <param name="stream">The stream, where the image should be.</param>
-        /// <returns>The image metadata.</returns>
-        public ImageMetaData DecodeMetaData(Stream stream)
-        {
-            ImageMetaData metadata = new ImageMetaData();
-            this.ProcessStream(metadata, stream, true);
-            return metadata;
-        }
-
-        /// <summary>
         /// Dispose
         /// </summary>
         public void Dispose()

--- a/src/ImageSharp/Formats/Jpeg/JpegDecoderCore.cs
+++ b/src/ImageSharp/Formats/Jpeg/JpegDecoderCore.cs
@@ -505,9 +505,7 @@ namespace ImageSharp.Formats
         private Image<TColor> ConvertJpegPixelsToImagePixels<TColor>(ImageMetaData metadata)
             where TColor : struct, IPixel<TColor>
         {
-            Image<TColor> image = Image.Create<TColor>(this.ImageWidth, this.ImageHeight, this.configuration);
-
-            image.MetaData.LoadFrom(metadata);
+            Image<TColor> image = Image.Create<TColor>(this.ImageWidth, this.ImageHeight, metadata, this.configuration);
 
             if (this.grayImage.IsInitialized)
             {

--- a/src/ImageSharp/Formats/Jpeg/JpegDecoderCore.cs
+++ b/src/ImageSharp/Formats/Jpeg/JpegDecoderCore.cs
@@ -43,6 +43,11 @@ namespace ImageSharp.Formats
         private readonly IDecoderOptions options;
 
         /// <summary>
+        /// The global configuration
+        /// </summary>
+        private readonly Configuration configuration;
+
+        /// <summary>
         /// The App14 marker color-space
         /// </summary>
         private byte adobeTransform;
@@ -91,8 +96,10 @@ namespace ImageSharp.Formats
         /// Initializes a new instance of the <see cref="JpegDecoderCore" /> class.
         /// </summary>
         /// <param name="options">The decoder options.</param>
-        public JpegDecoderCore(IDecoderOptions options)
+        /// <param name="configuration">The configuration.</param>
+        public JpegDecoderCore(IDecoderOptions options, Configuration configuration)
         {
+            this.configuration = configuration ?? Configuration.Default;
             this.options = options ?? new DecoderOptions();
             this.HuffmanTrees = HuffmanTree.CreateHuffmanTrees();
             this.QuantizationTables = new Block8x8F[MaxTq + 1];
@@ -498,7 +505,8 @@ namespace ImageSharp.Formats
         private Image<TColor> ConvertJpegPixelsToImagePixels<TColor>(ImageMetaData metadata)
             where TColor : struct, IPixel<TColor>
         {
-            Image<TColor> image = new Image<TColor>(this.ImageWidth, this.ImageHeight);
+            Image<TColor> image = Image.Create<TColor>(this.ImageWidth, this.ImageHeight, this.configuration);
+
             image.MetaData.LoadFrom(metadata);
 
             if (this.grayImage.IsInitialized)

--- a/src/ImageSharp/Formats/Png/PngDecoder.cs
+++ b/src/ImageSharp/Formats/Png/PngDecoder.cs
@@ -31,24 +31,24 @@ namespace ImageSharp.Formats
     public class PngDecoder : IImageDecoder
     {
         /// <inheritdoc/>
-        public Image<TColor> Decode<TColor>(Stream stream, IDecoderOptions options, Configuration configuration)
+        public Image<TColor> Decode<TColor>(Configuration configuration, Stream stream, IDecoderOptions options)
 
             where TColor : struct, IPixel<TColor>
         {
             IPngDecoderOptions pngOptions = PngDecoderOptions.Create(options);
 
-            return this.Decode<TColor>(stream, pngOptions, configuration);
+            return this.Decode<TColor>(configuration, stream, pngOptions);
         }
 
         /// <summary>
         /// Decodes the image from the specified stream to the <see cref="ImageBase{TColor}"/>.
         /// </summary>
         /// <typeparam name="TColor">The pixel format.</typeparam>
+        /// <param name="configuration">The configuration for the image.</param>
         /// <param name="stream">The <see cref="Stream"/> containing image data.</param>
         /// <param name="options">The options for the decoder.</param>
-        /// <param name="configuration">The configuration for the image.</param>
         /// <returns>The decoded image.</returns>
-        public Image<TColor> Decode<TColor>(Stream stream, IPngDecoderOptions options, Configuration configuration)
+        public Image<TColor> Decode<TColor>(Configuration configuration, Stream stream, IPngDecoderOptions options)
             where TColor : struct, IPixel<TColor>
         {
             return new PngDecoderCore(options, configuration).Decode<TColor>(stream);

--- a/src/ImageSharp/Formats/Png/PngDecoder.cs
+++ b/src/ImageSharp/Formats/Png/PngDecoder.cs
@@ -31,25 +31,25 @@ namespace ImageSharp.Formats
     public class PngDecoder : IImageDecoder
     {
         /// <inheritdoc/>
-        public void Decode<TColor>(Image<TColor> image, Stream stream, IDecoderOptions options)
+        public Image<TColor> Decode<TColor>(Stream stream, IDecoderOptions options)
             where TColor : struct, IPixel<TColor>
         {
             IPngDecoderOptions pngOptions = PngDecoderOptions.Create(options);
 
-            this.Decode(image, stream, pngOptions);
+            return this.Decode<TColor>(stream, pngOptions);
         }
 
         /// <summary>
         /// Decodes the image from the specified stream to the <see cref="ImageBase{TColor}"/>.
         /// </summary>
         /// <typeparam name="TColor">The pixel format.</typeparam>
-        /// <param name="image">The <see cref="ImageBase{TColor}"/> to decode to.</param>
         /// <param name="stream">The <see cref="Stream"/> containing image data.</param>
         /// <param name="options">The options for the decoder.</param>
-        public void Decode<TColor>(Image<TColor> image, Stream stream, IPngDecoderOptions options)
+        /// <returns>The decoded image.</returns>
+        public Image<TColor> Decode<TColor>(Stream stream, IPngDecoderOptions options)
             where TColor : struct, IPixel<TColor>
         {
-            new PngDecoderCore(options).Decode(image, stream);
+            return new PngDecoderCore(options).Decode<TColor>(stream);
         }
     }
 }

--- a/src/ImageSharp/Formats/Png/PngDecoder.cs
+++ b/src/ImageSharp/Formats/Png/PngDecoder.cs
@@ -31,12 +31,13 @@ namespace ImageSharp.Formats
     public class PngDecoder : IImageDecoder
     {
         /// <inheritdoc/>
-        public Image<TColor> Decode<TColor>(Stream stream, IDecoderOptions options)
+        public Image<TColor> Decode<TColor>(Stream stream, IDecoderOptions options, Configuration configuration)
+
             where TColor : struct, IPixel<TColor>
         {
             IPngDecoderOptions pngOptions = PngDecoderOptions.Create(options);
 
-            return this.Decode<TColor>(stream, pngOptions);
+            return this.Decode<TColor>(stream, pngOptions, configuration);
         }
 
         /// <summary>
@@ -45,11 +46,12 @@ namespace ImageSharp.Formats
         /// <typeparam name="TColor">The pixel format.</typeparam>
         /// <param name="stream">The <see cref="Stream"/> containing image data.</param>
         /// <param name="options">The options for the decoder.</param>
+        /// <param name="configuration">The configuration for the image.</param>
         /// <returns>The decoded image.</returns>
-        public Image<TColor> Decode<TColor>(Stream stream, IPngDecoderOptions options)
+        public Image<TColor> Decode<TColor>(Stream stream, IPngDecoderOptions options, Configuration configuration)
             where TColor : struct, IPixel<TColor>
         {
-            return new PngDecoderCore(options).Decode<TColor>(stream);
+            return new PngDecoderCore(options, configuration).Decode<TColor>(stream);
         }
     }
 }

--- a/src/ImageSharp/Formats/Png/PngDecoderCore.cs
+++ b/src/ImageSharp/Formats/Png/PngDecoderCore.cs
@@ -75,6 +75,11 @@ namespace ImageSharp.Formats
         private readonly Crc32 crc = new Crc32();
 
         /// <summary>
+        /// The global configuration.
+        /// </summary>
+        private readonly Configuration configuration;
+
+        /// <summary>
         /// The stream to decode from.
         /// </summary>
         private Stream currentStream;
@@ -134,8 +139,10 @@ namespace ImageSharp.Formats
         /// Initializes a new instance of the <see cref="PngDecoderCore"/> class.
         /// </summary>
         /// <param name="options">The decoder options.</param>
-        public PngDecoderCore(IPngDecoderOptions options)
+        /// <param name="configuration">The configuration.</param>
+        public PngDecoderCore(IPngDecoderOptions options, Configuration configuration)
         {
+            this.configuration = configuration ?? Configuration.Default;
             this.options = options ?? new PngDecoderOptions();
         }
 
@@ -213,7 +220,7 @@ namespace ImageSharp.Formats
                     throw new ArgumentOutOfRangeException($"The input png '{this.header.Width}x{this.header.Height}' is bigger than the max allowed size '{Image<TColor>.MaxWidth}x{Image<TColor>.MaxHeight}'");
                 }
 
-                Image<TColor> image = new Image<TColor>(this.header.Width, this.header.Height);
+                Image<TColor> image = Image.Create<TColor>(this.header.Width, this.header.Height, this.configuration);
                 image.MetaData.LoadFrom(metadata);
 
                 using (PixelAccessor<TColor> pixels = image.Lock())

--- a/src/ImageSharp/Formats/Png/PngDecoderCore.cs
+++ b/src/ImageSharp/Formats/Png/PngDecoderCore.cs
@@ -220,8 +220,7 @@ namespace ImageSharp.Formats
                     throw new ArgumentOutOfRangeException($"The input png '{this.header.Width}x{this.header.Height}' is bigger than the max allowed size '{Image<TColor>.MaxWidth}x{Image<TColor>.MaxHeight}'");
                 }
 
-                Image<TColor> image = Image.Create<TColor>(this.header.Width, this.header.Height, this.configuration);
-                image.MetaData.LoadFrom(metadata);
+                Image<TColor> image = Image.Create<TColor>(this.header.Width, this.header.Height, metadata, this.configuration);
 
                 using (PixelAccessor<TColor> pixels = image.Lock())
                 {

--- a/src/ImageSharp/Formats/Png/PngDecoderCore.cs
+++ b/src/ImageSharp/Formats/Png/PngDecoderCore.cs
@@ -148,7 +148,6 @@ namespace ImageSharp.Formats
         /// Decodes the stream to the image.
         /// </summary>
         /// <typeparam name="TColor">The pixel format.</typeparam>
-        /// <param name="image">The image to decode to.</param>
         /// <param name="stream">The stream containing image data. </param>
         /// <exception cref="ImageFormatException">
         /// Thrown if the stream does not contain and end chunk.
@@ -156,10 +155,11 @@ namespace ImageSharp.Formats
         /// <exception cref="System.ArgumentOutOfRangeException">
         /// Thrown if the image is larger than the maximum allowable size.
         /// </exception>
-        public void Decode<TColor>(Image<TColor> image, Stream stream)
+        /// <returns>The decoded image</returns>
+        public Image<TColor> Decode<TColor>(Stream stream)
             where TColor : struct, IPixel<TColor>
         {
-            Image<TColor> currentImage = image;
+            ImageMetaData metadata = new ImageMetaData();
             this.currentStream = stream;
             this.currentStream.Skip(8);
 
@@ -177,7 +177,7 @@ namespace ImageSharp.Formats
                                 this.ValidateHeader();
                                 break;
                             case PngChunkTypes.Physical:
-                                this.ReadPhysicalChunk(currentImage, currentChunk.Data);
+                                this.ReadPhysicalChunk(metadata, currentChunk.Data);
                                 break;
                             case PngChunkTypes.Data:
                                 dataStream.Write(currentChunk.Data, 0, currentChunk.Length);
@@ -186,7 +186,7 @@ namespace ImageSharp.Formats
                                 byte[] pal = new byte[currentChunk.Length];
                                 Buffer.BlockCopy(currentChunk.Data, 0, pal, 0, currentChunk.Length);
                                 this.palette = pal;
-                                image.MetaData.Quality = pal.Length / 3;
+                                metadata.Quality = pal.Length / 3;
                                 break;
                             case PngChunkTypes.PaletteAlpha:
                                 byte[] alpha = new byte[currentChunk.Length];
@@ -194,7 +194,7 @@ namespace ImageSharp.Formats
                                 this.paletteAlpha = alpha;
                                 break;
                             case PngChunkTypes.Text:
-                                this.ReadTextChunk(currentImage, currentChunk.Data, currentChunk.Length);
+                                this.ReadTextChunk(metadata, currentChunk.Data, currentChunk.Length);
                                 break;
                             case PngChunkTypes.End:
                                 this.isEndChunkReached = true;
@@ -208,17 +208,20 @@ namespace ImageSharp.Formats
                     }
                 }
 
-                if (this.header.Width > image.MaxWidth || this.header.Height > image.MaxHeight)
+                if (this.header.Width > Image<TColor>.MaxWidth || this.header.Height > Image<TColor>.MaxHeight)
                 {
-                    throw new ArgumentOutOfRangeException($"The input png '{this.header.Width}x{this.header.Height}' is bigger than the max allowed size '{image.MaxWidth}x{image.MaxHeight}'");
+                    throw new ArgumentOutOfRangeException($"The input png '{this.header.Width}x{this.header.Height}' is bigger than the max allowed size '{Image<TColor>.MaxWidth}x{Image<TColor>.MaxHeight}'");
                 }
 
-                image.InitPixels(this.header.Width, this.header.Height);
+                Image<TColor> image = new Image<TColor>(this.header.Width, this.header.Height);
+                image.MetaData.LoadFrom(metadata);
 
                 using (PixelAccessor<TColor> pixels = image.Lock())
                 {
                     this.ReadScanlines(dataStream, pixels);
                 }
+
+                return image;
             }
         }
 
@@ -270,18 +273,16 @@ namespace ImageSharp.Formats
         /// <summary>
         /// Reads the data chunk containing physical dimension data.
         /// </summary>
-        /// <typeparam name="TColor">The pixel format.</typeparam>
-        /// <param name="image">The image to read to.</param>
+        /// <param name="metadata">The metadata to read to.</param>
         /// <param name="data">The data containing physical data.</param>
-        private void ReadPhysicalChunk<TColor>(Image<TColor> image, byte[] data)
-            where TColor : struct, IPixel<TColor>
+        private void ReadPhysicalChunk(ImageMetaData metadata, byte[] data)
         {
             data.ReverseBytes(0, 4);
             data.ReverseBytes(4, 4);
 
             // 39.3700787 = inches in a meter.
-            image.MetaData.HorizontalResolution = BitConverter.ToInt32(data, 0) / 39.3700787d;
-            image.MetaData.VerticalResolution = BitConverter.ToInt32(data, 4) / 39.3700787d;
+            metadata.HorizontalResolution = BitConverter.ToInt32(data, 0) / 39.3700787d;
+            metadata.VerticalResolution = BitConverter.ToInt32(data, 4) / 39.3700787d;
         }
 
         /// <summary>
@@ -768,12 +769,10 @@ namespace ImageSharp.Formats
         /// <summary>
         /// Reads a text chunk containing image properties from the data.
         /// </summary>
-        /// <typeparam name="TColor">The pixel format.</typeparam>
-        /// <param name="image">The image to decode to.</param>
+        /// <param name="metadata">The metadata to decode to.</param>
         /// <param name="data">The <see cref="T:byte[]"/> containing  data.</param>
         /// <param name="length">The maximum length to read.</param>
-        private void ReadTextChunk<TColor>(Image<TColor> image, byte[] data, int length)
-            where TColor : struct, IPixel<TColor>
+        private void ReadTextChunk(ImageMetaData metadata, byte[] data, int length)
         {
             if (this.options.IgnoreMetadata)
             {
@@ -794,7 +793,7 @@ namespace ImageSharp.Formats
             string name = this.options.TextEncoding.GetString(data, 0, zeroIndex);
             string value = this.options.TextEncoding.GetString(data, zeroIndex + 1, length - zeroIndex - 1);
 
-            image.MetaData.Properties.Add(new ImageProperty(name, value));
+            metadata.Properties.Add(new ImageProperty(name, value));
         }
 
         /// <summary>

--- a/src/ImageSharp/Image.Create.cs
+++ b/src/ImageSharp/Image.Create.cs
@@ -1,0 +1,46 @@
+﻿// <copyright file="Image.cs" company="James Jackson-South">
+// Copyright (c) James Jackson-South and contributors.
+// Licensed under the Apache License, Version 2.0.
+// </copyright>
+
+namespace ImageSharp
+{
+    using System;
+    using System.Diagnostics;
+    using System.IO;
+
+    using Formats;
+
+    /// <summary>
+    /// Represents an image. Each pixel is a made up four 8-bit components red, green, blue, and alpha
+    /// packed into a single unsigned integer value.
+    /// </summary>
+    public sealed partial class Image
+    {
+        /// <summary>
+        /// Create a new instance of the <see cref="Image{TColor}"/> class
+        /// with the height and the width of the image.
+        /// </summary>
+        /// <typeparam name="TColor">The pixel format.</typeparam>
+        /// <param name="width">The width of the image in pixels.</param>
+        /// <param name="height">The height of the image in pixels.</param>
+        /// <param name="configuration">
+        /// The configuration providing initialization code which allows extending the library.
+        /// </param>
+        /// <returns>
+        /// A new <see cref="Image{TColor}"/> unless <typeparamref name="TColor"/> is <see cref="Color"/> in which case it returns <see cref="Image" />
+        /// </returns>
+        internal static Image<TColor> Create<TColor>(int width, int height, Configuration configuration)
+            where TColor : struct, IPixel<TColor>
+        {
+            if (typeof(TColor) == typeof(Color))
+            {
+                return new Image(width, height, configuration) as Image<TColor>;
+            }
+            else
+            {
+                return new Image<TColor>(width, height, configuration);
+            }
+        }
+    }
+}

--- a/src/ImageSharp/Image.Create.cs
+++ b/src/ImageSharp/Image.Create.cs
@@ -24,6 +24,33 @@ namespace ImageSharp
         /// <typeparam name="TColor">The pixel format.</typeparam>
         /// <param name="width">The width of the image in pixels.</param>
         /// <param name="height">The height of the image in pixels.</param>
+        /// <param name="metadata">The images matadata to preload.</param>
+        /// <param name="configuration">
+        /// The configuration providing initialization code which allows extending the library.
+        /// </param>
+        /// <returns>
+        /// A new <see cref="Image{TColor}"/> unless <typeparamref name="TColor"/> is <see cref="Color"/> in which case it returns <see cref="Image" />
+        /// </returns>
+        internal static Image<TColor> Create<TColor>(int width, int height, ImageMetaData metadata, Configuration configuration)
+            where TColor : struct, IPixel<TColor>
+        {
+            if (typeof(TColor) == typeof(Color))
+            {
+                return new Image(width, height, metadata, configuration) as Image<TColor>;
+            }
+            else
+            {
+                return new Image<TColor>(width, height, metadata, configuration);
+            }
+        }
+
+        /// <summary>
+        /// Create a new instance of the <see cref="Image{TColor}"/> class
+        /// with the height and the width of the image.
+        /// </summary>
+        /// <typeparam name="TColor">The pixel format.</typeparam>
+        /// <param name="width">The width of the image in pixels.</param>
+        /// <param name="height">The height of the image in pixels.</param>
         /// <param name="configuration">
         /// The configuration providing initialization code which allows extending the library.
         /// </param>
@@ -33,14 +60,7 @@ namespace ImageSharp
         internal static Image<TColor> Create<TColor>(int width, int height, Configuration configuration)
             where TColor : struct, IPixel<TColor>
         {
-            if (typeof(TColor) == typeof(Color))
-            {
-                return new Image(width, height, configuration) as Image<TColor>;
-            }
-            else
-            {
-                return new Image<TColor>(width, height, configuration);
-            }
+            return Image.Create<TColor>(width, height, null, configuration);
         }
     }
 }

--- a/src/ImageSharp/Image.Decode.cs
+++ b/src/ImageSharp/Image.Decode.cs
@@ -19,7 +19,7 @@ namespace ImageSharp
     /// </summary>
     public sealed partial class Image
     {
-        private static IImageFormat DiscoverFormat(Stream stream, IDecoderOptions options, Configuration config)
+        private static IImageFormat DiscoverFormat(Stream stream, Configuration config)
         {
             int maxHeaderSize = config.MaxHeaderSize;
             if (maxHeaderSize <= 0)
@@ -57,13 +57,13 @@ namespace ImageSharp
         private static Image<TColor> Decode<TColor>(Stream stream, IDecoderOptions options, Configuration config)
         where TColor : struct, IPixel<TColor>
         {
-            IImageFormat format = DiscoverFormat(stream, options, config);
+            IImageFormat format = DiscoverFormat(stream, config);
             if (format == null)
             {
                 return null;
             }
 
-            Image<TColor> img = format.Decoder.Decode<TColor>(stream, options);
+            Image<TColor> img = format.Decoder.Decode<TColor>(stream, options, config);
             img.CurrentImageFormat = format;
             return img;
         }

--- a/src/ImageSharp/Image.Decode.cs
+++ b/src/ImageSharp/Image.Decode.cs
@@ -67,7 +67,7 @@ namespace ImageSharp
                 return null;
             }
 
-            Image<TColor> img = format.Decoder.Decode<TColor>(stream, options, config);
+            Image<TColor> img = format.Decoder.Decode<TColor>(config, stream, options);
             img.CurrentImageFormat = format;
             return img;
         }

--- a/src/ImageSharp/Image.Decode.cs
+++ b/src/ImageSharp/Image.Decode.cs
@@ -5,12 +5,9 @@
 
 namespace ImageSharp
 {
-    using System;
     using System.Buffers;
-    using System.Diagnostics;
     using System.IO;
     using System.Linq;
-    using System.Text;
     using Formats;
 
     /// <summary>
@@ -19,8 +16,15 @@ namespace ImageSharp
     /// </summary>
     public sealed partial class Image
     {
+        /// <summary>
+        /// By reading the header on the provided stream this calculates the images format.
+        /// </summary>
+        /// <param name="stream">The image stream to read the header from.</param>
+        /// <param name="config">The configuration.</param>
+        /// <returns>The image format or null if none found.</returns>
         private static IImageFormat DiscoverFormat(Stream stream, Configuration config)
         {
+            // This is probably a candidate for making into a public API in the future!
             int maxHeaderSize = config.MaxHeaderSize;
             if (maxHeaderSize <= 0)
             {

--- a/src/ImageSharp/Image.Decode.cs
+++ b/src/ImageSharp/Image.Decode.cs
@@ -1,0 +1,67 @@
+﻿// <copyright file="Image.Decode.cs" company="James Jackson-South">
+// Copyright (c) James Jackson-South and contributors.
+// Licensed under the Apache License, Version 2.0.
+// </copyright>
+
+namespace ImageSharp
+{
+    using System;
+    using System.Buffers;
+    using System.Diagnostics;
+    using System.IO;
+    using System.Linq;
+    using System.Text;
+    using Formats;
+
+    /// <summary>
+    /// Represents an image. Each pixel is a made up four 8-bit components red, green, blue, and alpha
+    /// packed into a single unsigned integer value.
+    /// </summary>
+    public sealed partial class Image
+    {
+        /// <summary>
+        /// Decodes the image stream to the current image.
+        /// </summary>
+        /// <typeparam name="TColor">The pixel format.</typeparam>
+        /// <param name="stream">The stream.</param>
+        /// <param name="options">The options for the decoder.</param>
+        /// <param name="config">the configuration.</param>
+        /// <param name="img">The decoded image</param>
+        /// <returns>
+        ///  [true] if can successfull decode the image otherwise [false].
+        /// </returns>
+        private static bool Decode<TColor>(Stream stream, IDecoderOptions options, Configuration config, out Image<TColor> img)
+            where TColor : struct, IPixel<TColor>
+        {
+            img = null;
+            int maxHeaderSize = config.MaxHeaderSize;
+            if (maxHeaderSize <= 0)
+            {
+                return false;
+            }
+
+            IImageFormat format;
+            byte[] header = ArrayPool<byte>.Shared.Rent(maxHeaderSize);
+            try
+            {
+                long startPosition = stream.Position;
+                stream.Read(header, 0, maxHeaderSize);
+                stream.Position = startPosition;
+                format = config.ImageFormats.FirstOrDefault(x => x.IsSupportedFileFormat(header));
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(header);
+            }
+
+            if (format == null)
+            {
+                return false;
+            }
+
+            img = format.Decoder.Decode<TColor>(stream, options);
+            img.CurrentImageFormat = format;
+            return true;
+        }
+    }
+}

--- a/src/ImageSharp/Image.FromBytes.cs
+++ b/src/ImageSharp/Image.FromBytes.cs
@@ -25,7 +25,7 @@ namespace ImageSharp
         /// <returns>The image</returns>
         public static Image Load(byte[] data)
         {
-            return Load(data, null, (Configuration)null);
+            return Load(null, data, null);
         }
 
         /// <summary>
@@ -39,21 +39,21 @@ namespace ImageSharp
         /// <returns>The image</returns>
         public static Image Load(byte[] data, IDecoderOptions options)
         {
-            return Load(data, options, null);
+            return Load(null, data, options);
         }
 
         /// <summary>
         /// Loads the image from the given byte array.
         /// </summary>
-        /// <param name="data">The byte array containing image data.</param>
         /// <param name="config">The config for the decoder.</param>
+        /// <param name="data">The byte array containing image data.</param>
         /// <exception cref="NotSupportedException">
         /// Thrown if the stream is not readable nor seekable.
         /// </exception>
         /// <returns>The image</returns>
-        public static Image Load(byte[] data, Configuration config)
+        public static Image Load(Configuration config, byte[] data)
         {
-            return Load(data, null, config);
+            return Load(config, data, null);
         }
 
         /// <summary>
@@ -73,18 +73,18 @@ namespace ImageSharp
         /// <summary>
         /// Loads the image from the given byte array.
         /// </summary>
+        /// <param name="config">The configuration options.</param>
         /// <param name="data">The byte array containing image data.</param>
         /// <param name="options">The options for the decoder.</param>
-        /// <param name="config">The configuration options.</param>
         /// <exception cref="NotSupportedException">
         /// Thrown if the stream is not readable nor seekable.
         /// </exception>
         /// <returns>The image</returns>
-        public static Image Load(byte[] data, IDecoderOptions options, Configuration config)
+        public static Image Load(Configuration config, byte[] data, IDecoderOptions options)
         {
             using (MemoryStream ms = new MemoryStream(data))
             {
-                return Load(ms, options, config);
+                return Load(config, ms, options);
             }
         }
 
@@ -118,7 +118,7 @@ namespace ImageSharp
         public static Image<TColor> Load<TColor>(byte[] data)
             where TColor : struct, IPixel<TColor>
         {
-            return Load<TColor>(data, null, (Configuration)null);
+            return Load<TColor>(null, data, null);
         }
 
         /// <summary>
@@ -134,23 +134,23 @@ namespace ImageSharp
         public static Image<TColor> Load<TColor>(byte[] data, IDecoderOptions options)
             where TColor : struct, IPixel<TColor>
         {
-            return Load<TColor>(data, options, null);
+            return Load<TColor>(null, data, options);
         }
 
         /// <summary>
         /// Loads the image from the given byte array.
         /// </summary>
         /// <typeparam name="TColor">The pixel format.</typeparam>
-        /// <param name="data">The byte array containing image data.</param>
         /// <param name="config">The config for the decoder.</param>
+        /// <param name="data">The byte array containing image data.</param>
         /// <exception cref="NotSupportedException">
         /// Thrown if the stream is not readable nor seekable.
         /// </exception>
         /// <returns>The image</returns>
-        public static Image<TColor> Load<TColor>(byte[] data, Configuration config)
+        public static Image<TColor> Load<TColor>(Configuration config, byte[] data)
             where TColor : struct, IPixel<TColor>
         {
-            return Load<TColor>(data, null, config);
+            return Load<TColor>(config, data, null);
         }
 
         /// <summary>
@@ -173,19 +173,19 @@ namespace ImageSharp
         /// Loads the image from the given byte array.
         /// </summary>
         /// <typeparam name="TColor">The pixel format.</typeparam>
+        /// <param name="config">The configuration options.</param>
         /// <param name="data">The byte array containing image data.</param>
         /// <param name="options">The options for the decoder.</param>
-        /// <param name="config">The configuration options.</param>
         /// <exception cref="NotSupportedException">
         /// Thrown if the stream is not readable nor seekable.
         /// </exception>
         /// <returns>The image</returns>
-        public static Image<TColor> Load<TColor>(byte[] data, IDecoderOptions options, Configuration config)
+        public static Image<TColor> Load<TColor>(Configuration config, byte[] data, IDecoderOptions options)
             where TColor : struct, IPixel<TColor>
         {
             using (MemoryStream ms = new MemoryStream(data))
             {
-                return Load<TColor>(ms, options, config);
+                return Load<TColor>(config, ms, options);
             }
         }
 

--- a/src/ImageSharp/Image.FromBytes.cs
+++ b/src/ImageSharp/Image.FromBytes.cs
@@ -1,0 +1,148 @@
+﻿// <copyright file="Image.FromStream.cs" company="James Jackson-South">
+// Copyright (c) James Jackson-South and contributors.
+// Licensed under the Apache License, Version 2.0.
+// </copyright>
+
+namespace ImageSharp
+{
+    using System;
+    using System.Buffers;
+    using System.Diagnostics;
+    using System.IO;
+    using System.Linq;
+    using System.Text;
+    using Formats;
+
+    /// <summary>
+    /// Represents an image. Each pixel is a made up four 8-bit components red, green, blue, and alpha
+    /// packed into a single unsigned integer value.
+    /// </summary>
+    public sealed partial class Image
+    {
+        /// <summary>
+        /// Loads the image from the given stream.
+        /// </summary>
+        /// <param name="stream">The stream containing image information.</param>
+        /// <exception cref="NotSupportedException">
+        /// Thrown if the stream is not readable nor seekable.
+        /// </exception>
+        /// <returns>The image</returns>
+        public static Image Load(byte[] stream)
+        {
+            return Load(stream, null, null);
+        }
+
+        /// <summary>
+        /// Loads the image from the given stream.
+        /// </summary>
+        /// <param name="stream">The stream containing image information.</param>
+        /// <param name="options">The options for the decoder.</param>
+        /// <exception cref="NotSupportedException">
+        /// Thrown if the stream is not readable nor seekable.
+        /// </exception>
+        /// <returns>The image</returns>
+        public static Image Load(byte[] stream, IDecoderOptions options)
+        {
+            return Load(stream, options, null);
+        }
+
+        /// <summary>
+        /// Loads the image from the given stream.
+        /// </summary>
+        /// <param name="stream">The stream containing image information.</param>
+        /// <param name="config">The config for the decoder.</param>
+        /// <exception cref="NotSupportedException">
+        /// Thrown if the stream is not readable nor seekable.
+        /// </exception>
+        /// <returns>The image</returns>
+        public static Image Load(byte[] stream, Configuration config)
+        {
+            return Load(stream, null, config);
+        }
+
+        /// <summary>
+        /// Loads the image from the given stream.
+        /// </summary>
+        /// <param name="stream">The stream containing image information.</param>
+        /// <param name="options">The options for the decoder.</param>
+        /// <param name="config">The configuration options.</param>
+        /// <exception cref="NotSupportedException">
+        /// Thrown if the stream is not readable nor seekable.
+        /// </exception>
+        /// <returns>The image</returns>
+        public static Image Load(byte[] stream, IDecoderOptions options, Configuration config)
+        {
+            using (MemoryStream ms = new MemoryStream(stream))
+            {
+                return Load(ms, options, config);
+            }
+        }
+
+        /// <summary>
+        /// Loads the image from the given stream.
+        /// </summary>
+        /// <typeparam name="TColor">The pixel format.</typeparam>
+        /// <param name="stream">The stream containing image information.</param>
+        /// <exception cref="NotSupportedException">
+        /// Thrown if the stream is not readable nor seekable.
+        /// </exception>
+        /// <returns>The image</returns>
+        public static Image<TColor> Load<TColor>(byte[] stream)
+            where TColor : struct, IPixel<TColor>
+        {
+            return Load<TColor>(stream, null, null);
+        }
+
+        /// <summary>
+        /// Loads the image from the given stream.
+        /// </summary>
+        /// <typeparam name="TColor">The pixel format.</typeparam>
+        /// <param name="stream">The stream containing image information.</param>
+        /// <param name="options">The options for the decoder.</param>
+        /// <exception cref="NotSupportedException">
+        /// Thrown if the stream is not readable nor seekable.
+        /// </exception>
+        /// <returns>The image</returns>
+        public static Image<TColor> Load<TColor>(byte[] stream, IDecoderOptions options)
+            where TColor : struct, IPixel<TColor>
+        {
+            return Load<TColor>(stream, options, null);
+        }
+
+        /// <summary>
+        /// Loads the image from the given stream.
+        /// </summary>
+        /// <typeparam name="TColor">The pixel format.</typeparam>
+        /// <param name="stream">The stream containing image information.</param>
+        /// <param name="config">The config for the decoder.</param>
+        /// <exception cref="NotSupportedException">
+        /// Thrown if the stream is not readable nor seekable.
+        /// </exception>
+        /// <returns>The image</returns>
+        public static Image<TColor> Load<TColor>(byte[] stream, Configuration config)
+            where TColor : struct, IPixel<TColor>
+        {
+            return Load<TColor>(stream, null, config);
+        }
+
+        /// <summary>
+        /// Loads the image from the given stream.
+        /// </summary>
+        /// <typeparam name="TColor">The pixel format.</typeparam>
+        /// <param name="stream">The stream containing image information.</param>
+        /// <param name="options">The options for the decoder.</param>
+        /// <param name="config">The configuration options.</param>
+        /// <exception cref="NotSupportedException">
+        /// Thrown if the stream is not readable nor seekable.
+        /// </exception>
+        /// <returns>The image</returns>
+        public static Image<TColor> Load<TColor>(byte[] stream, IDecoderOptions options, Configuration config)
+            where TColor : struct, IPixel<TColor>
+        {
+            using (MemoryStream ms = new MemoryStream(stream))
+            {
+                return Load<TColor>(ms, options, config);
+            }
+        }
+    }
+}

--- a/src/ImageSharp/Image.FromBytes.cs
+++ b/src/ImageSharp/Image.FromBytes.cs
@@ -29,7 +29,7 @@ namespace ImageSharp
         /// <returns>The image</returns>
         public static Image Load(byte[] data)
         {
-            return Load(data, null, null);
+            return Load(data, null, (Configuration)null);
         }
 
         /// <summary>
@@ -64,6 +64,20 @@ namespace ImageSharp
         /// Loads the image from the given byte array.
         /// </summary>
         /// <param name="data">The byte array containing image data.</param>
+        /// <param name="decoder">The decoder.</param>
+        /// <exception cref="NotSupportedException">
+        /// Thrown if the stream is not readable nor seekable.
+        /// </exception>
+        /// <returns>The image</returns>
+        public static Image Load(byte[] data, IImageDecoder decoder)
+        {
+            return Load(data, decoder, null);
+        }
+
+        /// <summary>
+        /// Loads the image from the given byte array.
+        /// </summary>
+        /// <param name="data">The byte array containing image data.</param>
         /// <param name="options">The options for the decoder.</param>
         /// <param name="config">The configuration options.</param>
         /// <exception cref="NotSupportedException">
@@ -81,6 +95,24 @@ namespace ImageSharp
         /// <summary>
         /// Loads the image from the given byte array.
         /// </summary>
+        /// <param name="data">The byte array containing image data.</param>
+        /// <param name="decoder">The decoder.</param>
+        /// <param name="options">The options for the decoder.</param>
+        /// <exception cref="NotSupportedException">
+        /// Thrown if the stream is not readable nor seekable.
+        /// </exception>
+        /// <returns>The image</returns>
+        public static Image Load(byte[] data, IImageDecoder decoder, IDecoderOptions options)
+        {
+            using (MemoryStream ms = new MemoryStream(data))
+            {
+                return Load(ms, decoder, options);
+            }
+        }
+
+        /// <summary>
+        /// Loads the image from the given byte array.
+        /// </summary>
         /// <typeparam name="TColor">The pixel format.</typeparam>
         /// <param name="data">The byte array containing image data.</param>
         /// <exception cref="NotSupportedException">
@@ -90,7 +122,7 @@ namespace ImageSharp
         public static Image<TColor> Load<TColor>(byte[] data)
             where TColor : struct, IPixel<TColor>
         {
-            return Load<TColor>(data, null, null);
+            return Load<TColor>(data, null, (Configuration)null);
         }
 
         /// <summary>
@@ -130,6 +162,22 @@ namespace ImageSharp
         /// </summary>
         /// <typeparam name="TColor">The pixel format.</typeparam>
         /// <param name="data">The byte array containing image data.</param>
+        /// <param name="decoder">The decoder.</param>
+        /// <exception cref="NotSupportedException">
+        /// Thrown if the stream is not readable nor seekable.
+        /// </exception>
+        /// <returns>The image</returns>
+        public static Image<TColor> Load<TColor>(byte[] data, IImageDecoder decoder)
+            where TColor : struct, IPixel<TColor>
+        {
+            return Load<TColor>(data, decoder, null);
+        }
+
+        /// <summary>
+        /// Loads the image from the given byte array.
+        /// </summary>
+        /// <typeparam name="TColor">The pixel format.</typeparam>
+        /// <param name="data">The byte array containing image data.</param>
         /// <param name="options">The options for the decoder.</param>
         /// <param name="config">The configuration options.</param>
         /// <exception cref="NotSupportedException">
@@ -142,6 +190,26 @@ namespace ImageSharp
             using (MemoryStream ms = new MemoryStream(data))
             {
                 return Load<TColor>(ms, options, config);
+            }
+        }
+
+        /// <summary>
+        /// Loads the image from the given byte array.
+        /// </summary>
+        /// <typeparam name="TColor">The pixel format.</typeparam>
+        /// <param name="data">The byte array containing image data.</param>
+        /// <param name="decoder">The decoder.</param>
+        /// <param name="options">The options for the decoder.</param>
+        /// <exception cref="NotSupportedException">
+        /// Thrown if the stream is not readable nor seekable.
+        /// </exception>
+        /// <returns>The image</returns>
+        public static Image<TColor> Load<TColor>(byte[] data, IImageDecoder decoder, IDecoderOptions options)
+            where TColor : struct, IPixel<TColor>
+        {
+            using (MemoryStream ms = new MemoryStream(data))
+            {
+                return Load<TColor>(ms, decoder, options);
             }
         }
     }

--- a/src/ImageSharp/Image.FromBytes.cs
+++ b/src/ImageSharp/Image.FromBytes.cs
@@ -20,126 +20,126 @@ namespace ImageSharp
     public sealed partial class Image
     {
         /// <summary>
-        /// Loads the image from the given stream.
+        /// Loads the image from the given byte array.
         /// </summary>
-        /// <param name="stream">The stream containing image information.</param>
+        /// <param name="data">The byte array containing image data.</param>
         /// <exception cref="NotSupportedException">
         /// Thrown if the stream is not readable nor seekable.
         /// </exception>
         /// <returns>The image</returns>
-        public static Image Load(byte[] stream)
+        public static Image Load(byte[] data)
         {
-            return Load(stream, null, null);
+            return Load(data, null, null);
         }
 
         /// <summary>
-        /// Loads the image from the given stream.
+        /// Loads the image from the given byte array.
         /// </summary>
-        /// <param name="stream">The stream containing image information.</param>
+        /// <param name="data">The byte array containing image data.</param>
         /// <param name="options">The options for the decoder.</param>
         /// <exception cref="NotSupportedException">
         /// Thrown if the stream is not readable nor seekable.
         /// </exception>
         /// <returns>The image</returns>
-        public static Image Load(byte[] stream, IDecoderOptions options)
+        public static Image Load(byte[] data, IDecoderOptions options)
         {
-            return Load(stream, options, null);
+            return Load(data, options, null);
         }
 
         /// <summary>
-        /// Loads the image from the given stream.
+        /// Loads the image from the given byte array.
         /// </summary>
-        /// <param name="stream">The stream containing image information.</param>
+        /// <param name="data">The byte array containing image data.</param>
         /// <param name="config">The config for the decoder.</param>
         /// <exception cref="NotSupportedException">
         /// Thrown if the stream is not readable nor seekable.
         /// </exception>
         /// <returns>The image</returns>
-        public static Image Load(byte[] stream, Configuration config)
+        public static Image Load(byte[] data, Configuration config)
         {
-            return Load(stream, null, config);
+            return Load(data, null, config);
         }
 
         /// <summary>
-        /// Loads the image from the given stream.
+        /// Loads the image from the given byte array.
         /// </summary>
-        /// <param name="stream">The stream containing image information.</param>
+        /// <param name="data">The byte array containing image data.</param>
         /// <param name="options">The options for the decoder.</param>
         /// <param name="config">The configuration options.</param>
         /// <exception cref="NotSupportedException">
         /// Thrown if the stream is not readable nor seekable.
         /// </exception>
         /// <returns>The image</returns>
-        public static Image Load(byte[] stream, IDecoderOptions options, Configuration config)
+        public static Image Load(byte[] data, IDecoderOptions options, Configuration config)
         {
-            using (MemoryStream ms = new MemoryStream(stream))
+            using (MemoryStream ms = new MemoryStream(data))
             {
                 return Load(ms, options, config);
             }
         }
 
         /// <summary>
-        /// Loads the image from the given stream.
+        /// Loads the image from the given byte array.
         /// </summary>
         /// <typeparam name="TColor">The pixel format.</typeparam>
-        /// <param name="stream">The stream containing image information.</param>
+        /// <param name="data">The byte array containing image data.</param>
         /// <exception cref="NotSupportedException">
         /// Thrown if the stream is not readable nor seekable.
         /// </exception>
         /// <returns>The image</returns>
-        public static Image<TColor> Load<TColor>(byte[] stream)
+        public static Image<TColor> Load<TColor>(byte[] data)
             where TColor : struct, IPixel<TColor>
         {
-            return Load<TColor>(stream, null, null);
+            return Load<TColor>(data, null, null);
         }
 
         /// <summary>
-        /// Loads the image from the given stream.
+        /// Loads the image from the given byte array.
         /// </summary>
         /// <typeparam name="TColor">The pixel format.</typeparam>
-        /// <param name="stream">The stream containing image information.</param>
+        /// <param name="data">The byte array containing image data.</param>
         /// <param name="options">The options for the decoder.</param>
         /// <exception cref="NotSupportedException">
         /// Thrown if the stream is not readable nor seekable.
         /// </exception>
         /// <returns>The image</returns>
-        public static Image<TColor> Load<TColor>(byte[] stream, IDecoderOptions options)
+        public static Image<TColor> Load<TColor>(byte[] data, IDecoderOptions options)
             where TColor : struct, IPixel<TColor>
         {
-            return Load<TColor>(stream, options, null);
+            return Load<TColor>(data, options, null);
         }
 
         /// <summary>
-        /// Loads the image from the given stream.
+        /// Loads the image from the given byte array.
         /// </summary>
         /// <typeparam name="TColor">The pixel format.</typeparam>
-        /// <param name="stream">The stream containing image information.</param>
+        /// <param name="data">The byte array containing image data.</param>
         /// <param name="config">The config for the decoder.</param>
         /// <exception cref="NotSupportedException">
         /// Thrown if the stream is not readable nor seekable.
         /// </exception>
         /// <returns>The image</returns>
-        public static Image<TColor> Load<TColor>(byte[] stream, Configuration config)
+        public static Image<TColor> Load<TColor>(byte[] data, Configuration config)
             where TColor : struct, IPixel<TColor>
         {
-            return Load<TColor>(stream, null, config);
+            return Load<TColor>(data, null, config);
         }
 
         /// <summary>
-        /// Loads the image from the given stream.
+        /// Loads the image from the given byte array.
         /// </summary>
         /// <typeparam name="TColor">The pixel format.</typeparam>
-        /// <param name="stream">The stream containing image information.</param>
+        /// <param name="data">The byte array containing image data.</param>
         /// <param name="options">The options for the decoder.</param>
         /// <param name="config">The configuration options.</param>
         /// <exception cref="NotSupportedException">
         /// Thrown if the stream is not readable nor seekable.
         /// </exception>
         /// <returns>The image</returns>
-        public static Image<TColor> Load<TColor>(byte[] stream, IDecoderOptions options, Configuration config)
+        public static Image<TColor> Load<TColor>(byte[] data, IDecoderOptions options, Configuration config)
             where TColor : struct, IPixel<TColor>
         {
-            using (MemoryStream ms = new MemoryStream(stream))
+            using (MemoryStream ms = new MemoryStream(data))
             {
                 return Load<TColor>(ms, options, config);
             }

--- a/src/ImageSharp/Image.FromBytes.cs
+++ b/src/ImageSharp/Image.FromBytes.cs
@@ -6,11 +6,7 @@
 namespace ImageSharp
 {
     using System;
-    using System.Buffers;
-    using System.Diagnostics;
     using System.IO;
-    using System.Linq;
-    using System.Text;
     using Formats;
 
     /// <summary>

--- a/src/ImageSharp/Image.FromFile.cs
+++ b/src/ImageSharp/Image.FromFile.cs
@@ -30,7 +30,7 @@ namespace ImageSharp
         /// <returns>The image</returns>
         public static Image Load(string path)
         {
-            return Load(path, null, null);
+            return Load(path, null, (Configuration)null);
         }
 
         /// <summary>
@@ -65,6 +65,35 @@ namespace ImageSharp
         /// Loads the image from the given file.
         /// </summary>
         /// <param name="path">The file path to the image.</param>
+        /// <param name="decoder">The decoder.</param>
+        /// <exception cref="NotSupportedException">
+        /// Thrown if the stream is not readable nor seekable.
+        /// </exception>
+        /// <returns>The image</returns>
+        public static Image Load(string path, IImageDecoder decoder)
+        {
+            return Load(path, decoder, null);
+        }
+
+        /// <summary>
+        /// Loads the image from the given file.
+        /// </summary>
+        /// <param name="path">The file path to the image.</param>
+        /// <param name="decoder">The decoder.</param>
+        /// <param name="options">The options for the decoder.</param>
+        /// <exception cref="NotSupportedException">
+        /// Thrown if the stream is not readable nor seekable.
+        /// </exception>
+        /// <returns>The image</returns>
+        public static Image Load(string path, IImageDecoder decoder, IDecoderOptions options)
+        {
+            return new Image(Load<Color>(path, decoder, options));
+        }
+
+        /// <summary>
+        /// Loads the image from the given file.
+        /// </summary>
+        /// <param name="path">The file path to the image.</param>
         /// <param name="options">The options for the decoder.</param>
         /// <param name="config">The configuration options.</param>
         /// <exception cref="NotSupportedException">
@@ -88,7 +117,7 @@ namespace ImageSharp
         public static Image<TColor> Load<TColor>(string path)
             where TColor : struct, IPixel<TColor>
         {
-            return Load<TColor>(path, null, null);
+            return Load<TColor>(path, null, (Configuration)null);
         }
 
         /// <summary>
@@ -128,6 +157,22 @@ namespace ImageSharp
         /// </summary>
         /// <typeparam name="TColor">The pixel format.</typeparam>
         /// <param name="path">The file path to the image.</param>
+        /// <param name="decoder">The decoder.</param>
+        /// <exception cref="NotSupportedException">
+        /// Thrown if the stream is not readable nor seekable.
+        /// </exception>
+        /// <returns>The image</returns>
+        public static Image<TColor> Load<TColor>(string path, IImageDecoder decoder)
+            where TColor : struct, IPixel<TColor>
+        {
+            return Load<TColor>(path, decoder, null);
+        }
+
+        /// <summary>
+        /// Loads the image from the given file.
+        /// </summary>
+        /// <typeparam name="TColor">The pixel format.</typeparam>
+        /// <param name="path">The file path to the image.</param>
         /// <param name="options">The options for the decoder.</param>
         /// <param name="config">The configuration options.</param>
         /// <exception cref="NotSupportedException">
@@ -141,6 +186,27 @@ namespace ImageSharp
             using (Stream s = config.FileSystem.OpenRead(path))
             {
                 return Load<TColor>(s, options, config);
+            }
+        }
+
+        /// <summary>
+        /// Loads the image from the given file.
+        /// </summary>
+        /// <typeparam name="TColor">The pixel format.</typeparam>
+        /// <param name="path">The file path to the image.</param>
+        /// <param name="decoder">The decoder.</param>
+        /// <param name="options">The options for the decoder.</param>
+        /// <exception cref="NotSupportedException">
+        /// Thrown if the stream is not readable nor seekable.
+        /// </exception>
+        /// <returns>The image</returns>
+        public static Image<TColor> Load<TColor>(string path, IImageDecoder decoder, IDecoderOptions options)
+            where TColor : struct, IPixel<TColor>
+        {
+            Configuration config = Configuration.Default;
+            using (Stream s = config.FileSystem.OpenRead(path))
+            {
+                return Load<TColor>(s, decoder, options);
             }
         }
     }

--- a/src/ImageSharp/Image.FromFile.cs
+++ b/src/ImageSharp/Image.FromFile.cs
@@ -21,124 +21,124 @@ namespace ImageSharp
     public sealed partial class Image
     {
         /// <summary>
-        /// Loads the image from the given stream.
+        /// Loads the image from the given file.
         /// </summary>
-        /// <param name="stream">The stream containing image information.</param>
+        /// <param name="path">The file path to the image.</param>
         /// <exception cref="NotSupportedException">
         /// Thrown if the stream is not readable nor seekable.
         /// </exception>
         /// <returns>The image</returns>
-        public static Image Load(string stream)
+        public static Image Load(string path)
         {
-            return Load(stream, null, null);
+            return Load(path, null, null);
         }
 
         /// <summary>
-        /// Loads the image from the given stream.
+        /// Loads the image from the given file.
         /// </summary>
-        /// <param name="stream">The stream containing image information.</param>
+        /// <param name="path">The file path to the image.</param>
         /// <param name="options">The options for the decoder.</param>
         /// <exception cref="NotSupportedException">
         /// Thrown if the stream is not readable nor seekable.
         /// </exception>
         /// <returns>The image</returns>
-        public static Image Load(string stream, IDecoderOptions options)
+        public static Image Load(string path, IDecoderOptions options)
         {
-            return Load(stream, options, null);
+            return Load(path, options, null);
         }
 
         /// <summary>
-        /// Loads the image from the given stream.
+        /// Loads the image from the given file.
         /// </summary>
-        /// <param name="stream">The stream containing image information.</param>
+        /// <param name="path">The file path to the image.</param>
         /// <param name="config">The config for the decoder.</param>
         /// <exception cref="NotSupportedException">
         /// Thrown if the stream is not readable nor seekable.
         /// </exception>
         /// <returns>The image</returns>
-        public static Image Load(string stream, Configuration config)
+        public static Image Load(string path, Configuration config)
         {
-            return Load(stream, null, config);
+            return Load(path, null, config);
         }
 
         /// <summary>
-        /// Loads the image from the given stream.
+        /// Loads the image from the given file.
         /// </summary>
-        /// <param name="stream">The stream containing image information.</param>
+        /// <param name="path">The file path to the image.</param>
         /// <param name="options">The options for the decoder.</param>
         /// <param name="config">The configuration options.</param>
         /// <exception cref="NotSupportedException">
         /// Thrown if the stream is not readable nor seekable.
         /// </exception>
         /// <returns>The image</returns>
-        public static Image Load(string stream, IDecoderOptions options, Configuration config)
+        public static Image Load(string path, IDecoderOptions options, Configuration config)
         {
-            return new Image(Image.Load<Color>(stream, options, config));
+            return new Image(Load<Color>(path, options, config));
         }
 
         /// <summary>
-        /// Loads the image from the given stream.
+        /// Loads the image from the given file.
         /// </summary>
         /// <typeparam name="TColor">The pixel format.</typeparam>
-        /// <param name="stream">The stream containing image information.</param>
+        /// <param name="path">The file path to the image.</param>
         /// <exception cref="NotSupportedException">
         /// Thrown if the stream is not readable nor seekable.
         /// </exception>
         /// <returns>The image</returns>
-        public static Image<TColor> Load<TColor>(string stream)
+        public static Image<TColor> Load<TColor>(string path)
             where TColor : struct, IPixel<TColor>
         {
-            return Load<TColor>(stream, null, null);
+            return Load<TColor>(path, null, null);
         }
 
         /// <summary>
-        /// Loads the image from the given stream.
+        /// Loads the image from the given file.
         /// </summary>
         /// <typeparam name="TColor">The pixel format.</typeparam>
-        /// <param name="stream">The stream containing image information.</param>
+        /// <param name="path">The file path to the image.</param>
         /// <param name="options">The options for the decoder.</param>
         /// <exception cref="NotSupportedException">
         /// Thrown if the stream is not readable nor seekable.
         /// </exception>
         /// <returns>The image</returns>
-        public static Image<TColor> Load<TColor>(string stream, IDecoderOptions options)
+        public static Image<TColor> Load<TColor>(string path, IDecoderOptions options)
             where TColor : struct, IPixel<TColor>
         {
-            return Load<TColor>(stream, options, null);
+            return Load<TColor>(path, options, null);
         }
 
         /// <summary>
-        /// Loads the image from the given stream.
+        /// Loads the image from the given file.
         /// </summary>
         /// <typeparam name="TColor">The pixel format.</typeparam>
-        /// <param name="stream">The stream containing image information.</param>
+        /// <param name="path">The file path to the image.</param>
         /// <param name="config">The config for the decoder.</param>
         /// <exception cref="NotSupportedException">
         /// Thrown if the stream is not readable nor seekable.
         /// </exception>
         /// <returns>The image</returns>
-        public static Image<TColor> Load<TColor>(string stream, Configuration config)
+        public static Image<TColor> Load<TColor>(string path, Configuration config)
             where TColor : struct, IPixel<TColor>
         {
-            return Load<TColor>(stream, null, config);
+            return Load<TColor>(path, null, config);
         }
 
         /// <summary>
-        /// Loads the image from the given stream.
+        /// Loads the image from the given file.
         /// </summary>
         /// <typeparam name="TColor">The pixel format.</typeparam>
-        /// <param name="stream">The stream containing image information.</param>
+        /// <param name="path">The file path to the image.</param>
         /// <param name="options">The options for the decoder.</param>
         /// <param name="config">The configuration options.</param>
         /// <exception cref="NotSupportedException">
         /// Thrown if the stream is not readable nor seekable.
         /// </exception>
         /// <returns>The image</returns>
-        public static Image<TColor> Load<TColor>(string stream, IDecoderOptions options, Configuration config)
+        public static Image<TColor> Load<TColor>(string path, IDecoderOptions options, Configuration config)
             where TColor : struct, IPixel<TColor>
         {
             config = config ?? Configuration.Default;
-            using (Stream s = config.FileSystem.OpenRead(stream))
+            using (Stream s = config.FileSystem.OpenRead(path))
             {
                 return Load<TColor>(s, options, config);
             }

--- a/src/ImageSharp/Image.FromFile.cs
+++ b/src/ImageSharp/Image.FromFile.cs
@@ -5,15 +5,11 @@
 
 namespace ImageSharp
 {
+#if !NETSTANDARD1_1
     using System;
-    using System.Buffers;
-    using System.Diagnostics;
     using System.IO;
-    using System.Linq;
-    using System.Text;
     using Formats;
 
-#if !NETSTANDARD1_1
     /// <summary>
     /// Represents an image. Each pixel is a made up four 8-bit components red, green, blue, and alpha
     /// packed into a single unsigned integer value.

--- a/src/ImageSharp/Image.FromFile.cs
+++ b/src/ImageSharp/Image.FromFile.cs
@@ -102,7 +102,11 @@ namespace ImageSharp
         /// <returns>The image</returns>
         public static Image Load(string path, IDecoderOptions options, Configuration config)
         {
-            return new Image(Load<Color>(path, options, config));
+            config = config ?? Configuration.Default;
+            using (Stream s = config.FileSystem.OpenRead(path))
+            {
+                return Load(s, options, config);
+            }
         }
 
         /// <summary>

--- a/src/ImageSharp/Image.FromFile.cs
+++ b/src/ImageSharp/Image.FromFile.cs
@@ -26,7 +26,7 @@ namespace ImageSharp
         /// <returns>The image</returns>
         public static Image Load(string path)
         {
-            return Load(path, null, (Configuration)null);
+            return Load(null, path, null);
         }
 
         /// <summary>
@@ -40,21 +40,21 @@ namespace ImageSharp
         /// <returns>The image</returns>
         public static Image Load(string path, IDecoderOptions options)
         {
-            return Load(path, options, null);
+            return Load(null, path, options);
         }
 
         /// <summary>
         /// Loads the image from the given file.
         /// </summary>
-        /// <param name="path">The file path to the image.</param>
         /// <param name="config">The config for the decoder.</param>
+        /// <param name="path">The file path to the image.</param>
         /// <exception cref="NotSupportedException">
         /// Thrown if the stream is not readable nor seekable.
         /// </exception>
         /// <returns>The image</returns>
-        public static Image Load(string path, Configuration config)
+        public static Image Load(Configuration config, string path)
         {
-            return Load(path, null, config);
+            return Load(config, path, null);
         }
 
         /// <summary>
@@ -89,19 +89,19 @@ namespace ImageSharp
         /// <summary>
         /// Loads the image from the given file.
         /// </summary>
+        /// <param name="config">The configuration options.</param>
         /// <param name="path">The file path to the image.</param>
         /// <param name="options">The options for the decoder.</param>
-        /// <param name="config">The configuration options.</param>
         /// <exception cref="NotSupportedException">
         /// Thrown if the stream is not readable nor seekable.
         /// </exception>
         /// <returns>The image</returns>
-        public static Image Load(string path, IDecoderOptions options, Configuration config)
+        public static Image Load(Configuration config, string path, IDecoderOptions options)
         {
             config = config ?? Configuration.Default;
             using (Stream s = config.FileSystem.OpenRead(path))
             {
-                return Load(s, options, config);
+                return Load(config, s, options);
             }
         }
 
@@ -117,7 +117,7 @@ namespace ImageSharp
         public static Image<TColor> Load<TColor>(string path)
             where TColor : struct, IPixel<TColor>
         {
-            return Load<TColor>(path, null, (Configuration)null);
+            return Load<TColor>(null, path, null);
         }
 
         /// <summary>
@@ -133,23 +133,23 @@ namespace ImageSharp
         public static Image<TColor> Load<TColor>(string path, IDecoderOptions options)
             where TColor : struct, IPixel<TColor>
         {
-            return Load<TColor>(path, options, null);
+            return Load<TColor>(null, path, options);
         }
 
         /// <summary>
         /// Loads the image from the given file.
         /// </summary>
         /// <typeparam name="TColor">The pixel format.</typeparam>
-        /// <param name="path">The file path to the image.</param>
         /// <param name="config">The config for the decoder.</param>
+        /// <param name="path">The file path to the image.</param>
         /// <exception cref="NotSupportedException">
         /// Thrown if the stream is not readable nor seekable.
         /// </exception>
         /// <returns>The image</returns>
-        public static Image<TColor> Load<TColor>(string path, Configuration config)
+        public static Image<TColor> Load<TColor>(Configuration config, string path)
             where TColor : struct, IPixel<TColor>
         {
-            return Load<TColor>(path, null, config);
+            return Load<TColor>(config, path, null);
         }
 
         /// <summary>
@@ -172,20 +172,20 @@ namespace ImageSharp
         /// Loads the image from the given file.
         /// </summary>
         /// <typeparam name="TColor">The pixel format.</typeparam>
+        /// <param name="config">The configuration options.</param>
         /// <param name="path">The file path to the image.</param>
         /// <param name="options">The options for the decoder.</param>
-        /// <param name="config">The configuration options.</param>
         /// <exception cref="NotSupportedException">
         /// Thrown if the stream is not readable nor seekable.
         /// </exception>
         /// <returns>The image</returns>
-        public static Image<TColor> Load<TColor>(string path, IDecoderOptions options, Configuration config)
+        public static Image<TColor> Load<TColor>(Configuration config, string path, IDecoderOptions options)
             where TColor : struct, IPixel<TColor>
         {
             config = config ?? Configuration.Default;
             using (Stream s = config.FileSystem.OpenRead(path))
             {
-                return Load<TColor>(s, options, config);
+                return Load<TColor>(config, s, options);
             }
         }
 

--- a/src/ImageSharp/Image.FromFile.cs
+++ b/src/ImageSharp/Image.FromFile.cs
@@ -1,0 +1,148 @@
+﻿// <copyright file="Image.FromStream.cs" company="James Jackson-South">
+// Copyright (c) James Jackson-South and contributors.
+// Licensed under the Apache License, Version 2.0.
+// </copyright>
+
+namespace ImageSharp
+{
+    using System;
+    using System.Buffers;
+    using System.Diagnostics;
+    using System.IO;
+    using System.Linq;
+    using System.Text;
+    using Formats;
+
+#if !NETSTANDARD1_1
+    /// <summary>
+    /// Represents an image. Each pixel is a made up four 8-bit components red, green, blue, and alpha
+    /// packed into a single unsigned integer value.
+    /// </summary>
+    public sealed partial class Image
+    {
+        /// <summary>
+        /// Loads the image from the given stream.
+        /// </summary>
+        /// <param name="stream">The stream containing image information.</param>
+        /// <exception cref="NotSupportedException">
+        /// Thrown if the stream is not readable nor seekable.
+        /// </exception>
+        /// <returns>The image</returns>
+        public static Image Load(string stream)
+        {
+            return Load(stream, null, null);
+        }
+
+        /// <summary>
+        /// Loads the image from the given stream.
+        /// </summary>
+        /// <param name="stream">The stream containing image information.</param>
+        /// <param name="options">The options for the decoder.</param>
+        /// <exception cref="NotSupportedException">
+        /// Thrown if the stream is not readable nor seekable.
+        /// </exception>
+        /// <returns>The image</returns>
+        public static Image Load(string stream, IDecoderOptions options)
+        {
+            return Load(stream, options, null);
+        }
+
+        /// <summary>
+        /// Loads the image from the given stream.
+        /// </summary>
+        /// <param name="stream">The stream containing image information.</param>
+        /// <param name="config">The config for the decoder.</param>
+        /// <exception cref="NotSupportedException">
+        /// Thrown if the stream is not readable nor seekable.
+        /// </exception>
+        /// <returns>The image</returns>
+        public static Image Load(string stream, Configuration config)
+        {
+            return Load(stream, null, config);
+        }
+
+        /// <summary>
+        /// Loads the image from the given stream.
+        /// </summary>
+        /// <param name="stream">The stream containing image information.</param>
+        /// <param name="options">The options for the decoder.</param>
+        /// <param name="config">The configuration options.</param>
+        /// <exception cref="NotSupportedException">
+        /// Thrown if the stream is not readable nor seekable.
+        /// </exception>
+        /// <returns>The image</returns>
+        public static Image Load(string stream, IDecoderOptions options, Configuration config)
+        {
+            return new Image(Image.Load<Color>(stream, options, config));
+        }
+
+        /// <summary>
+        /// Loads the image from the given stream.
+        /// </summary>
+        /// <typeparam name="TColor">The pixel format.</typeparam>
+        /// <param name="stream">The stream containing image information.</param>
+        /// <exception cref="NotSupportedException">
+        /// Thrown if the stream is not readable nor seekable.
+        /// </exception>
+        /// <returns>The image</returns>
+        public static Image<TColor> Load<TColor>(string stream)
+            where TColor : struct, IPixel<TColor>
+        {
+            return Load<TColor>(stream, null, null);
+        }
+
+        /// <summary>
+        /// Loads the image from the given stream.
+        /// </summary>
+        /// <typeparam name="TColor">The pixel format.</typeparam>
+        /// <param name="stream">The stream containing image information.</param>
+        /// <param name="options">The options for the decoder.</param>
+        /// <exception cref="NotSupportedException">
+        /// Thrown if the stream is not readable nor seekable.
+        /// </exception>
+        /// <returns>The image</returns>
+        public static Image<TColor> Load<TColor>(string stream, IDecoderOptions options)
+            where TColor : struct, IPixel<TColor>
+        {
+            return Load<TColor>(stream, options, null);
+        }
+
+        /// <summary>
+        /// Loads the image from the given stream.
+        /// </summary>
+        /// <typeparam name="TColor">The pixel format.</typeparam>
+        /// <param name="stream">The stream containing image information.</param>
+        /// <param name="config">The config for the decoder.</param>
+        /// <exception cref="NotSupportedException">
+        /// Thrown if the stream is not readable nor seekable.
+        /// </exception>
+        /// <returns>The image</returns>
+        public static Image<TColor> Load<TColor>(string stream, Configuration config)
+            where TColor : struct, IPixel<TColor>
+        {
+            return Load<TColor>(stream, null, config);
+        }
+
+        /// <summary>
+        /// Loads the image from the given stream.
+        /// </summary>
+        /// <typeparam name="TColor">The pixel format.</typeparam>
+        /// <param name="stream">The stream containing image information.</param>
+        /// <param name="options">The options for the decoder.</param>
+        /// <param name="config">The configuration options.</param>
+        /// <exception cref="NotSupportedException">
+        /// Thrown if the stream is not readable nor seekable.
+        /// </exception>
+        /// <returns>The image</returns>
+        public static Image<TColor> Load<TColor>(string stream, IDecoderOptions options, Configuration config)
+            where TColor : struct, IPixel<TColor>
+        {
+            config = config ?? Configuration.Default;
+            using (Stream s = config.FileSystem.OpenRead(stream))
+            {
+                return Load<TColor>(s, options, config);
+            }
+        }
+    }
+#endif
+}

--- a/src/ImageSharp/Image.FromStream.cs
+++ b/src/ImageSharp/Image.FromStream.cs
@@ -1,0 +1,184 @@
+﻿// <copyright file="Image.FromStream.cs" company="James Jackson-South">
+// Copyright (c) James Jackson-South and contributors.
+// Licensed under the Apache License, Version 2.0.
+// </copyright>
+
+namespace ImageSharp
+{
+    using System;
+    using System.Buffers;
+    using System.Diagnostics;
+    using System.IO;
+    using System.Linq;
+    using System.Text;
+    using Formats;
+
+    /// <summary>
+    /// Represents an image. Each pixel is a made up four 8-bit components red, green, blue, and alpha
+    /// packed into a single unsigned integer value.
+    /// </summary>
+    public sealed partial class Image
+    {
+        /// <summary>
+        /// Loads the image from the given stream.
+        /// </summary>
+        /// <param name="stream">The stream containing image information.</param>
+        /// <exception cref="NotSupportedException">
+        /// Thrown if the stream is not readable nor seekable.
+        /// </exception>
+        /// <returns>The image</returns>
+        public static Image Load(Stream stream)
+        {
+            return Load(stream, null, null);
+        }
+
+        /// <summary>
+        /// Loads the image from the given stream.
+        /// </summary>
+        /// <param name="stream">The stream containing image information.</param>
+        /// <param name="options">The options for the decoder.</param>
+        /// <exception cref="NotSupportedException">
+        /// Thrown if the stream is not readable nor seekable.
+        /// </exception>
+        /// <returns>The image</returns>
+        public static Image Load(Stream stream, IDecoderOptions options)
+        {
+            return Load(stream, options, null);
+        }
+
+        /// <summary>
+        /// Loads the image from the given stream.
+        /// </summary>
+        /// <param name="stream">The stream containing image information.</param>
+        /// <param name="config">The config for the decoder.</param>
+        /// <exception cref="NotSupportedException">
+        /// Thrown if the stream is not readable nor seekable.
+        /// </exception>
+        /// <returns>The image</returns>
+        public static Image Load(Stream stream, Configuration config)
+        {
+            return Load(stream, null, config);
+        }
+
+        /// <summary>
+        /// Loads the image from the given stream.
+        /// </summary>
+        /// <param name="stream">The stream containing image information.</param>
+        /// <param name="options">The options for the decoder.</param>
+        /// <param name="config">The configuration options.</param>
+        /// <exception cref="NotSupportedException">
+        /// Thrown if the stream is not readable nor seekable.
+        /// </exception>
+        /// <returns>The image</returns>
+        public static Image Load(Stream stream, IDecoderOptions options, Configuration config)
+        {
+            return new Image(Load<Color>(stream, options, config));
+        }
+
+        /// <summary>
+        /// Loads the image from the given stream.
+        /// </summary>
+        /// <typeparam name="TColor">The pixel format.</typeparam>
+        /// <param name="stream">The stream containing image information.</param>
+        /// <exception cref="NotSupportedException">
+        /// Thrown if the stream is not readable nor seekable.
+        /// </exception>
+        /// <returns>The image</returns>
+        public static Image<TColor> Load<TColor>(Stream stream)
+            where TColor : struct, IPixel<TColor>
+        {
+            return Load<TColor>(stream, null, null);
+        }
+
+        /// <summary>
+        /// Loads the image from the given stream.
+        /// </summary>
+        /// <typeparam name="TColor">The pixel format.</typeparam>
+        /// <param name="stream">The stream containing image information.</param>
+        /// <param name="options">The options for the decoder.</param>
+        /// <exception cref="NotSupportedException">
+        /// Thrown if the stream is not readable nor seekable.
+        /// </exception>
+        /// <returns>The image</returns>
+        public static Image<TColor> Load<TColor>(Stream stream, IDecoderOptions options)
+            where TColor : struct, IPixel<TColor>
+        {
+            return Load<TColor>(stream, options, null);
+        }
+
+        /// <summary>
+        /// Loads the image from the given stream.
+        /// </summary>
+        /// <typeparam name="TColor">The pixel format.</typeparam>
+        /// <param name="stream">The stream containing image information.</param>
+        /// <param name="config">The config for the decoder.</param>
+        /// <exception cref="NotSupportedException">
+        /// Thrown if the stream is not readable nor seekable.
+        /// </exception>
+        /// <returns>The image</returns>
+        public static Image<TColor> Load<TColor>(Stream stream, Configuration config)
+            where TColor : struct, IPixel<TColor>
+        {
+            return Load<TColor>(stream, null, config);
+        }
+
+        /// <summary>
+        /// Loads the image from the given stream.
+        /// </summary>
+        /// <typeparam name="TColor">The pixel format.</typeparam>
+        /// <param name="stream">The stream containing image information.</param>
+        /// <param name="options">The options for the decoder.</param>
+        /// <param name="config">The configuration options.</param>
+        /// <exception cref="NotSupportedException">
+        /// Thrown if the stream is not readable nor seekable.
+        /// </exception>
+        /// <returns>The image</returns>
+        public static Image<TColor> Load<TColor>(Stream stream, IDecoderOptions options, Configuration config)
+            where TColor : struct, IPixel<TColor>
+        {
+            config = config ?? Configuration.Default;
+
+            if (!config.ImageFormats.Any())
+            {
+                throw new InvalidOperationException("No image formats have been configured.");
+            }
+
+            if (!stream.CanRead)
+            {
+                throw new NotSupportedException("Cannot read from the stream.");
+            }
+
+            if (stream.CanSeek)
+            {
+                if (Decode(stream, options, config, out Image<TColor> img))
+                {
+                    return img;
+                }
+            }
+            else
+            {
+                // We want to be able to load images from things like HttpContext.Request.Body
+                using (MemoryStream ms = new MemoryStream())
+                {
+                    stream.CopyTo(ms);
+                    ms.Position = 0;
+
+                    if (Decode(ms, options, config, out Image<TColor> img))
+                    {
+                        return img;
+                    }
+                }
+            }
+
+            StringBuilder stringBuilder = new StringBuilder();
+            stringBuilder.AppendLine("Image cannot be loaded. Available formats:");
+
+            foreach (IImageFormat format in config.ImageFormats)
+            {
+                stringBuilder.AppendLine("-" + format);
+            }
+
+            throw new NotSupportedException(stringBuilder.ToString());
+        }
+    }
+}

--- a/src/ImageSharp/Image.FromStream.cs
+++ b/src/ImageSharp/Image.FromStream.cs
@@ -181,7 +181,7 @@ namespace ImageSharp
         public static Image<TColor> Load<TColor>(Stream stream, IImageDecoder decoder, IDecoderOptions options)
             where TColor : struct, IPixel<TColor>
         {
-            return WithSeekableStream(stream, s => decoder.Decode<TColor>(s, options));
+            return WithSeekableStream(stream, s => decoder.Decode<TColor>(s, options, Configuration.Default));
         }
 
         /// <summary>

--- a/src/ImageSharp/Image.FromStream.cs
+++ b/src/ImageSharp/Image.FromStream.cs
@@ -26,7 +26,7 @@ namespace ImageSharp
         /// <returns>The image</returns>
         public static Image Load(Stream stream)
         {
-            return Load(stream, null, (Configuration)null);
+            return Load(null, stream, null);
         }
 
         /// <summary>
@@ -40,21 +40,21 @@ namespace ImageSharp
         /// <returns>The image</returns>
         public static Image Load(Stream stream, IDecoderOptions options)
         {
-            return Load(stream, options, null);
+            return Load(null, stream, options);
         }
 
         /// <summary>
         /// Loads the image from the given stream.
         /// </summary>
-        /// <param name="stream">The stream containing image information.</param>
         /// <param name="config">The config for the decoder.</param>
+        /// <param name="stream">The stream containing image information.</param>
         /// <exception cref="NotSupportedException">
         /// Thrown if the stream is not readable nor seekable.
         /// </exception>
         /// <returns>The image</returns>
-        public static Image Load(Stream stream, Configuration config)
+        public static Image Load(Configuration config, Stream stream)
         {
-            return Load(stream, null, config);
+            return Load(config, stream, null);
         }
 
         /// <summary>
@@ -74,16 +74,16 @@ namespace ImageSharp
         /// <summary>
         /// Loads the image from the given stream.
         /// </summary>
+        /// <param name="config">The configuration options.</param>
         /// <param name="stream">The stream containing image information.</param>
         /// <param name="options">The options for the decoder.</param>
-        /// <param name="config">The configuration options.</param>
         /// <exception cref="NotSupportedException">
         /// Thrown if the stream is not readable nor seekable.
         /// </exception>
         /// <returns>The image</returns>
-        public static Image Load(Stream stream, IDecoderOptions options, Configuration config)
+        public static Image Load(Configuration config, Stream stream, IDecoderOptions options)
         {
-            Image<Color> image = Load<Color>(stream, options, config);
+            Image<Color> image = Load<Color>(config, stream, options);
 
             return image as Image ?? new Image(image);
         }
@@ -117,7 +117,7 @@ namespace ImageSharp
         public static Image<TColor> Load<TColor>(Stream stream)
             where TColor : struct, IPixel<TColor>
         {
-            return Load<TColor>(stream, null, (Configuration)null);
+            return Load<TColor>(null, stream, null);
         }
 
         /// <summary>
@@ -133,23 +133,23 @@ namespace ImageSharp
         public static Image<TColor> Load<TColor>(Stream stream, IDecoderOptions options)
             where TColor : struct, IPixel<TColor>
         {
-            return Load<TColor>(stream, options, null);
+            return Load<TColor>(null, stream, options);
         }
 
         /// <summary>
         /// Loads the image from the given stream.
         /// </summary>
         /// <typeparam name="TColor">The pixel format.</typeparam>
-        /// <param name="stream">The stream containing image information.</param>
         /// <param name="config">The config for the decoder.</param>
+        /// <param name="stream">The stream containing image information.</param>
         /// <exception cref="NotSupportedException">
         /// Thrown if the stream is not readable nor seekable.
         /// </exception>
         /// <returns>The image</returns>
-        public static Image<TColor> Load<TColor>(Stream stream, Configuration config)
+        public static Image<TColor> Load<TColor>(Configuration config, Stream stream)
             where TColor : struct, IPixel<TColor>
         {
-            return Load<TColor>(stream, null, config);
+            return Load<TColor>(config, stream, null);
         }
 
         /// <summary>
@@ -189,14 +189,14 @@ namespace ImageSharp
         /// Loads the image from the given stream.
         /// </summary>
         /// <typeparam name="TColor">The pixel format.</typeparam>
+        /// <param name="config">The configuration options.</param>
         /// <param name="stream">The stream containing image information.</param>
         /// <param name="options">The options for the decoder.</param>
-        /// <param name="config">The configuration options.</param>
         /// <exception cref="NotSupportedException">
         /// Thrown if the stream is not readable nor seekable.
         /// </exception>
         /// <returns>The image</returns>
-        public static Image<TColor> Load<TColor>(Stream stream, IDecoderOptions options, Configuration config)
+        public static Image<TColor> Load<TColor>(Configuration config, Stream stream, IDecoderOptions options)
             where TColor : struct, IPixel<TColor>
         {
             config = config ?? Configuration.Default;

--- a/src/ImageSharp/Image.FromStream.cs
+++ b/src/ImageSharp/Image.FromStream.cs
@@ -6,10 +6,7 @@
 namespace ImageSharp
 {
     using System;
-    using System.Buffers;
-    using System.Diagnostics;
     using System.IO;
-    using System.Linq;
     using System.Text;
     using Formats;
 
@@ -86,7 +83,9 @@ namespace ImageSharp
         /// <returns>The image</returns>
         public static Image Load(Stream stream, IDecoderOptions options, Configuration config)
         {
-            return new Image(Load<Color>(stream, options, config));
+            Image<Color> image = Load<Color>(stream, options, config);
+
+            return image as Image ?? new Image(image);
         }
 
         /// <summary>
@@ -101,7 +100,9 @@ namespace ImageSharp
         /// <returns>The image</returns>
         public static Image Load(Stream stream, IImageDecoder decoder, IDecoderOptions options)
         {
-            return new Image(Load<Color>(stream, decoder, options));
+            Image<Color> image = new Image(Load<Color>(stream, decoder, options));
+
+            return image as Image ?? new Image(image);
         }
 
         /// <summary>
@@ -200,10 +201,7 @@ namespace ImageSharp
         {
             config = config ?? Configuration.Default;
 
-            Image<TColor> img = WithSeekableStream(stream, s =>
-            {
-                return Decode<TColor>(stream, options, config);
-            });
+            Image<TColor> img = WithSeekableStream(stream, s => Decode<TColor>(stream, options, config));
 
             if (img != null)
             {

--- a/src/ImageSharp/Image.FromStream.cs
+++ b/src/ImageSharp/Image.FromStream.cs
@@ -182,7 +182,7 @@ namespace ImageSharp
         public static Image<TColor> Load<TColor>(Stream stream, IImageDecoder decoder, IDecoderOptions options)
             where TColor : struct, IPixel<TColor>
         {
-            return WithSeekableStream(stream, s => decoder.Decode<TColor>(s, options, Configuration.Default));
+            return WithSeekableStream(stream, s => decoder.Decode<TColor>(Configuration.Default, s, options));
         }
 
         /// <summary>

--- a/src/ImageSharp/Image.cs
+++ b/src/ImageSharp/Image.cs
@@ -49,7 +49,7 @@ namespace ImageSharp
         /// </summary>
         /// <param name="other">The other image, where the clone should be made from.</param>
         /// <exception cref="System.ArgumentNullException"><paramref name="other"/> is null.</exception>
-        internal Image(Image<Color> other)
+        public Image(Image<Color> other)
             : base(other)
         {
         }

--- a/src/ImageSharp/Image.cs
+++ b/src/ImageSharp/Image.cs
@@ -53,5 +53,20 @@ namespace ImageSharp
             : base(other)
         {
         }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Image"/> class
+        /// with the height and the width of the image.
+        /// </summary>
+        /// <param name="width">The width of the image in pixels.</param>
+        /// <param name="height">The height of the image in pixels.</param>
+        /// <param name="metadata">The metadata.</param>
+        /// <param name="configuration">
+        /// The configuration providing initialization code which allows extending the library.
+        /// </param>
+        internal Image(int width, int height, ImageMetaData metadata, Configuration configuration)
+          : base(width, height, metadata, configuration)
+        {
+        }
     }
 }

--- a/src/ImageSharp/Image.cs
+++ b/src/ImageSharp/Image.cs
@@ -5,6 +5,7 @@
 
 namespace ImageSharp
 {
+    using System;
     using System.Diagnostics;
     using System.IO;
 
@@ -15,7 +16,7 @@ namespace ImageSharp
     /// packed into a single unsigned integer value.
     /// </summary>
     [DebuggerDisplay("Image: {Width}x{Height}")]
-    public sealed class Image : Image<Color>
+    public sealed partial class Image : Image<Color>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Image"/> class
@@ -26,190 +27,19 @@ namespace ImageSharp
         /// <param name="configuration">
         /// The configuration providing initialization code which allows extending the library.
         /// </param>
-        public Image(int width, int height, Configuration configuration = null)
+        public Image(int width, int height, Configuration configuration)
           : base(width, height, configuration)
         {
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="Image"/> class.
+        /// Initializes a new instance of the <see cref="Image"/> class
+        /// with the height and the width of the image.
         /// </summary>
-        /// <param name="stream">
-        /// The stream containing image information.
-        /// </param>
-        /// <exception cref="System.ArgumentNullException">Thrown if the <paramref name="stream"/> is null.</exception>
-        public Image(Stream stream)
-            : base(stream, null, null)
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Image"/> class.
-        /// </summary>
-        /// <param name="stream">
-        /// The stream containing image information.
-        /// </param>
-        /// <param name="options">
-        /// The options for the decoder.
-        /// </param>
-        /// <exception cref="System.ArgumentNullException">Thrown if the <paramref name="stream"/> is null.</exception>
-        public Image(Stream stream, IDecoderOptions options)
-            : base(stream, options, null)
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Image"/> class.
-        /// </summary>
-        /// <param name="stream">
-        /// The stream containing image information.
-        /// </param>
-        /// <param name="configuration">
-        /// The configuration providing initialization code which allows extending the library.
-        /// </param>
-        /// <exception cref="System.ArgumentNullException">Thrown if the <paramref name="stream"/> is null.</exception>
-        public Image(Stream stream, Configuration configuration)
-            : base(stream, null, configuration)
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Image"/> class.
-        /// </summary>
-        /// <param name="stream">
-        /// The stream containing image information.
-        /// </param>
-        /// <param name="options">
-        /// The options for the decoder.
-        /// </param>
-        /// <param name="configuration">
-        /// The configuration providing initialization code which allows extending the library.
-        /// </param>
-        /// <exception cref="System.ArgumentNullException">Thrown if the <paramref name="stream"/> is null.</exception>
-        public Image(Stream stream, IDecoderOptions options, Configuration configuration)
-            : base(stream, options, configuration)
-        {
-        }
-
-#if !NETSTANDARD1_1
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Image"/> class.
-        /// </summary>
-        /// <param name="filePath">
-        /// A file path to read image information.
-        /// </param>
-        /// <exception cref="System.ArgumentNullException">Thrown if the <paramref name="filePath"/> is null.</exception>
-        public Image(string filePath)
-            : base(filePath, null, null)
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Image"/> class.
-        /// </summary>
-        /// <param name="filePath">
-        /// A file path to read image information.
-        /// </param>
-        /// <param name="options">
-        /// The options for the decoder.
-        /// </param>
-        /// <exception cref="System.ArgumentNullException">Thrown if the <paramref name="filePath"/> is null.</exception>
-        public Image(string filePath, IDecoderOptions options)
-            : base(filePath, options, null)
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Image"/> class.
-        /// </summary>
-        /// <param name="filePath">
-        /// A file path to read image information.
-        /// </param>
-        /// <param name="configuration">
-        /// The configuration providing initialization code which allows extending the library.
-        /// </param>
-        /// <exception cref="System.ArgumentNullException">Thrown if the <paramref name="filePath"/> is null.</exception>
-        public Image(string filePath, Configuration configuration)
-            : base(filePath, null, configuration)
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Image"/> class.
-        /// </summary>
-        /// <param name="filePath">
-        /// A file path to read image information.
-        /// </param>
-        /// <param name="options">
-        /// The options for the decoder.
-        /// </param>
-        /// <param name="configuration">
-        /// The configuration providing initialization code which allows extending the library.
-        /// </param>
-        /// <exception cref="System.ArgumentNullException">Thrown if the <paramref name="filePath"/> is null.</exception>
-        public Image(string filePath, IDecoderOptions options, Configuration configuration)
-            : base(filePath, options, configuration)
-        {
-        }
-#endif
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Image"/> class.
-        /// </summary>
-        /// <param name="bytes">
-        /// The byte array containing image information.
-        /// </param>
-        /// <exception cref="System.ArgumentNullException">Thrown if the <paramref name="bytes"/> is null.</exception>
-        public Image(byte[] bytes)
-           : base(bytes, null, null)
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Image"/> class.
-        /// </summary>
-        /// <param name="bytes">
-        /// The byte array containing image information.
-        /// </param>
-        /// <param name="options">
-        /// The options for the decoder.
-        /// </param>
-        /// <exception cref="System.ArgumentNullException">Thrown if the <paramref name="bytes"/> is null.</exception>
-        public Image(byte[] bytes, IDecoderOptions options)
-           : base(bytes, options, null)
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Image"/> class.
-        /// </summary>
-        /// <param name="bytes">
-        /// The byte array containing image information.
-        /// </param>
-        /// <param name="configuration">
-        /// The configuration providing initialization code which allows extending the library.
-        /// </param>
-        /// <exception cref="System.ArgumentNullException">Thrown if the <paramref name="bytes"/> is null.</exception>
-        public Image(byte[] bytes, Configuration configuration)
-           : base(bytes, null, configuration)
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Image"/> class.
-        /// </summary>
-        /// <param name="bytes">
-        /// The byte array containing image information.
-        /// </param>
-        /// <param name="options">
-        /// The options for the decoder.
-        /// </param>
-        /// <param name="configuration">
-        /// The configuration providing initialization code which allows extending the library.
-        /// </param>
-        /// <exception cref="System.ArgumentNullException">Thrown if the <paramref name="bytes"/> is null.</exception>
-        public Image(byte[] bytes, IDecoderOptions options, Configuration configuration)
-           : base(bytes, options, configuration)
+        /// <param name="width">The width of the image in pixels.</param>
+        /// <param name="height">The height of the image in pixels.</param>
+        public Image(int width, int height)
+          : this(width, height, null)
         {
         }
 
@@ -219,7 +49,7 @@ namespace ImageSharp
         /// </summary>
         /// <param name="other">The other image, where the clone should be made from.</param>
         /// <exception cref="System.ArgumentNullException"><paramref name="other"/> is null.</exception>
-        public Image(Image other)
+        internal Image(Image<Color> other)
             : base(other)
         {
         }

--- a/src/ImageSharp/Image/IImageBase.cs
+++ b/src/ImageSharp/Image/IImageBase.cs
@@ -16,16 +16,6 @@ namespace ImageSharp
         Rectangle Bounds { get; }
 
         /// <summary>
-        /// Gets or sets the maximum allowable width in pixels.
-        /// </summary>
-        int MaxWidth { get; set; }
-
-        /// <summary>
-        /// Gets or sets the maximum allowable height in pixels.
-        /// </summary>
-        int MaxHeight { get; set; }
-
-        /// <summary>
         /// Gets the width in pixels.
         /// </summary>
         int Width { get; }

--- a/src/ImageSharp/Image/IImageBase{TColor}.cs
+++ b/src/ImageSharp/Image/IImageBase{TColor}.cs
@@ -22,16 +22,6 @@ namespace ImageSharp
         TColor[] Pixels { get; }
 
         /// <summary>
-        /// Sets the size of the pixel array of the image to the given width and height.
-        /// </summary>
-        /// <param name="width">The new width of the image. Must be greater than zero.</param>
-        /// <param name="height">The new height of the image. Must be greater than zero.</param>
-        /// <exception cref="System.ArgumentOutOfRangeException">
-        /// Thrown if either <paramref name="width"/> or <paramref name="height"/> are less than or equal to 0.
-        /// </exception>
-        void InitPixels(int width, int height);
-
-        /// <summary>
         /// Locks the image providing access to the pixels.
         /// <remarks>
         /// It is imperative that the accessor is correctly disposed off after use.

--- a/src/ImageSharp/Image/ImageBase{TColor}.cs
+++ b/src/ImageSharp/Image/ImageBase{TColor}.cs
@@ -19,6 +19,16 @@ namespace ImageSharp
         where TColor : struct, IPixel<TColor>
     {
         /// <summary>
+        /// Gets or sets the maximum allowable width in pixels.
+        /// </summary>
+        public const int MaxWidth = int.MaxValue;
+
+        /// <summary>
+        /// Gets or sets the maximum allowable height in pixels.
+        /// </summary>
+        public const int MaxHeight = int.MaxValue;
+
+        /// <summary>
         /// The image pixels
         /// </summary>
         private TColor[] pixelBuffer;
@@ -40,7 +50,7 @@ namespace ImageSharp
         /// <param name="configuration">
         /// The configuration providing initialization code which allows extending the library.
         /// </param>
-        protected ImageBase(Configuration configuration = null)
+        protected ImageBase(Configuration configuration)
         {
             this.Configuration = configuration ?? Configuration.Default;
         }
@@ -56,10 +66,15 @@ namespace ImageSharp
         /// <exception cref="ArgumentOutOfRangeException">
         /// Thrown if either <paramref name="width"/> or <paramref name="height"/> are less than or equal to 0.
         /// </exception>
-        protected ImageBase(int width, int height, Configuration configuration = null)
+        protected ImageBase(int width, int height, Configuration configuration)
+            : this(configuration)
         {
-            this.Configuration = configuration ?? Configuration.Default;
-            this.InitPixels(width, height);
+            Guard.MustBeGreaterThan(width, 0, nameof(width));
+            Guard.MustBeGreaterThan(height, 0, nameof(height));
+
+            this.Width = width;
+            this.Height = height;
+            this.RentPixels();
             this.ClearPixels();
         }
 
@@ -73,6 +88,7 @@ namespace ImageSharp
         /// Thrown if the given <see cref="ImageBase{TColor}"/> is null.
         /// </exception>
         protected ImageBase(ImageBase<TColor> other)
+            : this(other.Configuration)
         {
             Guard.NotNull(other, nameof(other), "Other image cannot be null.");
 
@@ -89,12 +105,6 @@ namespace ImageSharp
                 sourcePixels.CopyTo(target);
             }
         }
-
-        /// <inheritdoc/>
-        public int MaxWidth { get; set; } = int.MaxValue;
-
-        /// <inheritdoc/>
-        public int MaxHeight { get; set; } = int.MaxValue;
 
         /// <inheritdoc/>
         public TColor[] Pixels => this.pixelBuffer;
@@ -137,17 +147,6 @@ namespace ImageSharp
             // and prevent finalization code for this object
             // from executing a second time.
             GC.SuppressFinalize(this);
-        }
-
-        /// <inheritdoc/>
-        public void InitPixels(int width, int height)
-        {
-            Guard.MustBeGreaterThan(width, 0, nameof(width));
-            Guard.MustBeGreaterThan(height, 0, nameof(height));
-
-            this.Width = width;
-            this.Height = height;
-            this.RentPixels();
         }
 
         /// <inheritdoc/>

--- a/src/ImageSharp/Image/Image{TColor}.cs
+++ b/src/ImageSharp/Image/Image{TColor}.cs
@@ -36,15 +36,8 @@ namespace ImageSharp
         /// The configuration providing initialization code which allows extending the library.
         /// </param>
         public Image(int width, int height, Configuration configuration)
-            : base(width, height, configuration)
+            : this(width, height, new ImageMetaData(), configuration)
         {
-            if (!this.Configuration.ImageFormats.Any())
-            {
-                throw new InvalidOperationException("No image formats have been configured.");
-            }
-
-            this.MetaData = new ImageMetaData();
-            this.CurrentImageFormat = this.Configuration.ImageFormats.First();
         }
 
         /// <summary>
@@ -87,12 +80,35 @@ namespace ImageSharp
         public Image(ImageBase<TColor> other)
             : base(other)
         {
+            this.MetaData = new ImageMetaData();
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Image{TColor}"/> class
+        /// with the height and the width of the image.
+        /// </summary>
+        /// <param name="width">The width of the image in pixels.</param>
+        /// <param name="height">The height of the image in pixels.</param>
+        /// <param name="metadata">The images metadata.</param>
+        /// <param name="configuration">
+        /// The configuration providing initialization code which allows extending the library.
+        /// </param>
+        internal Image(int width, int height, ImageMetaData metadata, Configuration configuration)
+            : base(width, height, configuration)
+        {
+            if (!this.Configuration.ImageFormats.Any())
+            {
+                throw new InvalidOperationException("No image formats have been configured.");
+            }
+
+            this.MetaData = metadata ?? new ImageMetaData();
+            this.CurrentImageFormat = this.Configuration.ImageFormats.First();
         }
 
         /// <summary>
         /// Gets the meta data of the image.
         /// </summary>
-        public ImageMetaData MetaData { get; private set; } = new ImageMetaData();
+        public ImageMetaData MetaData { get; private set; }
 
         /// <summary>
         /// Gets the width of the image in inches. It is calculated as the width of the image

--- a/src/ImageSharp/Image/Image{TColor}.cs
+++ b/src/ImageSharp/Image/Image{TColor}.cs
@@ -35,7 +35,7 @@ namespace ImageSharp
         /// <param name="configuration">
         /// The configuration providing initialization code which allows extending the library.
         /// </param>
-        public Image(int width, int height, Configuration configuration = null)
+        public Image(int width, int height, Configuration configuration)
             : base(width, height, configuration)
         {
             if (!this.Configuration.ImageFormats.Any())
@@ -43,203 +43,19 @@ namespace ImageSharp
                 throw new InvalidOperationException("No image formats have been configured.");
             }
 
+            this.MetaData = new ImageMetaData();
             this.CurrentImageFormat = this.Configuration.ImageFormats.First();
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="Image{TColor}"/> class.
+        /// Initializes a new instance of the <see cref="Image{TColor}"/> class
+        /// with the height and the width of the image.
         /// </summary>
-        /// <param name="stream">
-        /// The stream containing image information.
-        /// </param>
-        /// <exception cref="System.ArgumentNullException">Thrown if the <paramref name="stream"/> is null.</exception>
-        public Image(Stream stream)
-            : this(stream, null, null)
+        /// <param name="width">The width of the image in pixels.</param>
+        /// <param name="height">The height of the image in pixels.</param>
+        public Image(int width, int height)
+            : this(width, height, null)
         {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Image{TColor}"/> class.
-        /// </summary>
-        /// <param name="stream">
-        /// The stream containing image information.
-        /// </param>
-        /// <param name="options">
-        /// The options for the decoder.
-        /// </param>
-        /// <exception cref="System.ArgumentNullException">Thrown if the <paramref name="stream"/> is null.</exception>
-        public Image(Stream stream, IDecoderOptions options)
-            : this(stream, options, null)
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Image{TColor}"/> class.
-        /// </summary>
-        /// <param name="stream">
-        /// The stream containing image information.
-        /// </param>
-        /// <param name="configuration">
-        /// The configuration providing initialization code which allows extending the library.
-        /// </param>
-        /// <exception cref="System.ArgumentNullException">Thrown if the <paramref name="stream"/> is null.</exception>
-        public Image(Stream stream, Configuration configuration)
-            : this(stream, null, configuration)
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Image{TColor}"/> class.
-        /// </summary>
-        /// <param name="stream">
-        /// The stream containing image information.
-        /// </param>
-        /// <param name="options">
-        /// The options for the decoder.
-        /// </param>
-        /// <param name="configuration">
-        /// The configuration providing initialization code which allows extending the library.
-        /// </param>
-        /// <exception cref="System.ArgumentNullException">Thrown if the <paramref name="stream"/> is null.</exception>
-        public Image(Stream stream, IDecoderOptions options, Configuration configuration)
-            : base(configuration)
-        {
-            Guard.NotNull(stream, nameof(stream));
-            this.Load(stream, options);
-        }
-
-#if !NETSTANDARD1_1
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Image{TColor}"/> class.
-        /// </summary>
-        /// <param name="filePath">
-        /// The file containing image information.
-        /// </param>
-        /// <exception cref="System.ArgumentNullException">Thrown if the <paramref name="filePath"/> is null.</exception>
-        public Image(string filePath)
-            : this(filePath, null, null)
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Image{TColor}"/> class.
-        /// </summary>
-        /// <param name="filePath">
-        /// The file containing image information.
-        /// </param>
-        /// <param name="options">
-        /// The options for the decoder.
-        /// </param>
-        /// <exception cref="System.ArgumentNullException">Thrown if the <paramref name="filePath"/> is null.</exception>
-        public Image(string filePath, IDecoderOptions options)
-            : this(filePath, options, null)
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Image{TColor}"/> class.
-        /// </summary>
-        /// <param name="filePath">
-        /// The file containing image information.
-        /// </param>
-        /// <param name="configuration">
-        /// The configuration providing initialization code which allows extending the library.
-        /// </param>
-        /// <exception cref="System.ArgumentNullException">Thrown if the <paramref name="filePath"/> is null.</exception>
-        public Image(string filePath, Configuration configuration)
-            : this(filePath, null, configuration)
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Image{TColor}"/> class.
-        /// </summary>
-        /// <param name="filePath">
-        /// The file containing image information.
-        /// </param>
-        /// <param name="options">
-        /// The options for the decoder.
-        /// </param>
-        /// <param name="configuration">
-        /// The configuration providing initialization code which allows extending the library.
-        /// </param>
-        /// <exception cref="System.ArgumentNullException">Thrown if the <paramref name="filePath"/> is null.</exception>
-        public Image(string filePath, IDecoderOptions options, Configuration configuration)
-            : base(configuration)
-        {
-            Guard.NotNull(filePath, nameof(filePath));
-
-            using (Stream fs = this.Configuration.FileSystem.OpenRead(filePath))
-            {
-                this.Load(fs, options);
-            }
-        }
-#endif
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Image{TColor}"/> class.
-        /// </summary>
-        /// <param name="bytes">
-        /// The byte array containing image information.
-        /// </param>
-        /// <exception cref="System.ArgumentNullException">Thrown if the <paramref name="bytes"/> is null.</exception>
-        public Image(byte[] bytes)
-            : this(bytes, null, null)
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Image{TColor}"/> class.
-        /// </summary>
-        /// <param name="bytes">
-        /// The byte array containing image information.
-        /// </param>
-        /// <param name="options">
-        /// The options for the decoder.
-        /// </param>
-        /// <exception cref="System.ArgumentNullException">Thrown if the <paramref name="bytes"/> is null.</exception>
-        public Image(byte[] bytes, IDecoderOptions options)
-            : this(bytes, options, null)
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Image{TColor}"/> class.
-        /// </summary>
-        /// <param name="bytes">
-        /// The byte array containing image information.
-        /// </param>
-        /// <param name="configuration">
-        /// The configuration providing initialization code which allows extending the library.
-        /// </param>
-        /// <exception cref="System.ArgumentNullException">Thrown if the <paramref name="bytes"/> is null.</exception>
-        public Image(byte[] bytes, Configuration configuration)
-            : this(bytes, null, configuration)
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Image{TColor}"/> class.
-        /// </summary>
-        /// <param name="bytes">
-        /// The byte array containing image information.
-        /// </param>
-        /// <param name="options">
-        /// The options for the decoder.
-        /// </param>
-        /// <param name="configuration">
-        /// The configuration providing initialization code which allows extending the library.
-        /// </param>
-        /// <exception cref="System.ArgumentNullException">Thrown if the <paramref name="bytes"/> is null.</exception>
-        public Image(byte[] bytes, IDecoderOptions options, Configuration configuration)
-            : base(configuration)
-        {
-            Guard.NotNull(bytes, nameof(bytes));
-
-            using (MemoryStream stream = new MemoryStream(bytes, false))
-            {
-                this.Load(stream, options);
-            }
         }
 
         /// <summary>
@@ -271,7 +87,6 @@ namespace ImageSharp
         public Image(ImageBase<TColor> other)
             : base(other)
         {
-            this.CopyProperties(other);
         }
 
         /// <summary>
@@ -588,103 +403,8 @@ namespace ImageSharp
         /// </param>
         private void CopyProperties(IImage other)
         {
-            base.CopyProperties(other);
-
             this.CurrentImageFormat = other.CurrentImageFormat;
             this.MetaData = new ImageMetaData(other.MetaData);
-        }
-
-        /// <summary>
-        /// Loads the image from the given stream.
-        /// </summary>
-        /// <param name="stream">The stream containing image information.</param>
-        /// <param name="options">The options for the decoder.</param>
-        /// <exception cref="NotSupportedException">
-        /// Thrown if the stream is not readable nor seekable.
-        /// </exception>
-        private void Load(Stream stream, IDecoderOptions options)
-        {
-            if (!this.Configuration.ImageFormats.Any())
-            {
-                throw new InvalidOperationException("No image formats have been configured.");
-            }
-
-            if (!stream.CanRead)
-            {
-                throw new NotSupportedException("Cannot read from the stream.");
-            }
-
-            if (stream.CanSeek)
-            {
-                if (this.Decode(stream, options))
-                {
-                    return;
-                }
-            }
-            else
-            {
-                // We want to be able to load images from things like HttpContext.Request.Body
-                using (MemoryStream ms = new MemoryStream())
-                {
-                    stream.CopyTo(ms);
-                    ms.Position = 0;
-
-                    if (this.Decode(ms, options))
-                    {
-                        return;
-                    }
-                }
-            }
-
-            StringBuilder stringBuilder = new StringBuilder();
-            stringBuilder.AppendLine("Image cannot be loaded. Available formats:");
-
-            foreach (IImageFormat format in this.Configuration.ImageFormats)
-            {
-                stringBuilder.AppendLine("-" + format);
-            }
-
-            throw new NotSupportedException(stringBuilder.ToString());
-        }
-
-        /// <summary>
-        /// Decodes the image stream to the current image.
-        /// </summary>
-        /// <param name="stream">The stream.</param>
-        /// <param name="options">The options for the decoder.</param>
-        /// <returns>
-        /// The <see cref="bool"/>.
-        /// </returns>
-        private bool Decode(Stream stream, IDecoderOptions options)
-        {
-            int maxHeaderSize = this.Configuration.MaxHeaderSize;
-            if (maxHeaderSize <= 0)
-            {
-                return false;
-            }
-
-            IImageFormat format;
-            byte[] header = ArrayPool<byte>.Shared.Rent(maxHeaderSize);
-            try
-            {
-                long startPosition = stream.Position;
-                stream.Read(header, 0, maxHeaderSize);
-                stream.Position = startPosition;
-                format = this.Configuration.ImageFormats.FirstOrDefault(x => x.IsSupportedFileFormat(header));
-            }
-            finally
-            {
-                ArrayPool<byte>.Shared.Return(header);
-            }
-
-            if (format == null)
-            {
-                return false;
-            }
-
-            format.Decoder.Decode(this, stream, options);
-            this.CurrentImageFormat = format;
-            return true;
         }
     }
 }

--- a/src/ImageSharp/ImageSharp.csproj
+++ b/src/ImageSharp/ImageSharp.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Description>A cross-platform library for the processing of image files; written in C#</Description>
     <AssemblyTitle>ImageSharp</AssemblyTitle>
-    <VersionPrefix>1.0.0-alpha4</VersionPrefix>
+    <VersionPrefix>1.0.0-alpha5</VersionPrefix>
     <Authors>James Jackson-South and contributors</Authors>
     <TargetFrameworks>netstandard1.3;netstandard1.1</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/src/ImageSharp/MetaData/ImageMetaData.cs
+++ b/src/ImageSharp/MetaData/ImageMetaData.cs
@@ -5,6 +5,7 @@
 
 namespace ImageSharp
 {
+    using System;
     using System.Collections.Generic;
 
     /// <summary>
@@ -47,21 +48,7 @@ namespace ImageSharp
         {
             DebugGuard.NotNull(other, nameof(other));
 
-            this.HorizontalResolution = other.HorizontalResolution;
-            this.VerticalResolution = other.VerticalResolution;
-            this.Quality = other.Quality;
-            this.FrameDelay = other.FrameDelay;
-            this.RepeatCount = other.RepeatCount;
-
-            foreach (ImageProperty property in other.Properties)
-            {
-              this.Properties.Add(new ImageProperty(property));
-            }
-
-            if (other.ExifProfile != null)
-            {
-              this.ExifProfile = new ExifProfile(other.ExifProfile);
-            }
+            this.LoadFrom(other);
         }
 
         /// <summary>
@@ -142,6 +129,33 @@ namespace ImageSharp
         internal void SyncProfiles()
         {
             this.ExifProfile?.Sync(this);
+        }
+
+        /// <summary>
+        /// Sets the current metadata values based on a previous metadata object.
+        /// </summary>
+        /// <param name="other">Meta data object to copy values from.</param>
+        internal void LoadFrom(ImageMetaData other)
+        {
+            this.HorizontalResolution = other.HorizontalResolution;
+            this.VerticalResolution = other.VerticalResolution;
+            this.Quality = other.Quality;
+            this.FrameDelay = other.FrameDelay;
+            this.RepeatCount = other.RepeatCount;
+
+            foreach (ImageProperty property in other.Properties)
+            {
+                this.Properties.Add(new ImageProperty(property));
+            }
+
+            if (other.ExifProfile != null)
+            {
+                this.ExifProfile = new ExifProfile(other.ExifProfile);
+            }
+            else
+            {
+                this.ExifProfile = null;
+            }
         }
     }
 }

--- a/src/ImageSharp/MetaData/ImageMetaData.cs
+++ b/src/ImageSharp/MetaData/ImageMetaData.cs
@@ -48,7 +48,25 @@ namespace ImageSharp
         {
             DebugGuard.NotNull(other, nameof(other));
 
-            this.LoadFrom(other);
+            this.HorizontalResolution = other.HorizontalResolution;
+            this.VerticalResolution = other.VerticalResolution;
+            this.Quality = other.Quality;
+            this.FrameDelay = other.FrameDelay;
+            this.RepeatCount = other.RepeatCount;
+
+            foreach (ImageProperty property in other.Properties)
+            {
+                this.Properties.Add(new ImageProperty(property));
+            }
+
+            if (other.ExifProfile != null)
+            {
+                this.ExifProfile = new ExifProfile(other.ExifProfile);
+            }
+            else
+            {
+                this.ExifProfile = null;
+            }
         }
 
         /// <summary>
@@ -129,33 +147,6 @@ namespace ImageSharp
         internal void SyncProfiles()
         {
             this.ExifProfile?.Sync(this);
-        }
-
-        /// <summary>
-        /// Sets the current metadata values based on a previous metadata object.
-        /// </summary>
-        /// <param name="other">Meta data object to copy values from.</param>
-        internal void LoadFrom(ImageMetaData other)
-        {
-            this.HorizontalResolution = other.HorizontalResolution;
-            this.VerticalResolution = other.VerticalResolution;
-            this.Quality = other.Quality;
-            this.FrameDelay = other.FrameDelay;
-            this.RepeatCount = other.RepeatCount;
-
-            foreach (ImageProperty property in other.Properties)
-            {
-                this.Properties.Add(new ImageProperty(property));
-            }
-
-            if (other.ExifProfile != null)
-            {
-                this.ExifProfile = new ExifProfile(other.ExifProfile);
-            }
-            else
-            {
-                this.ExifProfile = null;
-            }
         }
     }
 }

--- a/src/ImageSharp/MetaData/Profiles/Exif/ExifProfile.cs
+++ b/src/ImageSharp/MetaData/Profiles/Exif/ExifProfile.cs
@@ -137,7 +137,7 @@ namespace ImageSharp
 
             using (MemoryStream memStream = new MemoryStream(this.data, this.thumbnailOffset, this.thumbnailLength))
             {
-                return new Image<TColor>(memStream);
+                return Image.Load<TColor>(memStream);
             }
         }
 

--- a/src/README.md
+++ b/src/README.md
@@ -1,0 +1,7 @@
+# ImageSharp core libraries
+
+## Coding conventions
+
+### Argument ordering 
+
+- When passing a `Configuration` object it should be the first argument

--- a/tests/ImageSharp.Benchmarks/Image/DecodeBmp.cs
+++ b/tests/ImageSharp.Benchmarks/Image/DecodeBmp.cs
@@ -43,7 +43,7 @@ namespace ImageSharp.Benchmarks.Image
         {
             using (MemoryStream memoryStream = new MemoryStream(this.bmpBytes))
             {
-                using (CoreImage image = new CoreImage(memoryStream))
+                using (CoreImage image = CoreImage.Load(memoryStream))
                 {
                     return new CoreSize(image.Width, image.Height);
                 }

--- a/tests/ImageSharp.Benchmarks/Image/DecodeFilteredPng.cs
+++ b/tests/ImageSharp.Benchmarks/Image/DecodeFilteredPng.cs
@@ -31,7 +31,7 @@ namespace ImageSharp.Benchmarks.Image
 
         private Size LoadPng(MemoryStream stream)
         {
-            using (Image image = new Image(stream))
+            using (Image image = Image.Load(stream))
             {
                 return new Size(image.Width, image.Height);
             }

--- a/tests/ImageSharp.Benchmarks/Image/DecodeGif.cs
+++ b/tests/ImageSharp.Benchmarks/Image/DecodeGif.cs
@@ -43,7 +43,7 @@ namespace ImageSharp.Benchmarks.Image
         {
             using (MemoryStream memoryStream = new MemoryStream(this.gifBytes))
             {
-                using (CoreImage image = new CoreImage(memoryStream))
+                using (CoreImage image = CoreImage.Load(memoryStream))
                 {
                     return new CoreSize(image.Width, image.Height);
                 }

--- a/tests/ImageSharp.Benchmarks/Image/DecodeJpeg.cs
+++ b/tests/ImageSharp.Benchmarks/Image/DecodeJpeg.cs
@@ -43,7 +43,7 @@ namespace ImageSharp.Benchmarks.Image
         {
             using (MemoryStream memoryStream = new MemoryStream(this.jpegBytes))
             {
-                using (CoreImage image = new CoreImage(memoryStream))
+                using (CoreImage image = CoreImage.Load(memoryStream))
                 {
                     return new CoreSize(image.Width, image.Height);
                 }

--- a/tests/ImageSharp.Benchmarks/Image/DecodeJpegMultiple.cs
+++ b/tests/ImageSharp.Benchmarks/Image/DecodeJpegMultiple.cs
@@ -25,7 +25,7 @@ namespace ImageSharp.Benchmarks.Image
         public void DecodeJpegImageSharp()
         {
             this.ForEachStream(
-                ms => new ImageSharp.Image(ms)
+                ms => ImageSharp.Image.Load(ms)
                 );  
         }
 

--- a/tests/ImageSharp.Benchmarks/Image/DecodePng.cs
+++ b/tests/ImageSharp.Benchmarks/Image/DecodePng.cs
@@ -43,7 +43,7 @@ namespace ImageSharp.Benchmarks.Image
         {
             using (MemoryStream memoryStream = new MemoryStream(this.pngBytes))
             {
-                using (CoreImage image = new CoreImage(memoryStream))
+                using (CoreImage image = CoreImage.Load(memoryStream))
                 {
                     return new CoreSize(image.Width, image.Height);
                 }

--- a/tests/ImageSharp.Benchmarks/Image/EncodeBmp.cs
+++ b/tests/ImageSharp.Benchmarks/Image/EncodeBmp.cs
@@ -25,7 +25,7 @@ namespace ImageSharp.Benchmarks.Image
             if (this.bmpStream == null)
             {
                 this.bmpStream = File.OpenRead("../ImageSharp.Tests/TestImages/Formats/Bmp/Car.bmp");
-                this.bmpCore = new CoreImage(this.bmpStream);
+                this.bmpCore = CoreImage.Load(this.bmpStream);
                 this.bmpStream.Position = 0;
                 this.bmpDrawing = Image.FromStream(this.bmpStream);
             }

--- a/tests/ImageSharp.Benchmarks/Image/EncodeGif.cs
+++ b/tests/ImageSharp.Benchmarks/Image/EncodeGif.cs
@@ -25,7 +25,7 @@ namespace ImageSharp.Benchmarks.Image
             if (this.bmpStream == null)
             {
                 this.bmpStream = File.OpenRead("../ImageSharp.Tests/TestImages/Formats/Bmp/Car.bmp");
-                this.bmpCore = new CoreImage(this.bmpStream);
+                this.bmpCore = CoreImage.Load(this.bmpStream);
                 this.bmpStream.Position = 0;
                 this.bmpDrawing = Image.FromStream(this.bmpStream);
             }

--- a/tests/ImageSharp.Benchmarks/Image/EncodeIndexedPng.cs
+++ b/tests/ImageSharp.Benchmarks/Image/EncodeIndexedPng.cs
@@ -34,7 +34,7 @@ namespace ImageSharp.Benchmarks.Image
                                   ? "../ImageSharp.Tests/TestImages/Formats/Jpg/baseline/jpeg420exif.jpg"
                                   : "../ImageSharp.Tests/TestImages/Formats/Bmp/Car.bmp";
                 this.bmpStream = File.OpenRead(path);
-                this.bmpCore = new Image(this.bmpStream);
+                this.bmpCore = Image.Load(this.bmpStream);
                 this.bmpStream.Position = 0;
             }
         }

--- a/tests/ImageSharp.Benchmarks/Image/EncodeJpeg.cs
+++ b/tests/ImageSharp.Benchmarks/Image/EncodeJpeg.cs
@@ -25,7 +25,7 @@ namespace ImageSharp.Benchmarks.Image
             if (this.bmpStream == null)
             {
                 this.bmpStream = File.OpenRead("../ImageSharp.Tests/TestImages/Formats/Bmp/Car.bmp");
-                this.bmpCore = new CoreImage(this.bmpStream);
+                this.bmpCore = CoreImage.Load(this.bmpStream);
                 this.bmpStream.Position = 0;
                 this.bmpDrawing = Image.FromStream(this.bmpStream);
             }

--- a/tests/ImageSharp.Benchmarks/Image/EncodePng.cs
+++ b/tests/ImageSharp.Benchmarks/Image/EncodePng.cs
@@ -38,7 +38,7 @@ namespace ImageSharp.Benchmarks.Image
                                   ? "../ImageSharp.Tests/TestImages/Formats/Jpg/baseline/jpeg420exif.jpg"
                                   : "../ImageSharp.Tests/TestImages/Formats/Bmp/Car.bmp";
                 this.bmpStream = File.OpenRead(path);
-                this.bmpCore = new CoreImage(this.bmpStream);
+                this.bmpCore = CoreImage.Load(this.bmpStream);
                 this.bmpStream.Position = 0;
                 this.bmpDrawing = Image.FromStream(this.bmpStream);
             }

--- a/tests/ImageSharp.Benchmarks/Image/MultiImageBenchmarkBase.cs
+++ b/tests/ImageSharp.Benchmarks/Image/MultiImageBenchmarkBase.cs
@@ -154,7 +154,7 @@ namespace ImageSharp.Benchmarks.Image
 
                     using (MemoryStream ms1 = new MemoryStream(bytes))
                     {
-                        this.FileNamesToImageSharpImages[fn] = new Image(ms1);
+                        this.FileNamesToImageSharpImages[fn] = Image.Load(ms1);
 
                     }
 

--- a/tests/ImageSharp.Benchmarks/Samplers/DetectEdges.cs
+++ b/tests/ImageSharp.Benchmarks/Samplers/DetectEdges.cs
@@ -23,7 +23,7 @@ namespace ImageSharp.Benchmarks
             {
                 using (FileStream stream = File.OpenRead("../ImageSharp.Tests/TestImages/Formats/Bmp/Car.bmp"))
                 {
-                    this.image = new CoreImage(stream);
+                    this.image = CoreImage.Load(stream);
                 }
             }
         }

--- a/tests/ImageSharp.Tests/Formats/GeneralFormatTests.cs
+++ b/tests/ImageSharp.Tests/Formats/GeneralFormatTests.cs
@@ -150,7 +150,7 @@ namespace ImageSharp.Tests
                     serialized = memoryStream.ToArray();
                 }
 
-                using (Image image2 = new Image(serialized))
+                using (Image image2 = Image.Load(serialized))
                 using (FileStream output = File.OpenWrite($"{path}/{file.FileName}"))
                 {
                     image2.Save(output);

--- a/tests/ImageSharp.Tests/Formats/Gif/GifEncoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Gif/GifEncoderTests.cs
@@ -29,7 +29,7 @@ namespace ImageSharp.Tests
                     input.Save(memStream, new GifFormat(), options);
 
                     memStream.Position = 0;
-                    using (Image output = new Image(memStream))
+                    using (Image output = Image.Load(memStream))
                     {
                         Assert.Equal(1, output.MetaData.Properties.Count);
                         Assert.Equal("Comments", output.MetaData.Properties[0].Name);
@@ -56,7 +56,7 @@ namespace ImageSharp.Tests
                     input.SaveAsGif(memStream, options);
 
                     memStream.Position = 0;
-                    using (Image output = new Image(memStream))
+                    using (Image output = Image.Load(memStream))
                     {
                         Assert.Equal(0, output.MetaData.Properties.Count);
                     }
@@ -77,7 +77,7 @@ namespace ImageSharp.Tests
                     input.Save(memStream, new GifFormat());
 
                     memStream.Position = 0;
-                    using (Image output = new Image(memStream))
+                    using (Image output = Image.Load(memStream))
                     {
                         Assert.Equal(1, output.MetaData.Properties.Count);
                         Assert.Equal("Comments", output.MetaData.Properties[0].Name);

--- a/tests/ImageSharp.Tests/Formats/Jpg/JpegDecoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/JpegDecoderTests.cs
@@ -90,7 +90,7 @@ namespace ImageSharp.Tests
                     image.Save(ms, new JpegEncoder());
                     ms.Seek(0, SeekOrigin.Begin);
                     
-                    using (JpegDecoderCore decoder = new JpegDecoderCore(null))
+                    using (JpegDecoderCore decoder = new JpegDecoderCore(null, null))
                     {
                         Image<TColor> mirror = decoder.Decode<TColor>(ms);
 

--- a/tests/ImageSharp.Tests/Formats/Jpg/JpegDecoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/JpegDecoderTests.cs
@@ -89,11 +89,10 @@ namespace ImageSharp.Tests
                 {
                     image.Save(ms, new JpegEncoder());
                     ms.Seek(0, SeekOrigin.Begin);
-
-                    Image<TColor> mirror = provider.Factory.CreateImage(1, 1);
+                    
                     using (JpegDecoderCore decoder = new JpegDecoderCore(null))
                     {
-                        decoder.Decode(mirror, ms, true);
+                        Image<TColor> mirror = decoder.Decode<TColor>(ms);
 
                         Assert.Equal(decoder.ImageWidth, image.Width);
                         Assert.Equal(decoder.ImageHeight, image.Height);

--- a/tests/ImageSharp.Tests/Formats/Jpg/JpegEncoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/JpegEncoderTests.cs
@@ -88,7 +88,7 @@ namespace ImageSharp.Tests
                     input.Save(memStream, new JpegFormat(), options);
 
                     memStream.Position = 0;
-                    using (Image output = new Image(memStream))
+                    using (Image output = Image.Load(memStream))
                     {
                         Assert.NotNull(output.MetaData.ExifProfile);
                     }
@@ -113,7 +113,7 @@ namespace ImageSharp.Tests
                     input.SaveAsJpeg(memStream, options);
 
                     memStream.Position = 0;
-                    using (Image output = new Image(memStream))
+                    using (Image output = Image.Load(memStream))
                     {
                         Assert.Null(output.MetaData.ExifProfile);
                     }

--- a/tests/ImageSharp.Tests/Formats/Jpg/JpegProfilingBenchmarks.cs
+++ b/tests/ImageSharp.Tests/Formats/Jpg/JpegProfilingBenchmarks.cs
@@ -50,7 +50,7 @@ namespace ImageSharp.Tests
                 ExecutionCount,
                 () =>
                     {
-                        Image img = new Image(bytes);
+                        Image img = Image.Load(bytes);
                     },
                 // ReSharper disable once ExplicitCallerInfoArgument
                 $"Decode {fileName}");

--- a/tests/ImageSharp.Tests/Image/ImageLoadTests.cs
+++ b/tests/ImageSharp.Tests/Image/ImageLoadTests.cs
@@ -44,7 +44,7 @@ namespace ImageSharp.Tests
             this.localFormat.Setup(x => x.IsSupportedFileFormat(It.IsAny<byte[]>())).Returns(true);
             this.localFormat.Setup(x => x.SupportedExtensions).Returns(new string[] { "png", "jpg" });
 
-            this.localDecoder.Setup(x => x.Decode<Color>(It.IsAny<Stream>(), It.IsAny<IDecoderOptions>(), It.IsAny<Configuration>()))
+            this.localDecoder.Setup(x => x.Decode<Color>(It.IsAny<Configuration>(), It.IsAny<Stream>(), It.IsAny<IDecoderOptions>()))
 
                 .Callback<Stream, IDecoderOptions, Configuration>((s, o, c) => {
                     using (var ms = new MemoryStream())
@@ -133,7 +133,7 @@ namespace ImageSharp.Tests
             Assert.NotNull(img);
             Assert.Equal(this.localFormat.Object, img.CurrentImageFormat);
 
-            this.localDecoder.Verify(x => x.Decode<Color>(stream, null, this.LocalConfiguration));
+            this.localDecoder.Verify(x => x.Decode<Color>(this.LocalConfiguration, stream, null));
 
         }
 
@@ -147,7 +147,7 @@ namespace ImageSharp.Tests
             Assert.Equal(this.returnImage, img);
             Assert.Equal(this.localFormat.Object, img.CurrentImageFormat);
 
-            this.localDecoder.Verify(x => x.Decode<Color>(stream, null, this.LocalConfiguration));
+            this.localDecoder.Verify(x => x.Decode<Color>(this.LocalConfiguration, stream, null));
 
         }
 
@@ -160,7 +160,7 @@ namespace ImageSharp.Tests
             Assert.NotNull(img);
             Assert.Equal(this.localFormat.Object, img.CurrentImageFormat);
 
-            this.localDecoder.Verify(x => x.Decode<Color>(stream, this.decoderOptions, this.LocalConfiguration));
+            this.localDecoder.Verify(x => x.Decode<Color>(this.LocalConfiguration, stream, this.decoderOptions));
 
         }
 
@@ -174,7 +174,7 @@ namespace ImageSharp.Tests
             Assert.Equal(this.returnImage, img);
             Assert.Equal(this.localFormat.Object, img.CurrentImageFormat);
 
-            this.localDecoder.Verify(x => x.Decode<Color>(stream, this.decoderOptions, this.LocalConfiguration));
+            this.localDecoder.Verify(x => x.Decode<Color>(this.LocalConfiguration, stream, this.decoderOptions));
 
         }
 
@@ -187,7 +187,7 @@ namespace ImageSharp.Tests
             Image img = Image.Load(stream, this.localDecoder.Object);
 
             Assert.NotNull(img);
-            this.localDecoder.Verify(x => x.Decode<Color>(stream, null, Configuration.Default));
+            this.localDecoder.Verify(x => x.Decode<Color>(Configuration.Default, stream, null));
         }
 
         [Fact]
@@ -198,7 +198,7 @@ namespace ImageSharp.Tests
 
             Assert.NotNull(img);
             Assert.Equal(this.returnImage, img);
-            this.localDecoder.Verify(x => x.Decode<Color>(stream, null, Configuration.Default));
+            this.localDecoder.Verify(x => x.Decode<Color>(Configuration.Default, stream, null));
         }
 
         [Fact]
@@ -208,7 +208,7 @@ namespace ImageSharp.Tests
             Image img = Image.Load(stream, this.localDecoder.Object, this.decoderOptions);
 
             Assert.NotNull(img);
-            this.localDecoder.Verify(x => x.Decode<Color>(stream, this.decoderOptions, Configuration.Default));
+            this.localDecoder.Verify(x => x.Decode<Color>(Configuration.Default, stream, this.decoderOptions));
         }
 
         [Fact]
@@ -219,7 +219,7 @@ namespace ImageSharp.Tests
 
             Assert.NotNull(img);
             Assert.Equal(this.returnImage, img);
-            this.localDecoder.Verify(x => x.Decode<Color>(stream, this.decoderOptions, Configuration.Default));
+            this.localDecoder.Verify(x => x.Decode<Color>(Configuration.Default, stream, this.decoderOptions));
         }
 
         [Fact]
@@ -281,7 +281,7 @@ namespace ImageSharp.Tests
             Assert.NotNull(img);
             Assert.Equal(this.localFormat.Object, img.CurrentImageFormat);
 
-            this.localDecoder.Verify(x => x.Decode<Color>(It.IsAny<Stream>(), null, this.LocalConfiguration));
+            this.localDecoder.Verify(x => x.Decode<Color>(this.LocalConfiguration, It.IsAny<Stream>(), null));
 
             Assert.Equal(this.DataStream.ToArray(), this.DecodedData);
         }
@@ -296,7 +296,7 @@ namespace ImageSharp.Tests
             Assert.Equal(this.localFormat.Object, img.CurrentImageFormat);
 
 
-            this.localDecoder.Verify(x => x.Decode<Color>(It.IsAny<Stream>(), null, this.LocalConfiguration));
+            this.localDecoder.Verify(x => x.Decode<Color>(this.LocalConfiguration, It.IsAny<Stream>(), null));
 
             Assert.Equal(this.DataStream.ToArray(), this.DecodedData);
         }
@@ -309,7 +309,7 @@ namespace ImageSharp.Tests
             Assert.NotNull(img);
             Assert.Equal(this.localFormat.Object, img.CurrentImageFormat);
 
-            this.localDecoder.Verify(x => x.Decode<Color>(It.IsAny<Stream>(), this.decoderOptions, this.LocalConfiguration));
+            this.localDecoder.Verify(x => x.Decode<Color>(this.LocalConfiguration, It.IsAny<Stream>(), this.decoderOptions));
 
             Assert.Equal(this.DataStream.ToArray(), this.DecodedData);
         }
@@ -323,7 +323,7 @@ namespace ImageSharp.Tests
             Assert.Equal(this.returnImage, img);
             Assert.Equal(this.localFormat.Object, img.CurrentImageFormat);
 
-            this.localDecoder.Verify(x => x.Decode<Color>(It.IsAny<Stream>(), this.decoderOptions, this.LocalConfiguration));
+            this.localDecoder.Verify(x => x.Decode<Color>(this.LocalConfiguration, It.IsAny<Stream>(), this.decoderOptions));
 
             Assert.Equal(this.DataStream.ToArray(), this.DecodedData);
         }
@@ -335,7 +335,7 @@ namespace ImageSharp.Tests
             Image img = Image.Load(this.DataStream.ToArray(), this.localDecoder.Object);
 
             Assert.NotNull(img);
-            this.localDecoder.Verify(x => x.Decode<Color>(It.IsAny<Stream>(), null, Configuration.Default));
+            this.localDecoder.Verify(x => x.Decode<Color>(Configuration.Default, It.IsAny<Stream>(), null));
             Assert.Equal(this.DataStream.ToArray(), this.DecodedData);
         }
 
@@ -346,7 +346,7 @@ namespace ImageSharp.Tests
 
             Assert.NotNull(img);
             Assert.Equal(this.returnImage, img);
-            this.localDecoder.Verify(x => x.Decode<Color>(It.IsAny<Stream>(), null, Configuration.Default));
+            this.localDecoder.Verify(x => x.Decode<Color>(Configuration.Default, It.IsAny<Stream>(), null));
             Assert.Equal(this.DataStream.ToArray(), this.DecodedData);
         }
 
@@ -356,7 +356,7 @@ namespace ImageSharp.Tests
             Image img = Image.Load(this.DataStream.ToArray(), this.localDecoder.Object, this.decoderOptions);
 
             Assert.NotNull(img);
-            this.localDecoder.Verify(x => x.Decode<Color>(It.IsAny<Stream>(), this.decoderOptions, Configuration.Default));
+            this.localDecoder.Verify(x => x.Decode<Color>(Configuration.Default, It.IsAny<Stream>(), this.decoderOptions));
             Assert.Equal(this.DataStream.ToArray(), this.DecodedData);
         }
 
@@ -367,7 +367,7 @@ namespace ImageSharp.Tests
 
             Assert.NotNull(img);
             Assert.Equal(this.returnImage, img);
-            this.localDecoder.Verify(x => x.Decode<Color>(It.IsAny<Stream>(), this.decoderOptions, Configuration.Default));
+            this.localDecoder.Verify(x => x.Decode<Color>(Configuration.Default, It.IsAny<Stream>(), this.decoderOptions));
             Assert.Equal(this.DataStream.ToArray(), this.DecodedData);
         }
 
@@ -430,7 +430,7 @@ namespace ImageSharp.Tests
             Assert.NotNull(img);
             Assert.Equal(this.localFormat.Object, img.CurrentImageFormat);
 
-            this.localDecoder.Verify(x => x.Decode<Color>(this.DataStream, null, this.LocalConfiguration));
+            this.localDecoder.Verify(x => x.Decode<Color>(this.LocalConfiguration, this.DataStream, null));
 
         }
 
@@ -443,7 +443,7 @@ namespace ImageSharp.Tests
             Assert.Equal(this.returnImage, img);
             Assert.Equal(this.localFormat.Object, img.CurrentImageFormat);
 
-            this.localDecoder.Verify(x => x.Decode<Color>(this.DataStream, null, this.LocalConfiguration));
+            this.localDecoder.Verify(x => x.Decode<Color>(this.LocalConfiguration, this.DataStream, null));
 
         }
 
@@ -455,7 +455,7 @@ namespace ImageSharp.Tests
             Assert.NotNull(img);
             Assert.Equal(this.localFormat.Object, img.CurrentImageFormat);
 
-            this.localDecoder.Verify(x => x.Decode<Color>(this.DataStream, this.decoderOptions, this.LocalConfiguration));
+            this.localDecoder.Verify(x => x.Decode<Color>(this.LocalConfiguration, this.DataStream, this.decoderOptions));
 
         }
 
@@ -468,7 +468,7 @@ namespace ImageSharp.Tests
             Assert.Equal(this.returnImage, img);
             Assert.Equal(this.localFormat.Object, img.CurrentImageFormat);
 
-            this.localDecoder.Verify(x => x.Decode<Color>(this.DataStream, this.decoderOptions, this.LocalConfiguration));
+            this.localDecoder.Verify(x => x.Decode<Color>(this.LocalConfiguration, this.DataStream, this.decoderOptions));
 
         }
 
@@ -479,7 +479,7 @@ namespace ImageSharp.Tests
             Image img = Image.Load(this.FilePath, this.localDecoder.Object);
 
             Assert.NotNull(img);
-            this.localDecoder.Verify(x => x.Decode<Color>(this.DataStream, null, Configuration.Default));
+            this.localDecoder.Verify(x => x.Decode<Color>(Configuration.Default, this.DataStream, null));
         }
 
         [Fact]
@@ -489,7 +489,7 @@ namespace ImageSharp.Tests
 
             Assert.NotNull(img);
             Assert.Equal(this.returnImage, img);
-            this.localDecoder.Verify(x => x.Decode<Color>(this.DataStream, null, Configuration.Default));
+            this.localDecoder.Verify(x => x.Decode<Color>(Configuration.Default, this.DataStream, null));
         }
 
         [Fact]
@@ -498,7 +498,7 @@ namespace ImageSharp.Tests
             Image img = Image.Load(this.FilePath, this.localDecoder.Object, this.decoderOptions);
 
             Assert.NotNull(img);
-            this.localDecoder.Verify(x => x.Decode<Color>(this.DataStream, this.decoderOptions, Configuration.Default));
+            this.localDecoder.Verify(x => x.Decode<Color>(Configuration.Default, this.DataStream, this.decoderOptions));
         }
 
         [Fact]
@@ -508,7 +508,7 @@ namespace ImageSharp.Tests
 
             Assert.NotNull(img);
             Assert.Equal(this.returnImage, img);
-            this.localDecoder.Verify(x => x.Decode<Color>(this.DataStream, this.decoderOptions, Configuration.Default));
+            this.localDecoder.Verify(x => x.Decode<Color>(Configuration.Default, this.DataStream, this.decoderOptions));
         }
 
         public void Dispose()

--- a/tests/ImageSharp.Tests/Image/ImageLoadTests.cs
+++ b/tests/ImageSharp.Tests/Image/ImageLoadTests.cs
@@ -128,7 +128,7 @@ namespace ImageSharp.Tests
         public void LoadFromStreamWithConfig()
         {
             Stream stream = new MemoryStream();
-            Image img = Image.Load(stream, this.LocalConfiguration);
+            Image img = Image.Load(this.LocalConfiguration, stream);
 
             Assert.NotNull(img);
             Assert.Equal(this.localFormat.Object, img.CurrentImageFormat);
@@ -141,7 +141,7 @@ namespace ImageSharp.Tests
         public void LoadFromStreamWithTypeAndConfig()
         {
             Stream stream = new MemoryStream();
-            Image<Color> img = Image.Load<Color>(stream, this.LocalConfiguration);
+            Image<Color> img = Image.Load<Color>(this.LocalConfiguration, stream);
 
             Assert.NotNull(img);
             Assert.Equal(this.returnImage, img);
@@ -155,7 +155,7 @@ namespace ImageSharp.Tests
         public void LoadFromStreamWithConfigAndOptions()
         {
             Stream stream = new MemoryStream();
-            Image img = Image.Load(stream, this.decoderOptions, this.LocalConfiguration);
+            Image img = Image.Load(this.LocalConfiguration, stream, this.decoderOptions);
 
             Assert.NotNull(img);
             Assert.Equal(this.localFormat.Object, img.CurrentImageFormat);
@@ -168,7 +168,7 @@ namespace ImageSharp.Tests
         public void LoadFromStreamWithTypeAndConfigAndOptions()
         {
             Stream stream = new MemoryStream();
-            Image<Color> img = Image.Load<Color>(stream, this.decoderOptions, this.LocalConfiguration);
+            Image<Color> img = Image.Load<Color>(this.LocalConfiguration, stream, this.decoderOptions);
 
             Assert.NotNull(img);
             Assert.Equal(this.returnImage, img);
@@ -276,7 +276,7 @@ namespace ImageSharp.Tests
         [Fact]
         public void LoadFromBytesWithConfig()
         {
-            Image img = Image.Load(this.DataStream.ToArray(), this.LocalConfiguration);
+            Image img = Image.Load(this.LocalConfiguration, this.DataStream.ToArray());
 
             Assert.NotNull(img);
             Assert.Equal(this.localFormat.Object, img.CurrentImageFormat);
@@ -289,7 +289,7 @@ namespace ImageSharp.Tests
         [Fact]
         public void LoadFromBytesWithTypeAndConfig()
         {
-            Image<Color> img = Image.Load<Color>(this.DataStream.ToArray(), this.LocalConfiguration);
+            Image<Color> img = Image.Load<Color>(this.LocalConfiguration, this.DataStream.ToArray());
 
             Assert.NotNull(img);
             Assert.Equal(this.returnImage, img);
@@ -304,7 +304,7 @@ namespace ImageSharp.Tests
         [Fact]
         public void LoadFromBytesWithConfigAndOptions()
         {
-            Image img = Image.Load(this.DataStream.ToArray(), this.decoderOptions, this.LocalConfiguration);
+            Image img = Image.Load(this.LocalConfiguration, this.DataStream.ToArray(), this.decoderOptions);
 
             Assert.NotNull(img);
             Assert.Equal(this.localFormat.Object, img.CurrentImageFormat);
@@ -317,7 +317,7 @@ namespace ImageSharp.Tests
         [Fact]
         public void LoadFromBytesWithTypeAndConfigAndOptions()
         {
-            Image<Color> img = Image.Load<Color>(this.DataStream.ToArray(), this.decoderOptions, this.LocalConfiguration);
+            Image<Color> img = Image.Load<Color>(this.LocalConfiguration, this.DataStream.ToArray(), this.decoderOptions);
 
             Assert.NotNull(img);
             Assert.Equal(this.returnImage, img);
@@ -425,7 +425,7 @@ namespace ImageSharp.Tests
         [Fact]
         public void LoadFromFileWithConfig()
         {
-            Image img = Image.Load(this.FilePath, this.LocalConfiguration);
+            Image img = Image.Load(this.LocalConfiguration, this.FilePath);
 
             Assert.NotNull(img);
             Assert.Equal(this.localFormat.Object, img.CurrentImageFormat);
@@ -437,7 +437,7 @@ namespace ImageSharp.Tests
         [Fact]
         public void LoadFromFileWithTypeAndConfig()
         {
-            Image<Color> img = Image.Load<Color>(this.FilePath, this.LocalConfiguration);
+            Image<Color> img = Image.Load<Color>(this.LocalConfiguration, this.FilePath);
 
             Assert.NotNull(img);
             Assert.Equal(this.returnImage, img);
@@ -450,7 +450,7 @@ namespace ImageSharp.Tests
         [Fact]
         public void LoadFromFileWithConfigAndOptions()
         {
-            Image img = Image.Load(this.FilePath, this.decoderOptions, this.LocalConfiguration);
+            Image img = Image.Load(this.LocalConfiguration, this.FilePath, this.decoderOptions);
 
             Assert.NotNull(img);
             Assert.Equal(this.localFormat.Object, img.CurrentImageFormat);
@@ -462,7 +462,7 @@ namespace ImageSharp.Tests
         [Fact]
         public void LoadFromFileWithTypeAndConfigAndOptions()
         {
-            Image<Color> img = Image.Load<Color>(this.FilePath, this.decoderOptions, this.LocalConfiguration);
+            Image<Color> img = Image.Load<Color>(this.LocalConfiguration, this.FilePath, this.decoderOptions);
 
             Assert.NotNull(img);
             Assert.Equal(this.returnImage, img);

--- a/tests/ImageSharp.Tests/Image/ImageLoadTests.cs
+++ b/tests/ImageSharp.Tests/Image/ImageLoadTests.cs
@@ -46,7 +46,7 @@ namespace ImageSharp.Tests
 
             this.localDecoder.Setup(x => x.Decode<Color>(It.IsAny<Configuration>(), It.IsAny<Stream>(), It.IsAny<IDecoderOptions>()))
 
-                .Callback<Stream, IDecoderOptions, Configuration>((s, o, c) => {
+                .Callback<Configuration, Stream, IDecoderOptions>((c, s, o) => {
                     using (var ms = new MemoryStream())
                     {
                         s.CopyTo(ms);

--- a/tests/ImageSharp.Tests/Image/ImageLoadTests.cs
+++ b/tests/ImageSharp.Tests/Image/ImageLoadTests.cs
@@ -66,6 +66,9 @@ namespace ImageSharp.Tests
 
             this.FilePath = Guid.NewGuid().ToString();
             this.fileSystem.Setup(x => x.OpenRead(this.FilePath)).Returns(this.DataStream);
+
+            TestFileSystem.RegisterGloablTestFormat();
+            TestFileSystem.Global.AddFile(this.FilePath, this.DataStream);
         }
 
         [Fact]
@@ -154,6 +157,50 @@ namespace ImageSharp.Tests
             Assert.NotNull(img);
             Assert.Equal(this.returnImage, img);
             Assert.Equal(this.localFormat.Object, img.CurrentImageFormat);
+            this.localDecoder.Verify(x => x.Decode<Color>(stream, this.decoderOptions));
+        }
+
+
+
+        [Fact]
+        public void LoadFromStreamWithDecoder()
+        {
+            Stream stream = new MemoryStream();
+            Image img = Image.Load(stream, this.localDecoder.Object);
+
+            Assert.NotNull(img);
+            this.localDecoder.Verify(x => x.Decode<Color>(stream, null));
+        }
+
+        [Fact]
+        public void LoadFromStreamWithTypeAndDecoder()
+        {
+            Stream stream = new MemoryStream();
+            Image<Color> img = Image.Load<Color>(stream, this.localDecoder.Object);
+
+            Assert.NotNull(img);
+            Assert.Equal(this.returnImage, img);
+            this.localDecoder.Verify(x => x.Decode<Color>(stream, null));
+        }
+
+        [Fact]
+        public void LoadFromStreamWithDecoderAndOptions()
+        {
+            Stream stream = new MemoryStream();
+            Image img = Image.Load(stream, this.localDecoder.Object, this.decoderOptions);
+
+            Assert.NotNull(img);
+            this.localDecoder.Verify(x => x.Decode<Color>(stream, this.decoderOptions));
+        }
+
+        [Fact]
+        public void LoadFromStreamWithTypeAndDecoderAndOptions()
+        {
+            Stream stream = new MemoryStream();
+            Image<Color> img = Image.Load<Color>(stream, this.localDecoder.Object, this.decoderOptions);
+
+            Assert.NotNull(img);
+            Assert.Equal(this.returnImage, img);
             this.localDecoder.Verify(x => x.Decode<Color>(stream, this.decoderOptions));
         }
 
@@ -246,7 +293,50 @@ namespace ImageSharp.Tests
             this.localDecoder.Verify(x => x.Decode<Color>(It.IsAny<Stream>(), this.decoderOptions));
             Assert.Equal(this.DataStream.ToArray(), this.DecodedData);
         }
-        
+
+
+        [Fact]
+        public void LoadFromBytesWithDecoder()
+        {
+            Image img = Image.Load(this.DataStream.ToArray(), this.localDecoder.Object);
+
+            Assert.NotNull(img);
+            this.localDecoder.Verify(x => x.Decode<Color>(It.IsAny<Stream>(), null));
+            Assert.Equal(this.DataStream.ToArray(), this.DecodedData);
+        }
+
+        [Fact]
+        public void LoadFromBytesWithTypeAndDecoder()
+        {
+            Image<Color> img = Image.Load<Color>(this.DataStream.ToArray(), this.localDecoder.Object);
+
+            Assert.NotNull(img);
+            Assert.Equal(this.returnImage, img);
+            this.localDecoder.Verify(x => x.Decode<Color>(It.IsAny<Stream>(), null));
+            Assert.Equal(this.DataStream.ToArray(), this.DecodedData);
+        }
+
+        [Fact]
+        public void LoadFromBytesWithDecoderAndOptions()
+        {
+            Image img = Image.Load(this.DataStream.ToArray(), this.localDecoder.Object, this.decoderOptions);
+
+            Assert.NotNull(img);
+            this.localDecoder.Verify(x => x.Decode<Color>(It.IsAny<Stream>(), this.decoderOptions));
+            Assert.Equal(this.DataStream.ToArray(), this.DecodedData);
+        }
+
+        [Fact]
+        public void LoadFromBytesWithTypeAndDecoderAndOptions()
+        {
+            Image<Color> img = Image.Load<Color>(this.DataStream.ToArray(), this.localDecoder.Object, this.decoderOptions);
+
+            Assert.NotNull(img);
+            Assert.Equal(this.returnImage, img);
+            this.localDecoder.Verify(x => x.Decode<Color>(It.IsAny<Stream>(), this.decoderOptions));
+            Assert.Equal(this.DataStream.ToArray(), this.DecodedData);
+        }
+
         [Fact]
         public void LoadFromFile()
         {
@@ -324,11 +414,50 @@ namespace ImageSharp.Tests
         [Fact]
         public void LoadFromFileWithTypeAndConfigAndOptions()
         {
-            Image<Color> img = Image.Load<Color>(FilePath, this.decoderOptions, this.LocalConfiguration);
+            Image<Color> img = Image.Load<Color>(this.FilePath, this.decoderOptions, this.LocalConfiguration);
 
             Assert.NotNull(img);
             Assert.Equal(this.returnImage, img);
             Assert.Equal(this.localFormat.Object, img.CurrentImageFormat);
+            this.localDecoder.Verify(x => x.Decode<Color>(this.DataStream, this.decoderOptions));
+        }
+
+
+        [Fact]
+        public void LoadFromFileWithDecoder()
+        {
+            Image img = Image.Load(this.FilePath, this.localDecoder.Object);
+
+            Assert.NotNull(img);
+            this.localDecoder.Verify(x => x.Decode<Color>(this.DataStream, null));
+        }
+
+        [Fact]
+        public void LoadFromFileWithTypeAndDecoder()
+        {
+            Image<Color> img = Image.Load<Color>(this.FilePath, this.localDecoder.Object);
+
+            Assert.NotNull(img);
+            Assert.Equal(this.returnImage, img);
+            this.localDecoder.Verify(x => x.Decode<Color>(this.DataStream, null));
+        }
+
+        [Fact]
+        public void LoadFromFileWithDecoderAndOptions()
+        {
+            Image img = Image.Load(this.FilePath, this.localDecoder.Object, this.decoderOptions);
+
+            Assert.NotNull(img);
+            this.localDecoder.Verify(x => x.Decode<Color>(this.DataStream, this.decoderOptions));
+        }
+
+        [Fact]
+        public void LoadFromFileWithTypeAndDecoderAndOptions()
+        {
+            Image<Color> img = Image.Load<Color>(this.FilePath, this.localDecoder.Object, this.decoderOptions);
+
+            Assert.NotNull(img);
+            Assert.Equal(this.returnImage, img);
             this.localDecoder.Verify(x => x.Decode<Color>(this.DataStream, this.decoderOptions));
         }
 

--- a/tests/ImageSharp.Tests/Image/ImageLoadTests.cs
+++ b/tests/ImageSharp.Tests/Image/ImageLoadTests.cs
@@ -32,7 +32,7 @@ namespace ImageSharp.Tests
 
         public ImageLoadTests()
         {
-            this.returnImage = new Image<Color>(1, 1);
+            this.returnImage = new Image(1, 1);
            
             this.localDecoder = new Mock<IImageDecoder>();
             this.localFormat = new Mock<IImageFormat>();
@@ -43,8 +43,10 @@ namespace ImageSharp.Tests
             this.localFormat.Setup(x => x.HeaderSize).Returns(1);
             this.localFormat.Setup(x => x.IsSupportedFileFormat(It.IsAny<byte[]>())).Returns(true);
             this.localFormat.Setup(x => x.SupportedExtensions).Returns(new string[] { "png", "jpg" });
-            this.localDecoder.Setup(x => x.Decode<Color>(It.IsAny<Stream>(), It.IsAny<IDecoderOptions>()))
-                .Callback<Stream, IDecoderOptions>((s, o) => {
+
+            this.localDecoder.Setup(x => x.Decode<Color>(It.IsAny<Stream>(), It.IsAny<IDecoderOptions>(), It.IsAny<Configuration>()))
+
+                .Callback<Stream, IDecoderOptions, Configuration>((s, o, c) => {
                     using (var ms = new MemoryStream())
                     {
                         s.CopyTo(ms);
@@ -79,7 +81,9 @@ namespace ImageSharp.Tests
             Assert.NotNull(img);
             Assert.Equal(TestFormat.GlobalTestFormat, img.CurrentImageFormat);
 
-            TestFormat.GlobalTestFormat.VerifyDecodeCall(this.Marker, null);
+
+            TestFormat.GlobalTestFormat.VerifyDecodeCall(this.Marker, null, Configuration.Default);
+
         }
 
         [Fact]
@@ -90,7 +94,9 @@ namespace ImageSharp.Tests
             Assert.NotNull(img);
             Assert.Equal(TestFormat.GlobalTestFormat.Sample<Color>(), img);
             Assert.Equal(TestFormat.GlobalTestFormat, img.CurrentImageFormat);
-            TestFormat.GlobalTestFormat.VerifyDecodeCall(this.Marker, null);
+
+            TestFormat.GlobalTestFormat.VerifyDecodeCall(this.Marker, null, Configuration.Default);
+
         }
 
         [Fact]
@@ -100,7 +106,9 @@ namespace ImageSharp.Tests
 
             Assert.NotNull(img);
             Assert.Equal(TestFormat.GlobalTestFormat, img.CurrentImageFormat);
-            TestFormat.GlobalTestFormat.VerifyDecodeCall(this.Marker, this.decoderOptions);
+
+            TestFormat.GlobalTestFormat.VerifyDecodeCall(this.Marker, this.decoderOptions, Configuration.Default);
+
         }
 
         [Fact]
@@ -111,7 +119,9 @@ namespace ImageSharp.Tests
             Assert.NotNull(img);
             Assert.Equal(TestFormat.GlobalTestFormat.Sample<Color>(), img);
             Assert.Equal(TestFormat.GlobalTestFormat, img.CurrentImageFormat);
-            TestFormat.GlobalTestFormat.VerifyDecodeCall(this.Marker, this.decoderOptions);
+
+            TestFormat.GlobalTestFormat.VerifyDecodeCall(this.Marker, this.decoderOptions, Configuration.Default);
+
         }
 
         [Fact]
@@ -122,7 +132,9 @@ namespace ImageSharp.Tests
 
             Assert.NotNull(img);
             Assert.Equal(this.localFormat.Object, img.CurrentImageFormat);
-            this.localDecoder.Verify(x => x.Decode<Color>(stream, null));
+
+            this.localDecoder.Verify(x => x.Decode<Color>(stream, null, this.LocalConfiguration));
+
         }
 
         [Fact]
@@ -134,7 +146,9 @@ namespace ImageSharp.Tests
             Assert.NotNull(img);
             Assert.Equal(this.returnImage, img);
             Assert.Equal(this.localFormat.Object, img.CurrentImageFormat);
-            this.localDecoder.Verify(x => x.Decode<Color>(stream, null));
+
+            this.localDecoder.Verify(x => x.Decode<Color>(stream, null, this.LocalConfiguration));
+
         }
 
         [Fact]
@@ -145,7 +159,9 @@ namespace ImageSharp.Tests
 
             Assert.NotNull(img);
             Assert.Equal(this.localFormat.Object, img.CurrentImageFormat);
-            this.localDecoder.Verify(x => x.Decode<Color>(stream, this.decoderOptions));
+
+            this.localDecoder.Verify(x => x.Decode<Color>(stream, this.decoderOptions, this.LocalConfiguration));
+
         }
 
         [Fact]
@@ -157,7 +173,9 @@ namespace ImageSharp.Tests
             Assert.NotNull(img);
             Assert.Equal(this.returnImage, img);
             Assert.Equal(this.localFormat.Object, img.CurrentImageFormat);
-            this.localDecoder.Verify(x => x.Decode<Color>(stream, this.decoderOptions));
+
+            this.localDecoder.Verify(x => x.Decode<Color>(stream, this.decoderOptions, this.LocalConfiguration));
+
         }
 
 
@@ -169,7 +187,7 @@ namespace ImageSharp.Tests
             Image img = Image.Load(stream, this.localDecoder.Object);
 
             Assert.NotNull(img);
-            this.localDecoder.Verify(x => x.Decode<Color>(stream, null));
+            this.localDecoder.Verify(x => x.Decode<Color>(stream, null, Configuration.Default));
         }
 
         [Fact]
@@ -180,7 +198,7 @@ namespace ImageSharp.Tests
 
             Assert.NotNull(img);
             Assert.Equal(this.returnImage, img);
-            this.localDecoder.Verify(x => x.Decode<Color>(stream, null));
+            this.localDecoder.Verify(x => x.Decode<Color>(stream, null, Configuration.Default));
         }
 
         [Fact]
@@ -190,7 +208,7 @@ namespace ImageSharp.Tests
             Image img = Image.Load(stream, this.localDecoder.Object, this.decoderOptions);
 
             Assert.NotNull(img);
-            this.localDecoder.Verify(x => x.Decode<Color>(stream, this.decoderOptions));
+            this.localDecoder.Verify(x => x.Decode<Color>(stream, this.decoderOptions, Configuration.Default));
         }
 
         [Fact]
@@ -201,7 +219,7 @@ namespace ImageSharp.Tests
 
             Assert.NotNull(img);
             Assert.Equal(this.returnImage, img);
-            this.localDecoder.Verify(x => x.Decode<Color>(stream, this.decoderOptions));
+            this.localDecoder.Verify(x => x.Decode<Color>(stream, this.decoderOptions, Configuration.Default));
         }
 
         [Fact]
@@ -212,7 +230,9 @@ namespace ImageSharp.Tests
             Assert.NotNull(img);
             Assert.Equal(TestFormat.GlobalTestFormat, img.CurrentImageFormat);
 
-            TestFormat.GlobalTestFormat.VerifyDecodeCall(this.Marker, null);
+
+            TestFormat.GlobalTestFormat.VerifyDecodeCall(this.Marker, null, Configuration.Default);
+
         }
 
         [Fact]
@@ -223,7 +243,9 @@ namespace ImageSharp.Tests
             Assert.NotNull(img);
             Assert.Equal(TestFormat.GlobalTestFormat.Sample<Color>(), img);
             Assert.Equal(TestFormat.GlobalTestFormat, img.CurrentImageFormat);
-            TestFormat.GlobalTestFormat.VerifyDecodeCall(this.Marker, null);
+
+            TestFormat.GlobalTestFormat.VerifyDecodeCall(this.Marker, null, Configuration.Default);
+
         }
 
         [Fact]
@@ -233,7 +255,9 @@ namespace ImageSharp.Tests
 
             Assert.NotNull(img);
             Assert.Equal(TestFormat.GlobalTestFormat, img.CurrentImageFormat);
-            TestFormat.GlobalTestFormat.VerifyDecodeCall(this.Marker, this.decoderOptions);
+
+            TestFormat.GlobalTestFormat.VerifyDecodeCall(this.Marker, this.decoderOptions, Configuration.Default);
+
         }
 
         [Fact]
@@ -244,7 +268,9 @@ namespace ImageSharp.Tests
             Assert.NotNull(img);
             Assert.Equal(TestFormat.GlobalTestFormat.Sample<Color>(), img);
             Assert.Equal(TestFormat.GlobalTestFormat, img.CurrentImageFormat);
-            TestFormat.GlobalTestFormat.VerifyDecodeCall(this.Marker, this.decoderOptions);
+
+            TestFormat.GlobalTestFormat.VerifyDecodeCall(this.Marker, this.decoderOptions, Configuration.Default);
+
         }
 
         [Fact]
@@ -254,7 +280,9 @@ namespace ImageSharp.Tests
 
             Assert.NotNull(img);
             Assert.Equal(this.localFormat.Object, img.CurrentImageFormat);
-            this.localDecoder.Verify(x => x.Decode<Color>(It.IsAny<Stream>(), null));
+
+            this.localDecoder.Verify(x => x.Decode<Color>(It.IsAny<Stream>(), null, this.LocalConfiguration));
+
             Assert.Equal(this.DataStream.ToArray(), this.DecodedData);
         }
 
@@ -267,7 +295,9 @@ namespace ImageSharp.Tests
             Assert.Equal(this.returnImage, img);
             Assert.Equal(this.localFormat.Object, img.CurrentImageFormat);
 
-            this.localDecoder.Verify(x => x.Decode<Color>(It.IsAny<Stream>(), null));
+
+            this.localDecoder.Verify(x => x.Decode<Color>(It.IsAny<Stream>(), null, this.LocalConfiguration));
+
             Assert.Equal(this.DataStream.ToArray(), this.DecodedData);
         }
 
@@ -278,7 +308,9 @@ namespace ImageSharp.Tests
 
             Assert.NotNull(img);
             Assert.Equal(this.localFormat.Object, img.CurrentImageFormat);
-            this.localDecoder.Verify(x => x.Decode<Color>(It.IsAny<Stream>(), this.decoderOptions));
+
+            this.localDecoder.Verify(x => x.Decode<Color>(It.IsAny<Stream>(), this.decoderOptions, this.LocalConfiguration));
+
             Assert.Equal(this.DataStream.ToArray(), this.DecodedData);
         }
 
@@ -290,7 +322,9 @@ namespace ImageSharp.Tests
             Assert.NotNull(img);
             Assert.Equal(this.returnImage, img);
             Assert.Equal(this.localFormat.Object, img.CurrentImageFormat);
-            this.localDecoder.Verify(x => x.Decode<Color>(It.IsAny<Stream>(), this.decoderOptions));
+
+            this.localDecoder.Verify(x => x.Decode<Color>(It.IsAny<Stream>(), this.decoderOptions, this.LocalConfiguration));
+
             Assert.Equal(this.DataStream.ToArray(), this.DecodedData);
         }
 
@@ -301,7 +335,7 @@ namespace ImageSharp.Tests
             Image img = Image.Load(this.DataStream.ToArray(), this.localDecoder.Object);
 
             Assert.NotNull(img);
-            this.localDecoder.Verify(x => x.Decode<Color>(It.IsAny<Stream>(), null));
+            this.localDecoder.Verify(x => x.Decode<Color>(It.IsAny<Stream>(), null, Configuration.Default));
             Assert.Equal(this.DataStream.ToArray(), this.DecodedData);
         }
 
@@ -312,7 +346,7 @@ namespace ImageSharp.Tests
 
             Assert.NotNull(img);
             Assert.Equal(this.returnImage, img);
-            this.localDecoder.Verify(x => x.Decode<Color>(It.IsAny<Stream>(), null));
+            this.localDecoder.Verify(x => x.Decode<Color>(It.IsAny<Stream>(), null, Configuration.Default));
             Assert.Equal(this.DataStream.ToArray(), this.DecodedData);
         }
 
@@ -322,7 +356,7 @@ namespace ImageSharp.Tests
             Image img = Image.Load(this.DataStream.ToArray(), this.localDecoder.Object, this.decoderOptions);
 
             Assert.NotNull(img);
-            this.localDecoder.Verify(x => x.Decode<Color>(It.IsAny<Stream>(), this.decoderOptions));
+            this.localDecoder.Verify(x => x.Decode<Color>(It.IsAny<Stream>(), this.decoderOptions, Configuration.Default));
             Assert.Equal(this.DataStream.ToArray(), this.DecodedData);
         }
 
@@ -333,7 +367,7 @@ namespace ImageSharp.Tests
 
             Assert.NotNull(img);
             Assert.Equal(this.returnImage, img);
-            this.localDecoder.Verify(x => x.Decode<Color>(It.IsAny<Stream>(), this.decoderOptions));
+            this.localDecoder.Verify(x => x.Decode<Color>(It.IsAny<Stream>(), this.decoderOptions, Configuration.Default));
             Assert.Equal(this.DataStream.ToArray(), this.DecodedData);
         }
 
@@ -345,7 +379,9 @@ namespace ImageSharp.Tests
             Assert.NotNull(img);
             Assert.Equal(TestFormat.GlobalTestFormat, img.CurrentImageFormat);
 
-            TestFormat.GlobalTestFormat.VerifyDecodeCall(this.Marker, null);
+
+            TestFormat.GlobalTestFormat.VerifyDecodeCall(this.Marker, null, Configuration.Default);
+
         }
 
         [Fact]
@@ -356,7 +392,9 @@ namespace ImageSharp.Tests
             Assert.NotNull(img);
             Assert.Equal(TestFormat.GlobalTestFormat.Sample<Color>(), img);
             Assert.Equal(TestFormat.GlobalTestFormat, img.CurrentImageFormat);
-            TestFormat.GlobalTestFormat.VerifyDecodeCall(this.Marker, null);
+
+            TestFormat.GlobalTestFormat.VerifyDecodeCall(this.Marker, null, Configuration.Default);
+
         }
 
         [Fact]
@@ -366,7 +404,9 @@ namespace ImageSharp.Tests
 
             Assert.NotNull(img);
             Assert.Equal(TestFormat.GlobalTestFormat, img.CurrentImageFormat);
-            TestFormat.GlobalTestFormat.VerifyDecodeCall(this.Marker, this.decoderOptions);
+
+            TestFormat.GlobalTestFormat.VerifyDecodeCall(this.Marker, this.decoderOptions, Configuration.Default);
+
         }
 
         [Fact]
@@ -377,7 +417,9 @@ namespace ImageSharp.Tests
             Assert.NotNull(img);
             Assert.Equal(TestFormat.GlobalTestFormat.Sample<Color>(), img);
             Assert.Equal(TestFormat.GlobalTestFormat, img.CurrentImageFormat);
-            TestFormat.GlobalTestFormat.VerifyDecodeCall(this.Marker, this.decoderOptions);
+
+            TestFormat.GlobalTestFormat.VerifyDecodeCall(this.Marker, this.decoderOptions, Configuration.Default);
+
         }
 
         [Fact]
@@ -387,7 +429,9 @@ namespace ImageSharp.Tests
 
             Assert.NotNull(img);
             Assert.Equal(this.localFormat.Object, img.CurrentImageFormat);
-            this.localDecoder.Verify(x => x.Decode<Color>(this.DataStream, null));
+
+            this.localDecoder.Verify(x => x.Decode<Color>(this.DataStream, null, this.LocalConfiguration));
+
         }
 
         [Fact]
@@ -398,7 +442,9 @@ namespace ImageSharp.Tests
             Assert.NotNull(img);
             Assert.Equal(this.returnImage, img);
             Assert.Equal(this.localFormat.Object, img.CurrentImageFormat);
-            this.localDecoder.Verify(x => x.Decode<Color>(this.DataStream, null));
+
+            this.localDecoder.Verify(x => x.Decode<Color>(this.DataStream, null, this.LocalConfiguration));
+
         }
 
         [Fact]
@@ -408,7 +454,9 @@ namespace ImageSharp.Tests
 
             Assert.NotNull(img);
             Assert.Equal(this.localFormat.Object, img.CurrentImageFormat);
-            this.localDecoder.Verify(x => x.Decode<Color>(this.DataStream, this.decoderOptions));
+
+            this.localDecoder.Verify(x => x.Decode<Color>(this.DataStream, this.decoderOptions, this.LocalConfiguration));
+
         }
 
         [Fact]
@@ -419,7 +467,9 @@ namespace ImageSharp.Tests
             Assert.NotNull(img);
             Assert.Equal(this.returnImage, img);
             Assert.Equal(this.localFormat.Object, img.CurrentImageFormat);
-            this.localDecoder.Verify(x => x.Decode<Color>(this.DataStream, this.decoderOptions));
+
+            this.localDecoder.Verify(x => x.Decode<Color>(this.DataStream, this.decoderOptions, this.LocalConfiguration));
+
         }
 
 
@@ -429,7 +479,7 @@ namespace ImageSharp.Tests
             Image img = Image.Load(this.FilePath, this.localDecoder.Object);
 
             Assert.NotNull(img);
-            this.localDecoder.Verify(x => x.Decode<Color>(this.DataStream, null));
+            this.localDecoder.Verify(x => x.Decode<Color>(this.DataStream, null, Configuration.Default));
         }
 
         [Fact]
@@ -439,7 +489,7 @@ namespace ImageSharp.Tests
 
             Assert.NotNull(img);
             Assert.Equal(this.returnImage, img);
-            this.localDecoder.Verify(x => x.Decode<Color>(this.DataStream, null));
+            this.localDecoder.Verify(x => x.Decode<Color>(this.DataStream, null, Configuration.Default));
         }
 
         [Fact]
@@ -448,7 +498,7 @@ namespace ImageSharp.Tests
             Image img = Image.Load(this.FilePath, this.localDecoder.Object, this.decoderOptions);
 
             Assert.NotNull(img);
-            this.localDecoder.Verify(x => x.Decode<Color>(this.DataStream, this.decoderOptions));
+            this.localDecoder.Verify(x => x.Decode<Color>(this.DataStream, this.decoderOptions, Configuration.Default));
         }
 
         [Fact]
@@ -458,7 +508,7 @@ namespace ImageSharp.Tests
 
             Assert.NotNull(img);
             Assert.Equal(this.returnImage, img);
-            this.localDecoder.Verify(x => x.Decode<Color>(this.DataStream, this.decoderOptions));
+            this.localDecoder.Verify(x => x.Decode<Color>(this.DataStream, this.decoderOptions, Configuration.Default));
         }
 
         public void Dispose()

--- a/tests/ImageSharp.Tests/Image/ImageLoadTests.cs
+++ b/tests/ImageSharp.Tests/Image/ImageLoadTests.cs
@@ -1,0 +1,341 @@
+﻿// <copyright file="PixelAccessorTests.cs" company="James Jackson-South">
+// Copyright (c) James Jackson-South and contributors.
+// Licensed under the Apache License, Version 2.0.
+// </copyright>
+
+namespace ImageSharp.Tests
+{
+    using System;
+    using System.IO;
+    using System.Linq;
+    using ImageSharp.Formats;
+    using ImageSharp.IO;
+    using Moq;
+    using Xunit;
+
+    /// <summary>
+    /// Tests the <see cref="Image"/> class.
+    /// </summary>
+    public class ImageLoadTests : IDisposable
+    {
+        private readonly Mock<IFileSystem> fileSystem;
+        private readonly IDecoderOptions decoderOptions;
+        private Image<Color> returnImage;
+        private Mock<IImageDecoder> localDecoder;
+        private Mock<IImageFormat> localFormat;
+        private readonly string FilePath;
+
+        public Configuration LocalConfiguration { get; private set; }
+        public byte[] Marker { get; private set; }
+        public MemoryStream DataStream { get; private set; }
+        public byte[] DecodedData { get; private set; }
+
+        public ImageLoadTests()
+        {
+            this.returnImage = new Image<Color>(1, 1);
+           
+            this.localDecoder = new Mock<IImageDecoder>();
+            this.localFormat = new Mock<IImageFormat>();
+            this.localFormat.Setup(x => x.Decoder).Returns(this.localDecoder.Object);
+            this.localFormat.Setup(x => x.Encoder).Returns(new Mock<IImageEncoder>().Object);
+            this.localFormat.Setup(x => x.MimeType).Returns("img/test");
+            this.localFormat.Setup(x => x.Extension).Returns("png");
+            this.localFormat.Setup(x => x.HeaderSize).Returns(1);
+            this.localFormat.Setup(x => x.IsSupportedFileFormat(It.IsAny<byte[]>())).Returns(true);
+            this.localFormat.Setup(x => x.SupportedExtensions).Returns(new string[] { "png", "jpg" });
+            this.localDecoder.Setup(x => x.Decode<Color>(It.IsAny<Stream>(), It.IsAny<IDecoderOptions>()))
+                .Callback<Stream, IDecoderOptions>((s, o) => {
+                    using (var ms = new MemoryStream())
+                    {
+                        s.CopyTo(ms);
+                        this.DecodedData = ms.ToArray();
+                    }
+                })
+                .Returns(this.returnImage);
+
+            this.fileSystem = new Mock<IFileSystem>();
+            
+            this.LocalConfiguration = new Configuration(this.localFormat.Object)
+            {
+                FileSystem = this.fileSystem.Object
+            };
+            TestFormat.RegisterGloablTestFormat();
+            this.Marker = Guid.NewGuid().ToByteArray();
+            this.DataStream = TestFormat.GlobalTestFormat.CreateStream(this.Marker);
+            this.decoderOptions = new Mock<IDecoderOptions>().Object;
+
+            this.FilePath = Guid.NewGuid().ToString();
+            this.fileSystem.Setup(x => x.OpenRead(this.FilePath)).Returns(this.DataStream);
+        }
+
+        [Fact]
+        public void LoadFromStream()
+        {
+            Image img = Image.Load(this.DataStream);
+
+            Assert.NotNull(img);
+            Assert.Equal(TestFormat.GlobalTestFormat, img.CurrentImageFormat);
+
+            TestFormat.GlobalTestFormat.VerifyDecodeCall(this.Marker, null);
+        }
+
+        [Fact]
+        public void LoadFromStreamWithType()
+        {
+            Image<Color> img = Image.Load<Color>(this.DataStream);
+
+            Assert.NotNull(img);
+            Assert.Equal(TestFormat.GlobalTestFormat.Sample<Color>(), img);
+            Assert.Equal(TestFormat.GlobalTestFormat, img.CurrentImageFormat);
+            TestFormat.GlobalTestFormat.VerifyDecodeCall(this.Marker, null);
+        }
+
+        [Fact]
+        public void LoadFromStreamWithOptions()
+        {
+            Image img = Image.Load(this.DataStream, this.decoderOptions);
+
+            Assert.NotNull(img);
+            Assert.Equal(TestFormat.GlobalTestFormat, img.CurrentImageFormat);
+            TestFormat.GlobalTestFormat.VerifyDecodeCall(this.Marker, this.decoderOptions);
+        }
+
+        [Fact]
+        public void LoadFromStreamWithTypeAndOptions()
+        {
+            Image<Color> img = Image.Load<Color>(this.DataStream, this.decoderOptions);
+
+            Assert.NotNull(img);
+            Assert.Equal(TestFormat.GlobalTestFormat.Sample<Color>(), img);
+            Assert.Equal(TestFormat.GlobalTestFormat, img.CurrentImageFormat);
+            TestFormat.GlobalTestFormat.VerifyDecodeCall(this.Marker, this.decoderOptions);
+        }
+
+        [Fact]
+        public void LoadFromStreamWithConfig()
+        {
+            Stream stream = new MemoryStream();
+            Image img = Image.Load(stream, this.LocalConfiguration);
+
+            Assert.NotNull(img);
+            Assert.Equal(this.localFormat.Object, img.CurrentImageFormat);
+            this.localDecoder.Verify(x => x.Decode<Color>(stream, null));
+        }
+
+        [Fact]
+        public void LoadFromStreamWithTypeAndConfig()
+        {
+            Stream stream = new MemoryStream();
+            Image<Color> img = Image.Load<Color>(stream, this.LocalConfiguration);
+
+            Assert.NotNull(img);
+            Assert.Equal(this.returnImage, img);
+            Assert.Equal(this.localFormat.Object, img.CurrentImageFormat);
+            this.localDecoder.Verify(x => x.Decode<Color>(stream, null));
+        }
+
+        [Fact]
+        public void LoadFromStreamWithConfigAndOptions()
+        {
+            Stream stream = new MemoryStream();
+            Image img = Image.Load(stream, this.decoderOptions, this.LocalConfiguration);
+
+            Assert.NotNull(img);
+            Assert.Equal(this.localFormat.Object, img.CurrentImageFormat);
+            this.localDecoder.Verify(x => x.Decode<Color>(stream, this.decoderOptions));
+        }
+
+        [Fact]
+        public void LoadFromStreamWithTypeAndConfigAndOptions()
+        {
+            Stream stream = new MemoryStream();
+            Image<Color> img = Image.Load<Color>(stream, this.decoderOptions, this.LocalConfiguration);
+
+            Assert.NotNull(img);
+            Assert.Equal(this.returnImage, img);
+            Assert.Equal(this.localFormat.Object, img.CurrentImageFormat);
+            this.localDecoder.Verify(x => x.Decode<Color>(stream, this.decoderOptions));
+        }
+
+        [Fact]
+        public void LoadFromBytes()
+        {
+            Image img = Image.Load(this.DataStream.ToArray());
+
+            Assert.NotNull(img);
+            Assert.Equal(TestFormat.GlobalTestFormat, img.CurrentImageFormat);
+
+            TestFormat.GlobalTestFormat.VerifyDecodeCall(this.Marker, null);
+        }
+
+        [Fact]
+        public void LoadFromBytesWithType()
+        {
+            Image<Color> img = Image.Load<Color>(this.DataStream.ToArray());
+
+            Assert.NotNull(img);
+            Assert.Equal(TestFormat.GlobalTestFormat.Sample<Color>(), img);
+            Assert.Equal(TestFormat.GlobalTestFormat, img.CurrentImageFormat);
+            TestFormat.GlobalTestFormat.VerifyDecodeCall(this.Marker, null);
+        }
+
+        [Fact]
+        public void LoadFromBytesWithOptions()
+        {
+            Image img = Image.Load(this.DataStream.ToArray(), this.decoderOptions);
+
+            Assert.NotNull(img);
+            Assert.Equal(TestFormat.GlobalTestFormat, img.CurrentImageFormat);
+            TestFormat.GlobalTestFormat.VerifyDecodeCall(this.Marker, this.decoderOptions);
+        }
+
+        [Fact]
+        public void LoadFromBytesWithTypeAndOptions()
+        {
+            Image<Color> img = Image.Load<Color>(this.DataStream.ToArray(), this.decoderOptions);
+
+            Assert.NotNull(img);
+            Assert.Equal(TestFormat.GlobalTestFormat.Sample<Color>(), img);
+            Assert.Equal(TestFormat.GlobalTestFormat, img.CurrentImageFormat);
+            TestFormat.GlobalTestFormat.VerifyDecodeCall(this.Marker, this.decoderOptions);
+        }
+
+        [Fact]
+        public void LoadFromBytesWithConfig()
+        {
+            Image img = Image.Load(this.DataStream.ToArray(), this.LocalConfiguration);
+
+            Assert.NotNull(img);
+            Assert.Equal(this.localFormat.Object, img.CurrentImageFormat);
+            this.localDecoder.Verify(x => x.Decode<Color>(It.IsAny<Stream>(), null));
+            Assert.Equal(this.DataStream.ToArray(), this.DecodedData);
+        }
+
+        [Fact]
+        public void LoadFromBytesWithTypeAndConfig()
+        {
+            Image<Color> img = Image.Load<Color>(this.DataStream.ToArray(), this.LocalConfiguration);
+
+            Assert.NotNull(img);
+            Assert.Equal(this.returnImage, img);
+            Assert.Equal(this.localFormat.Object, img.CurrentImageFormat);
+
+            this.localDecoder.Verify(x => x.Decode<Color>(It.IsAny<Stream>(), null));
+            Assert.Equal(this.DataStream.ToArray(), this.DecodedData);
+        }
+
+        [Fact]
+        public void LoadFromBytesWithConfigAndOptions()
+        {
+            Image img = Image.Load(this.DataStream.ToArray(), this.decoderOptions, this.LocalConfiguration);
+
+            Assert.NotNull(img);
+            Assert.Equal(this.localFormat.Object, img.CurrentImageFormat);
+            this.localDecoder.Verify(x => x.Decode<Color>(It.IsAny<Stream>(), this.decoderOptions));
+            Assert.Equal(this.DataStream.ToArray(), this.DecodedData);
+        }
+
+        [Fact]
+        public void LoadFromBytesWithTypeAndConfigAndOptions()
+        {
+            Image<Color> img = Image.Load<Color>(this.DataStream.ToArray(), this.decoderOptions, this.LocalConfiguration);
+
+            Assert.NotNull(img);
+            Assert.Equal(this.returnImage, img);
+            Assert.Equal(this.localFormat.Object, img.CurrentImageFormat);
+            this.localDecoder.Verify(x => x.Decode<Color>(It.IsAny<Stream>(), this.decoderOptions));
+            Assert.Equal(this.DataStream.ToArray(), this.DecodedData);
+        }
+        
+        [Fact]
+        public void LoadFromFile()
+        {
+            Image img = Image.Load(this.DataStream);
+
+            Assert.NotNull(img);
+            Assert.Equal(TestFormat.GlobalTestFormat, img.CurrentImageFormat);
+
+            TestFormat.GlobalTestFormat.VerifyDecodeCall(this.Marker, null);
+        }
+
+        [Fact]
+        public void LoadFromFileWithType()
+        {
+            Image<Color> img = Image.Load<Color>(this.DataStream);
+
+            Assert.NotNull(img);
+            Assert.Equal(TestFormat.GlobalTestFormat.Sample<Color>(), img);
+            Assert.Equal(TestFormat.GlobalTestFormat, img.CurrentImageFormat);
+            TestFormat.GlobalTestFormat.VerifyDecodeCall(this.Marker, null);
+        }
+
+        [Fact]
+        public void LoadFromFileWithOptions()
+        {
+            Image img = Image.Load(this.DataStream, this.decoderOptions);
+
+            Assert.NotNull(img);
+            Assert.Equal(TestFormat.GlobalTestFormat, img.CurrentImageFormat);
+            TestFormat.GlobalTestFormat.VerifyDecodeCall(this.Marker, this.decoderOptions);
+        }
+
+        [Fact]
+        public void LoadFromFileWithTypeAndOptions()
+        {
+            Image<Color> img = Image.Load<Color>(this.DataStream, this.decoderOptions);
+
+            Assert.NotNull(img);
+            Assert.Equal(TestFormat.GlobalTestFormat.Sample<Color>(), img);
+            Assert.Equal(TestFormat.GlobalTestFormat, img.CurrentImageFormat);
+            TestFormat.GlobalTestFormat.VerifyDecodeCall(this.Marker, this.decoderOptions);
+        }
+
+        [Fact]
+        public void LoadFromFileWithConfig()
+        {
+            Image img = Image.Load(this.FilePath, this.LocalConfiguration);
+
+            Assert.NotNull(img);
+            Assert.Equal(this.localFormat.Object, img.CurrentImageFormat);
+            this.localDecoder.Verify(x => x.Decode<Color>(this.DataStream, null));
+        }
+
+        [Fact]
+        public void LoadFromFileWithTypeAndConfig()
+        {
+            Image<Color> img = Image.Load<Color>(this.FilePath, this.LocalConfiguration);
+
+            Assert.NotNull(img);
+            Assert.Equal(this.returnImage, img);
+            Assert.Equal(this.localFormat.Object, img.CurrentImageFormat);
+            this.localDecoder.Verify(x => x.Decode<Color>(this.DataStream, null));
+        }
+
+        [Fact]
+        public void LoadFromFileWithConfigAndOptions()
+        {
+            Image img = Image.Load(this.FilePath, this.decoderOptions, this.LocalConfiguration);
+
+            Assert.NotNull(img);
+            Assert.Equal(this.localFormat.Object, img.CurrentImageFormat);
+            this.localDecoder.Verify(x => x.Decode<Color>(this.DataStream, this.decoderOptions));
+        }
+
+        [Fact]
+        public void LoadFromFileWithTypeAndConfigAndOptions()
+        {
+            Image<Color> img = Image.Load<Color>(FilePath, this.decoderOptions, this.LocalConfiguration);
+
+            Assert.NotNull(img);
+            Assert.Equal(this.returnImage, img);
+            Assert.Equal(this.localFormat.Object, img.CurrentImageFormat);
+            this.localDecoder.Verify(x => x.Decode<Color>(this.DataStream, this.decoderOptions));
+        }
+
+        public void Dispose()
+        {
+            // clean up the global object;
+            this.returnImage?.Dispose();
+        }
+    }
+}

--- a/tests/ImageSharp.Tests/Image/ImageTests.cs
+++ b/tests/ImageSharp.Tests/Image/ImageTests.cs
@@ -21,11 +21,11 @@ namespace ImageSharp.Tests
         {
             Assert.Throws<ArgumentNullException>(() =>
             {
-                new Image((byte[])null);
+                Image.Load((byte[])null);
             });
 
             TestFile file = TestFile.Create(TestImages.Bmp.Car);
-            using (Image image = new Image(file.Bytes))
+            using (Image image = Image.Load(file.Bytes))
             {
                 Assert.Equal(600, image.Width);
                 Assert.Equal(450, image.Height);
@@ -36,7 +36,7 @@ namespace ImageSharp.Tests
         public void ConstructorFileSystem()
         {
             TestFile file = TestFile.Create(TestImages.Bmp.Car);
-            using (Image image = new Image(file.FilePath))
+            using (Image image = Image.Load(file.FilePath))
             {
                 Assert.Equal(600, image.Width);
                 Assert.Equal(450, image.Height);
@@ -49,7 +49,7 @@ namespace ImageSharp.Tests
             System.IO.FileNotFoundException ex = Assert.Throws<System.IO.FileNotFoundException>(
                 () =>
                 {
-                    new Image(Guid.NewGuid().ToString());
+                    Image.Load(Guid.NewGuid().ToString());
                 });
         }
 
@@ -59,7 +59,7 @@ namespace ImageSharp.Tests
             ArgumentNullException ex = Assert.Throws<ArgumentNullException>(
                 () =>
                 {
-                    new Image((string) null);
+                    Image.Load((string) null);
                 });
         }
 

--- a/tests/ImageSharp.Tests/MetaData/Profiles/Exif/ExifProfileTests.cs
+++ b/tests/ImageSharp.Tests/MetaData/Profiles/Exif/ExifProfileTests.cs
@@ -73,7 +73,7 @@ namespace ImageSharp.Tests
                 image.SaveAsJpeg(memStream);
 
                 memStream.Position = 0;
-                image = new Image(memStream);
+                image = Image.Load(memStream);
 
                 profile = image.MetaData.ExifProfile;
                 Assert.NotNull(profile);
@@ -91,7 +91,7 @@ namespace ImageSharp.Tests
                 image.SaveAsJpeg(memStream);
 
                 memStream.Position = 0;
-                image = new Image(memStream);
+                image = Image.Load(memStream);
 
                 profile = image.MetaData.ExifProfile;
                 Assert.NotNull(profile);
@@ -286,7 +286,7 @@ namespace ImageSharp.Tests
                 image.Dispose();
 
                 memStream.Position = 0;
-                return new Image(memStream);
+                return Image.Load(memStream);
             }
         }
 

--- a/tests/ImageSharp.Tests/TestFile.cs
+++ b/tests/ImageSharp.Tests/TestFile.cs
@@ -46,7 +46,7 @@ namespace ImageSharp.Tests
             this.file = file;
 
             this.Bytes = File.ReadAllBytes(file);
-            this.image = new Image(this.Bytes);
+            this.image = Image.Load(this.Bytes);
         }
 
         /// <summary>
@@ -139,7 +139,7 @@ namespace ImageSharp.Tests
         /// </returns>
         public Image CreateImage(IDecoderOptions options)
         {
-            return new Image(this.Bytes, options);
+            return Image.Load(this.Bytes, options);
         }
 
         /// <summary>

--- a/tests/ImageSharp.Tests/TestFileSystem.cs
+++ b/tests/ImageSharp.Tests/TestFileSystem.cs
@@ -1,0 +1,72 @@
+﻿// <copyright file="TestFileSystem.cs" company="James Jackson-South">
+// Copyright (c) James Jackson-South and contributors.
+// Licensed under the Apache License, Version 2.0.
+// </copyright>
+
+namespace ImageSharp.Tests
+{
+    using System;
+    using System.Collections.Concurrent;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Linq;
+    using System.Reflection;
+    using ImageSharp.Formats;
+    using Xunit;
+
+    /// <summary>
+    /// A test image file.
+    /// </summary>
+    public class TestFileSystem : ImageSharp.IO.IFileSystem
+    {
+
+        public static TestFileSystem Global { get; } = new TestFileSystem();
+
+        public static void RegisterGloablTestFormat()
+        {
+            Configuration.Default.FileSystem = Global;
+        }
+
+        Dictionary<string, Stream> fileSystem = new Dictionary<string, Stream>(StringComparer.OrdinalIgnoreCase);
+
+        public void AddFile(string path, Stream data)
+        {
+            fileSystem.Add(path, data);
+        }
+
+        public Stream Create(string path)
+        {
+            MemoryStream stream = new MemoryStream();
+            lock (fileSystem)
+            {
+                if (fileSystem.ContainsKey(path))
+                {
+                    fileSystem[path] = stream;
+                }
+                else
+                {
+                    fileSystem.Add(path, stream);
+                }
+            }
+            return stream;
+        }
+
+
+        public Stream OpenRead(string path)
+        {
+            lock (fileSystem)
+            {
+                if (fileSystem.ContainsKey(path))
+                {
+
+                    Stream stream =  fileSystem[path];
+                    stream.Position = 0;
+                    return stream;
+                }
+            }
+
+            return File.OpenRead(path);
+        }
+    }
+}
+

--- a/tests/ImageSharp.Tests/TestFileSystem.cs
+++ b/tests/ImageSharp.Tests/TestFileSystem.cs
@@ -36,29 +36,28 @@ namespace ImageSharp.Tests
 
         public Stream Create(string path)
         {
-            MemoryStream stream = new MemoryStream();
+            // if we have injected a fake file use it instead
             lock (fileSystem)
             {
                 if (fileSystem.ContainsKey(path))
                 {
-                    fileSystem[path] = stream;
-                }
-                else
-                {
-                    fileSystem.Add(path, stream);
+                    Stream stream = fileSystem[path];
+                    stream.Position = 0;
+                    return stream;
                 }
             }
-            return stream;
+
+            return File.Create(path);
         }
 
 
         public Stream OpenRead(string path)
         {
+            // if we have injected a fake file use it instead
             lock (fileSystem)
             {
                 if (fileSystem.ContainsKey(path))
                 {
-
                     Stream stream =  fileSystem[path];
                     stream.Position = 0;
                     return stream;

--- a/tests/ImageSharp.Tests/TestFormat.cs
+++ b/tests/ImageSharp.Tests/TestFormat.cs
@@ -149,7 +149,7 @@ namespace ImageSharp.Tests
             }
 
 
-            public Image<TColor> Decode<TColor>(Stream stream, IDecoderOptions options, Configuration config) where TColor : struct, IPixel<TColor>
+            public Image<TColor> Decode<TColor>(Configuration config, Stream stream, IDecoderOptions options) where TColor : struct, IPixel<TColor>
 
             {
                 var ms = new MemoryStream();

--- a/tests/ImageSharp.Tests/TestFormat.cs
+++ b/tests/ImageSharp.Tests/TestFormat.cs
@@ -1,0 +1,174 @@
+﻿// <copyright file="TestImage.cs" company="James Jackson-South">
+// Copyright (c) James Jackson-South and contributors.
+// Licensed under the Apache License, Version 2.0.
+// </copyright>
+
+namespace ImageSharp.Tests
+{
+    using System;
+    using System.Collections.Concurrent;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Linq;
+    using System.Reflection;
+    using ImageSharp.Formats;
+    using Xunit;
+
+    /// <summary>
+    /// A test image file.
+    /// </summary>
+    public class TestFormat : ImageSharp.Formats.IImageFormat
+    {
+        public static TestFormat GlobalTestFormat { get; } = new TestFormat();
+
+        public static void RegisterGloablTestFormat()
+        {
+            Configuration.Default.AddImageFormat(GlobalTestFormat);
+        }
+
+        public TestFormat()
+        {
+            this.Encoder = new TestEncoder(this); ;
+            this.Decoder = new TestDecoder(this); ;
+        }
+
+        public List<DecodeOperation> DecodeCalls { get; } = new List<DecodeOperation>();
+
+        public IImageEncoder Encoder { get; }
+
+        public IImageDecoder Decoder { get; }
+
+        private byte[] header = Guid.NewGuid().ToByteArray();
+
+        public MemoryStream CreateStream(byte[] marker = null)
+        {
+            MemoryStream ms = new MemoryStream();
+            byte[] data = this.header;
+            ms.Write(data, 0, data.Length);
+            if (marker != null)
+            {
+                ms.Write(marker, 0, marker.Length);
+            }
+            ms.Position = 0;
+            return ms;
+        }
+
+        Dictionary<Type, object> _sampleImages = new Dictionary<Type, object>();
+
+        public void VerifyDecodeCall(byte[] marker, IDecoderOptions options)
+        {
+            DecodeOperation[] discovered = this.DecodeCalls.Where(x => x.IsMatch(marker, options)).ToArray();
+
+            Assert.True(discovered.Any(), "No calls to decode on this formate with the proveded options happend");
+
+            foreach (DecodeOperation d in discovered) {
+                this.DecodeCalls.Remove(d);
+            }
+        }
+
+        public Image<TColor> Sample<TColor>()
+            where TColor : struct, IPixel<TColor>
+        {
+            lock (this._sampleImages)
+            {
+                if (!this._sampleImages.ContainsKey(typeof(TColor)))
+                {
+                    this._sampleImages.Add(typeof(TColor), new Image<TColor>(1, 1));
+                }
+            
+                return (Image<TColor>)this._sampleImages[typeof(TColor)];
+            }
+        }
+
+        public string MimeType => "img/test";
+
+        public string Extension => "test_ext";
+
+        public IEnumerable<string> SupportedExtensions => new[] { "test_ext" };
+
+        public int HeaderSize => this.header.Length;
+
+        public bool IsSupportedFileFormat(byte[] header)
+        {
+            if (header.Length < this.header.Length)
+            {
+                return false;
+            }
+            for (int i = 0; i < this.header.Length; i++)
+            {
+                if (header[i] != this.header[i])
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+        public struct DecodeOperation
+        {
+            public byte[] marker;
+            public IDecoderOptions options;
+
+            public bool IsMatch(byte[] testMarker, IDecoderOptions testOptions)
+            {
+                if(this.options != testOptions)
+                {
+                    return false;
+                }
+
+                if (testMarker.Length != this.marker.Length)
+                {
+                    return false;
+                }
+
+                for (int i = 0; i < this.marker.Length; i++)
+                {
+                    if (testMarker[i] != this.marker[i])
+                    {
+                        return false;
+                    }
+                }
+                return true;
+            }
+        }
+
+        public class TestDecoder : ImageSharp.Formats.IImageDecoder
+        {
+            private TestFormat testFormat;
+
+            public TestDecoder(TestFormat testFormat)
+            {
+                this.testFormat = testFormat;
+            }
+
+            public Image<TColor> Decode<TColor>(Stream stream, IDecoderOptions options) where TColor : struct, IPixel<TColor>
+            {
+                var ms = new MemoryStream();
+                stream.CopyTo(ms);
+                var marker = ms.ToArray().Skip(this.testFormat.header.Length).ToArray();
+                this.testFormat.DecodeCalls.Add(new DecodeOperation
+                {
+                    marker = marker,
+                    options = options
+                });
+
+                // TODO record this happend so we an verify it.
+                return this.testFormat.Sample<TColor>();
+            }
+        }
+
+        public class TestEncoder : ImageSharp.Formats.IImageEncoder
+        {
+            private TestFormat testFormat;
+
+            public TestEncoder(TestFormat testFormat)
+            {
+                this.testFormat = testFormat;
+            }
+
+            public void Encode<TColor>(Image<TColor> image, Stream stream, IEncoderOptions options) where TColor : struct, IPixel<TColor>
+            {
+                // TODO record this happend so we an verify it.
+            }
+        }
+    }
+}

--- a/tests/ImageSharp.Tests/TestFormat.cs
+++ b/tests/ImageSharp.Tests/TestFormat.cs
@@ -55,9 +55,11 @@ namespace ImageSharp.Tests
 
         Dictionary<Type, object> _sampleImages = new Dictionary<Type, object>();
 
-        public void VerifyDecodeCall(byte[] marker, IDecoderOptions options)
+
+        public void VerifyDecodeCall(byte[] marker, IDecoderOptions options, Configuration config)
         {
-            DecodeOperation[] discovered = this.DecodeCalls.Where(x => x.IsMatch(marker, options)).ToArray();
+            DecodeOperation[] discovered = this.DecodeCalls.Where(x => x.IsMatch(marker, options, config)).ToArray();
+
 
             Assert.True(discovered.Any(), "No calls to decode on this formate with the proveded options happend");
 
@@ -107,10 +109,16 @@ namespace ImageSharp.Tests
         {
             public byte[] marker;
             public IDecoderOptions options;
+            internal Configuration config;
 
-            public bool IsMatch(byte[] testMarker, IDecoderOptions testOptions)
+             public bool IsMatch(byte[] testMarker, IDecoderOptions testOptions, Configuration config)
             {
-                if(this.options != testOptions)
+                if (this.options != testOptions)
+                {
+                    return false;
+                }
+
+                if (this.config != config)
                 {
                     return false;
                 }
@@ -140,7 +148,9 @@ namespace ImageSharp.Tests
                 this.testFormat = testFormat;
             }
 
-            public Image<TColor> Decode<TColor>(Stream stream, IDecoderOptions options) where TColor : struct, IPixel<TColor>
+
+            public Image<TColor> Decode<TColor>(Stream stream, IDecoderOptions options, Configuration config) where TColor : struct, IPixel<TColor>
+
             {
                 var ms = new MemoryStream();
                 stream.CopyTo(ms);
@@ -148,7 +158,8 @@ namespace ImageSharp.Tests
                 this.testFormat.DecodeCalls.Add(new DecodeOperation
                 {
                     marker = marker,
-                    options = options
+                    options = options,
+                    config = config
                 });
 
                 // TODO record this happend so we an verify it.

--- a/tests/ImageSharp.Tests/TestUtilities/Factories/GenericFactory.cs
+++ b/tests/ImageSharp.Tests/TestUtilities/Factories/GenericFactory.cs
@@ -21,7 +21,7 @@ namespace ImageSharp.Tests
 
         public virtual Image<TColor> CreateImage(byte[] bytes)
         {
-            return new Image<TColor>(bytes);
+            return Image.Load<TColor>(bytes);
         }
 
         public virtual Image<TColor> CreateImage(Image<TColor> other)

--- a/tests/ImageSharp.Tests/TestUtilities/Factories/ImageFactory.cs
+++ b/tests/ImageSharp.Tests/TestUtilities/Factories/ImageFactory.cs
@@ -7,7 +7,7 @@ namespace ImageSharp.Tests
 {
     public class ImageFactory : GenericFactory<Color>
     {
-        public override Image<Color> CreateImage(byte[] bytes) => new Image(bytes);
+        public override Image<Color> CreateImage(byte[] bytes) => Image.Load(bytes);
 
         public override Image<Color> CreateImage(int width, int height) => new Image(width, height);
 


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/JimBobSquarePants/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practise as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
I've refactored Image loading (from stream, byte[] and files) to move the logic out of the `Image<TColor>` constructor and into static methods.

In the process I was able to clean up a a chunk of the Image data loading internals and additionally a shifted the responsibility of constructing the image object into the `IImageEncoder`s instead of user code. This allowed me to remove the `InitPixels(..)` method as they will always be initialised on construction.

Additionally I removed the optional parameters in from the constructors and now they are using proper overloads.
