### PR TITLE
Default text drawing at an image dpi independent size

### DIFF
--- a/src/ImageSharp.Drawing/Text/DrawText.cs
+++ b/src/ImageSharp.Drawing/Text/DrawText.cs
@@ -18,6 +18,8 @@ namespace ImageSharp
     /// </summary>
     public static partial class ImageExtensions
     {
+        private static readonly Vector2 DefaultTextDpi = new Vector2(72);
+
         /// <summary>
         /// Draws the text onto the the image filled via the brush.
         /// </summary>
@@ -169,7 +171,12 @@ namespace ImageSharp
 
             TextRenderer renderer = new TextRenderer(glyphBuilder);
 
-            Vector2 dpi = new Vector2((float)source.MetaData.HorizontalResolution, (float)source.MetaData.VerticalResolution);
+            Vector2 dpi = DefaultTextDpi;
+            if (options.UseImageResolution)
+            {
+                dpi = new Vector2((float)source.MetaData.HorizontalResolution, (float)source.MetaData.VerticalResolution);
+            }
+
             FontSpan style = new FontSpan(font)
             {
                 ApplyKerning = options.ApplyKerning,

--- a/src/ImageSharp.Drawing/Text/TextGraphicsOptions.cs
+++ b/src/ImageSharp.Drawing/Text/TextGraphicsOptions.cs
@@ -36,6 +36,12 @@ namespace ImageSharp.Drawing
         public float TabWidth;
 
         /// <summary>
+        /// Flag weather to use the current image resultion to for point size scaling.
+        /// If this is [false] the text renders at 72dpi otherwise it renders at Image resolution
+        /// </summary>
+        public bool UseImageResolution;
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="TextGraphicsOptions" /> struct.
         /// </summary>
         /// <param name="enableAntialiasing">If set to <c>true</c> [enable antialiasing].</param>
@@ -45,6 +51,7 @@ namespace ImageSharp.Drawing
             this.ApplyKerning = true;
             this.TabWidth = 4;
             this.AntialiasSubpixelDepth = 16;
+            this.UseImageResolution = false;
         }
 
         /// <summary>

--- a/tests/ImageSharp.Tests/Drawing/Text/DrawText.cs
+++ b/tests/ImageSharp.Tests/Drawing/Text/DrawText.cs
@@ -219,5 +219,32 @@ namespace ImageSharp.Tests.Drawing.Text
             Assert.IsType<FillRegionProcessor<Color>>(this.img.ProcessorApplications[0].processor);
             Assert.IsType<DrawPathProcessor<Color>>(this.img.ProcessorApplications[1].processor);
         }
+
+        [Fact]
+        public void GlyphHeightChangesBasedOnuseImageResolutionFlag()
+        {
+            this.img.MetaData.VerticalResolution = 1;
+            this.img.MetaData.HorizontalResolution = 1;
+            this.img.DrawText("1", this.Font, Brushes.Solid(Color.Red), Vector2.Zero, new TextGraphicsOptions(true) {
+                UseImageResolution = false
+            });
+
+            this.img.DrawText("1", this.Font, Brushes.Solid(Color.Red), Vector2.Zero, new TextGraphicsOptions(true)
+            {
+                UseImageResolution = true
+            });
+
+            Assert.NotEmpty(this.img.ProcessorApplications);
+            Assert.Equal(2, this.img.ProcessorApplications.Count);
+            FillRegionProcessor<Color> ownResolution = Assert.IsType<FillRegionProcessor<Color>>(this.img.ProcessorApplications[0].processor);
+            FillRegionProcessor<Color> imgResolution = Assert.IsType<FillRegionProcessor<Color>>(this.img.ProcessorApplications[1].processor);
+
+            ShapeRegion ownRegion = Assert.IsType<ShapeRegion>(ownResolution.Region);
+            ShapeRegion imgRegion = Assert.IsType<ShapeRegion>(imgResolution.Region);
+
+            // magic numbers based on the font used at well known resolutions
+            Assert.Equal(7.44, ownRegion.Shape.Bounds.Height, 2);
+            Assert.Equal(0.1, imgRegion.Shape.Bounds.Height, 2);
+        }
     }
 }


### PR DESCRIPTION

### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/JimBobSquarePants/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practise as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description

This changes the default behavior to by defaulting all text to be drawn as 72 dpi as apposed to the images native resolution thus ensuing that the pixel height per point is consistent across images by default.

Can be switched back to image resolution by setting `UseImageResolution` in `TextGraphicsOptions` to `true`.

This change will prevent confusion for people dealing with images in terms of pixels instead of sizes dependent on DPI.

72 dpi was chosen is because 1 pt = 1/72 inch.

Fixes #148 