### PR TITLE
Add image comparer test helper

### DIFF
--- a/src/ImageSharp/Formats/Png/PngEncoderCore.cs
+++ b/src/ImageSharp/Formats/Png/PngEncoderCore.cs
@@ -544,7 +544,7 @@ namespace ImageSharp.Formats
         /// </summary>
         /// <typeparam name="TColor">The pixel format.</typeparam>
         /// <param name="stream">The <see cref="Stream"/> containing image data.</param>
-        /// <param name="imageBase">The image base.</param>
+        /// <param name="image">The image.</param>
         private void WritePhysicalChunk<TColor>(Stream stream, Image<TColor> image)
             where TColor : struct, IPixel<TColor>
         {

--- a/src/ImageSharp/Formats/Png/PngEncoderCore.cs
+++ b/src/ImageSharp/Formats/Png/PngEncoderCore.cs
@@ -545,11 +545,10 @@ namespace ImageSharp.Formats
         /// <typeparam name="TColor">The pixel format.</typeparam>
         /// <param name="stream">The <see cref="Stream"/> containing image data.</param>
         /// <param name="imageBase">The image base.</param>
-        private void WritePhysicalChunk<TColor>(Stream stream, ImageBase<TColor> imageBase)
+        private void WritePhysicalChunk<TColor>(Stream stream, Image<TColor> image)
             where TColor : struct, IPixel<TColor>
         {
-            Image<TColor> image = imageBase as Image<TColor>;
-            if (image != null && image.MetaData.HorizontalResolution > 0 && image.MetaData.VerticalResolution > 0)
+            if (image.MetaData.HorizontalResolution > 0 && image.MetaData.VerticalResolution > 0)
             {
                 // 39.3700787 = inches in a meter.
                 int dpmX = (int)Math.Round(image.MetaData.HorizontalResolution * 39.3700787D);

--- a/src/ImageSharp/Formats/Png/PngInterlaceMode.cs
+++ b/src/ImageSharp/Formats/Png/PngInterlaceMode.cs
@@ -13,11 +13,11 @@ namespace ImageSharp.Formats
         /// <summary>
         /// Non interlaced
         /// </summary>
-        None,
+        None = 0,
 
         /// <summary>
         /// Adam 7 interlacing.
         /// </summary>
-        Adam7
+        Adam7 = 1
     }
 }

--- a/tests/ImageSharp.Tests/Drawing/FillRegionProcessorTests.cs
+++ b/tests/ImageSharp.Tests/Drawing/FillRegionProcessorTests.cs
@@ -27,7 +27,7 @@ namespace ImageSharp.Tests.Drawing
         [InlineData(false, 16, 4)] // we always do 4 sub=pixels when antialising is off.
         public void MinimumAntialiasSubpixelDepth(bool antialias, int antialiasSubpixelDepth, int expectedAntialiasSubpixelDepth)
         {
-            var bounds = new ImageSharp.Rectangle(0, 0, 1, 1);
+            ImageSharp.Rectangle bounds = new ImageSharp.Rectangle(0, 0, 1, 1);
 
             Mock<IBrush<Color>> brush = new Mock<IBrush<Color>>();
             Mock<Region> region = new Mock<Region>();

--- a/tests/ImageSharp.Tests/Formats/Png/PngEncoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Png/PngEncoderTests.cs
@@ -9,12 +9,12 @@ namespace ImageSharp.Tests
 {
     using System.IO;
     using System.Threading.Tasks;
-
+    using ImageSharp.IO;
     using Xunit;
 
     public class PngEncoderTests : FileTestBase
     {
-        [Fact]
+        [Fact(Skip ="Slow intergration test")]
         public void ImageCanSaveIndexedPng()
         {
             string path = CreateOutputDirectory("Png", "Indexed");
@@ -32,7 +32,7 @@ namespace ImageSharp.Tests
             }
         }
 
-        [Fact]
+        [Fact(Skip = "Slow intergration test")]
         public void ImageCanSavePngInParallel()
         {
             string path = this.CreateOutputDirectory("Png");
@@ -49,6 +49,64 @@ namespace ImageSharp.Tests
                             }
                         }
                     });
+        }
+
+        [Theory]
+        [WithBlankImages(1, 1, PixelTypes.All)]
+        public void WritesFileMarker<TColor>(TestImageProvider<TColor> provider)
+            where TColor : struct, IPixel<TColor>
+        {
+            using (Image<TColor> image = provider.GetImage())
+            using (EndianBinaryReader reader = Encode(image, null))
+            {
+
+                byte[] data = reader.ReadBytes(8);
+                byte[] expected = {
+                    0x89, // Set the high bit.
+                    0x50, // P
+                    0x4E, // N
+                    0x47, // G
+                    0x0D, // Line ending CRLF
+                    0x0A, // Line ending CRLF
+                    0x1A, // EOF
+                    0x0A // LF
+                };
+
+                Assert.Equal(expected, data);
+            }
+        }
+
+        [Theory]
+        [WithBlankImages(1, 1, PixelTypes.All)]
+        [WithBlankImages(10, 10, PixelTypes.StandardImageClass)]
+        public void WritesFileHeaderHasHeightAndWidth<TColor>(TestImageProvider<TColor> provider)
+            where TColor : struct, IPixel<TColor>
+        {
+            using (Image<TColor> image = provider.GetImage())
+            using (EndianBinaryReader reader = Encode(image, null))
+            {
+                reader.ReadBytes(8); // throw away the file header
+                uint width = reader.ReadUInt32();
+                uint height = reader.ReadUInt32();
+
+                byte bitDepth = reader.ReadByte();
+                byte colorType = reader.ReadByte();
+                byte compressionMethod = reader.ReadByte();
+                byte filterMethod = reader.ReadByte();
+                byte interlaceMethod = reader.ReadByte();
+
+                Assert.Equal(image.Width, (int)width);
+                Assert.Equal(image.Height, (int)height);
+            }
+        }
+
+        private static EndianBinaryReader Encode<TColor>(Image<TColor> img, IEncoderOptions options)
+            where TColor : struct, IPixel<TColor>
+        {
+            MemoryStream stream = new MemoryStream();
+            new PngEncoder().Encode(img, stream, null);
+            stream.Position = 0;
+            return new EndianBinaryReader(Endianness.BigEndian, stream);
         }
     }
 }

--- a/tests/ImageSharp.Tests/Formats/Png/PngEncoderTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Png/PngEncoderTests.cs
@@ -15,43 +15,6 @@ namespace ImageSharp.Tests
 
     public class PngEncoderTests : FileTestBase
     {
-        [Fact(Skip ="Slow intergration test")]
-        public void ImageCanSaveIndexedPng()
-        {
-            string path = CreateOutputDirectory("Png", "Indexed");
-
-            foreach (TestFile file in Files)
-            {
-                using (Image image = file.CreateImage())
-                {
-                    using (FileStream output = File.OpenWrite($"{path}/{file.FileNameWithoutExtension}.png"))
-                    {
-                        image.MetaData.Quality = 256;
-                        image.Save(output, new PngFormat());
-                    }
-                }
-            }
-        }
-
-        [Fact(Skip = "Slow intergration test")]
-        public void ImageCanSavePngInParallel()
-        {
-            string path = this.CreateOutputDirectory("Png");
-
-            Parallel.ForEach(
-                Files,
-                file =>
-                    {
-                        using (Image image = file.CreateImage())
-                        {
-                            using (FileStream output = File.OpenWrite($"{path}/{file.FileNameWithoutExtension}.png"))
-                            {
-                                image.SaveAsPng(output);
-                            }
-                        }
-                    });
-        }
-
         [Theory]
         [WithBlankImages(1, 1, PixelTypes.All)]
         public void WritesFileMarker<TColor>(TestImageProvider<TColor> provider)

--- a/tests/ImageSharp.Tests/Formats/Png/PngSmokeTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Png/PngSmokeTests.cs
@@ -1,0 +1,62 @@
+﻿// <copyright file="PngSmokeTests.cs" company="James Jackson-South">
+// Copyright (c) James Jackson-South and contributors.
+// Licensed under the Apache License, Version 2.0.
+// </copyright>
+
+namespace ImageSharp.Tests.Formats.Png
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Text;
+    using System.IO;
+    using Xunit;
+    using ImageSharp.Formats;
+    using System.Linq;
+    using ImageSharp.IO;
+
+    public class PngSmokeTests
+    {
+        [Theory]
+        [WithTestPatternImages(300, 300, PixelTypes.All)]
+        public void WritesFileMarker<TColor>(TestImageProvider<TColor> provider)
+            where TColor : struct, IPixel<TColor>
+        {
+            // does saving a file then repoening mean both files are identical???
+            using (Image<TColor> image = provider.GetImage())
+            using (MemoryStream ms = new MemoryStream())
+            {
+                image.Save(provider.Utility.GetTestOutputFileName("bmp"));
+
+                image.Save(ms, new PngEncoder());
+                ms.Position = 0;
+                using (Image img2 = new Image(ms, new Configuration(new PngFormat())))
+                {
+                    img2.Save(provider.Utility.GetTestOutputFileName("bmp", "_loaded"), new BmpEncoder());
+                    ImageComparer.VisualComparer(image, img2);
+                }
+            }
+        }
+
+        [Theory]
+        [WithTestPatternImages(300, 300, PixelTypes.All)]
+        public void Resize<TColor>(TestImageProvider<TColor> provider)
+            where TColor : struct, IPixel<TColor>
+        {
+            // does saving a file then repoening mean both files are identical???
+            using (Image<TColor> image = provider.GetImage())
+            using (MemoryStream ms = new MemoryStream())
+            {
+                // image.Save(provider.Utility.GetTestOutputFileName("png"));
+                image.Resize(100, 100);
+                // image.Save(provider.Utility.GetTestOutputFileName("png", "resize"));
+
+                image.Save(ms, new PngEncoder());
+                ms.Position = 0;
+                using (Image img2 = new Image(ms, new Configuration(new PngFormat())))
+                {
+                    ImageComparer.VisualComparer(image, img2);
+                }
+            }
+        }
+    }
+}

--- a/tests/ImageSharp.Tests/Formats/Png/PngSmokeTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Png/PngSmokeTests.cs
@@ -32,7 +32,7 @@ namespace ImageSharp.Tests.Formats.Png
                 using (Image img2 = new Image(ms, new Configuration(new PngFormat())))
                 {
                     // img2.Save(provider.Utility.GetTestOutputFileName("bmp", "_loaded"), new BmpEncoder());
-                    ImageComparer.VisualComparer(image, img2);
+                    ImageComparer.CheckSimilarity(image, img2);
                 }
             }
         }
@@ -53,7 +53,7 @@ namespace ImageSharp.Tests.Formats.Png
                 using (Image img2 = new Image(ms, new Configuration(new PngFormat())))
                 {
                     // img2.Save(provider.Utility.GetTestOutputFileName("bmp", "_loaded"), new BmpEncoder());
-                    ImageComparer.VisualComparer(image, img2);
+                    ImageComparer.CheckSimilarity(image, img2);
                 }
             }
         }
@@ -75,7 +75,7 @@ namespace ImageSharp.Tests.Formats.Png
                 ms.Position = 0;
                 using (Image img2 = new Image(ms, new Configuration(new PngFormat())))
                 {
-                    ImageComparer.VisualComparer(image, img2);
+                    ImageComparer.CheckSimilarity(image, img2);
                 }
             }
         }

--- a/tests/ImageSharp.Tests/Formats/Png/PngSmokeTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Png/PngSmokeTests.cs
@@ -18,20 +18,41 @@ namespace ImageSharp.Tests.Formats.Png
     {
         [Theory]
         [WithTestPatternImages(300, 300, PixelTypes.All)]
-        public void WritesFileMarker<TColor>(TestImageProvider<TColor> provider)
+        public void GeneralTest<TColor>(TestImageProvider<TColor> provider)
             where TColor : struct, IPixel<TColor>
         {
             // does saving a file then repoening mean both files are identical???
             using (Image<TColor> image = provider.GetImage())
             using (MemoryStream ms = new MemoryStream())
             {
-                image.Save(provider.Utility.GetTestOutputFileName("bmp"));
+                // image.Save(provider.Utility.GetTestOutputFileName("bmp"));
 
                 image.Save(ms, new PngEncoder());
                 ms.Position = 0;
                 using (Image img2 = new Image(ms, new Configuration(new PngFormat())))
                 {
-                    img2.Save(provider.Utility.GetTestOutputFileName("bmp", "_loaded"), new BmpEncoder());
+                    // img2.Save(provider.Utility.GetTestOutputFileName("bmp", "_loaded"), new BmpEncoder());
+                    ImageComparer.VisualComparer(image, img2);
+                }
+            }
+        }
+
+        [Theory]
+        [WithTestPatternImages(100, 100, PixelTypes.All)]
+        public void CanSaveIndexedPng<TColor>(TestImageProvider<TColor> provider)
+            where TColor : struct, IPixel<TColor>
+        {
+            // does saving a file then repoening mean both files are identical???
+            using (Image<TColor> image = provider.GetImage())
+            using (MemoryStream ms = new MemoryStream())
+            {
+                // image.Save(provider.Utility.GetTestOutputFileName("bmp"));
+                image.MetaData.Quality = 256;
+                image.Save(ms, new PngEncoder());
+                ms.Position = 0;
+                using (Image img2 = new Image(ms, new Configuration(new PngFormat())))
+                {
+                    // img2.Save(provider.Utility.GetTestOutputFileName("bmp", "_loaded"), new BmpEncoder());
                     ImageComparer.VisualComparer(image, img2);
                 }
             }

--- a/tests/ImageSharp.Tests/Formats/Png/PngSmokeTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Png/PngSmokeTests.cs
@@ -29,7 +29,7 @@ namespace ImageSharp.Tests.Formats.Png
 
                 image.Save(ms, new PngEncoder());
                 ms.Position = 0;
-                using (Image img2 = new Image(ms, new Configuration(new PngFormat())))
+                using (Image img2 = Image.Load(ms, new PngDecoder()))
                 {
                     // img2.Save(provider.Utility.GetTestOutputFileName("bmp", "_loaded"), new BmpEncoder());
                     ImageComparer.CheckSimilarity(image, img2);
@@ -50,7 +50,7 @@ namespace ImageSharp.Tests.Formats.Png
                 image.MetaData.Quality = 256;
                 image.Save(ms, new PngEncoder());
                 ms.Position = 0;
-                using (Image img2 = new Image(ms, new Configuration(new PngFormat())))
+                using (Image img2 = Image.Load(ms, new PngDecoder()))
                 {
                     // img2.Save(provider.Utility.GetTestOutputFileName("bmp", "_loaded"), new BmpEncoder());
                     ImageComparer.CheckSimilarity(image, img2);
@@ -73,7 +73,7 @@ namespace ImageSharp.Tests.Formats.Png
 
                 image.Save(ms, new PngEncoder());
                 ms.Position = 0;
-                using (Image img2 = new Image(ms, new Configuration(new PngFormat())))
+                using (Image img2 = Image.Load(ms, new PngDecoder()))
                 {
                     ImageComparer.CheckSimilarity(image, img2);
                 }

--- a/tests/ImageSharp.Tests/ImageComparer.cs
+++ b/tests/ImageSharp.Tests/ImageComparer.cs
@@ -17,7 +17,7 @@
            where TColorA : struct, IPixel<TColorA>
            where TColorB : struct, IPixel<TColorB>
         {
-            var percentage = expected.PercentageDifference(actual, segmentThreshold, scalingFactor);
+            float percentage = expected.PercentageDifference(actual, segmentThreshold, scalingFactor);
 
             Assert.InRange(percentage, 0, imageTheshold);
         }

--- a/tests/ImageSharp.Tests/ImageComparer.cs
+++ b/tests/ImageSharp.Tests/ImageComparer.cs
@@ -9,10 +9,29 @@
     /// </summary>
     public static class ImageComparer
     {
-        const int DefaultScalingFactor = 32;
-        const int DefaultSegmentThreshold = 3;
-        const float DefaultImageThreshold = 0.000f;
+        const int DefaultScalingFactor = 32; // this is means the images get scaled into a 32x32 image to sample pixels
+        const int DefaultSegmentThreshold = 3; // the greyscale difference between 2 segements my be > 3 before it influances the overall difference
+        const float DefaultImageThreshold = 0.000f; // after segment threasholds the images must have no differences
 
+        /// <summary>
+        /// Does a visual comparison between 2 images and then asserts the difference is less then a configurable threshold
+        /// </summary>
+        /// <typeparam name="TColorA">The color of the expected image</typeparam>
+        /// <typeparam name="TColorB">The color type fo the the actual image</typeparam>
+        /// <param name="expected">The expected image</param>
+        /// <param name="actual">The actual image</param>
+        /// <param name="imageTheshold">
+        /// The threshold for the percentage difference where the images are asumed to be the same.
+        /// The default/undefined value is <see cref="ImageComparer.DefaultImageThreshold"/>
+        /// </param>
+        /// <param name="segmentThreshold">
+        /// The threashold of the individual segments before it acumulates towards the overall difference.
+        /// The default undefined value is <see cref="ImageComparer.DefaultSegmentThreshold"/>
+        /// </param>
+        /// <param name="scalingFactor">
+        /// This is a sampling factor we sample a grid of average pixels <paramref name="scalingFactor"/> width by <paramref name="scalingFactor"/> high
+        /// The default undefined value is <see cref="ImageComparer.DefaultScalingFactor"/>
+        /// </param>
         public static void VisualComparer<TColorA, TColorB>(Image<TColorA> expected, Image<TColorB> actual, float imageTheshold = DefaultImageThreshold, byte segmentThreshold = DefaultSegmentThreshold, int scalingFactor = DefaultScalingFactor)
            where TColorA : struct, IPixel<TColorA>
            where TColorB : struct, IPixel<TColorB>
@@ -22,6 +41,22 @@
             Assert.InRange(percentage, 0, imageTheshold);
         }
 
+        /// <summary>
+        /// Does a visual comparison between 2 images and then and returns the percentage diffence between the 2
+        /// </summary>
+        /// <typeparam name="TColorA">The color of the source image</typeparam>
+        /// <typeparam name="TColorB">The color type for the target image</typeparam>
+        /// <param name="source">The source image</param>
+        /// <param name="target">The target image</param>
+        /// <param name="segmentThreshold">
+        /// The threashold of the individual segments before it acumulates towards the overall difference.
+        /// The default undefined value is <see cref="ImageComparer.DefaultSegmentThreshold"/>
+        /// </param>
+        /// <param name="scalingFactor">
+        /// This is a sampling factor we sample a grid of average pixels <paramref name="scalingFactor"/> width by <paramref name="scalingFactor"/> high
+        /// The default undefined value is <see cref="ImageComparer.DefaultScalingFactor"/>
+        /// </param>
+        /// <returns>Returns a number from 0 - 1 which represents the diference focter between the images.</returns>
         public static float PercentageDifference<TColorA, TColorB>(this Image<TColorA> source, Image<TColorB> target, byte segmentThreshold = DefaultSegmentThreshold, int scalingFactor = DefaultScalingFactor)
             where TColorA : struct, IPixel<TColorA>
             where TColorB : struct, IPixel<TColorB>

--- a/tests/ImageSharp.Tests/ImageComparer.cs
+++ b/tests/ImageSharp.Tests/ImageComparer.cs
@@ -32,7 +32,7 @@
         /// This is a sampling factor we sample a grid of average pixels <paramref name="scalingFactor"/> width by <paramref name="scalingFactor"/> high
         /// The default undefined value is <see cref="ImageComparer.DefaultScalingFactor"/>
         /// </param>
-        public static void VisualComparer<TColorA, TColorB>(Image<TColorA> expected, Image<TColorB> actual, float imageTheshold = DefaultImageThreshold, byte segmentThreshold = DefaultSegmentThreshold, int scalingFactor = DefaultScalingFactor)
+        public static void CheckSimilarity<TColorA, TColorB>(Image<TColorA> expected, Image<TColorB> actual, float imageTheshold = DefaultImageThreshold, byte segmentThreshold = DefaultSegmentThreshold, int scalingFactor = DefaultScalingFactor)
            where TColorA : struct, IPixel<TColorA>
            where TColorB : struct, IPixel<TColorB>
         {

--- a/tests/ImageSharp.Tests/ImageComparer.cs
+++ b/tests/ImageSharp.Tests/ImageComparer.cs
@@ -1,0 +1,84 @@
+﻿namespace ImageSharp.Tests
+{
+    using System;
+    using ImageSharp;
+    using Xunit;
+
+    /// <summary>
+    /// Class to perform simple image comparisons.
+    /// </summary>
+    public static class ImageComparer
+    {
+        const int DefaultScalingFactor = 32;
+        const int DefaultSegmentThreshold = 3;
+        const float DefaultImageThreshold = 0.000f;
+
+        public static void VisualComparer<TColorA, TColorB>(Image<TColorA> expected, Image<TColorB> actual, float imageTheshold = DefaultImageThreshold, byte segmentThreshold = DefaultSegmentThreshold, int scalingFactor = DefaultScalingFactor)
+           where TColorA : struct, IPixel<TColorA>
+           where TColorB : struct, IPixel<TColorB>
+        {
+            var percentage = expected.PercentageDifference(actual, segmentThreshold, scalingFactor);
+
+            Assert.InRange(percentage, 0, imageTheshold);
+        }
+
+        public static float PercentageDifference<TColorA, TColorB>(this Image<TColorA> source, Image<TColorB> target, byte segmentThreshold = DefaultSegmentThreshold, int scalingFactor = DefaultScalingFactor)
+            where TColorA : struct, IPixel<TColorA>
+            where TColorB : struct, IPixel<TColorB>
+        {
+            // code adapted from https://www.codeproject.com/Articles/374386/Simple-image-comparison-in-NET
+            Fast2DArray<byte> differences = GetDifferences(source, target, scalingFactor);
+
+            int diffPixels = 0;
+
+            foreach (byte b in differences.Data)
+            {
+                if (b > segmentThreshold) { diffPixels++; }
+            }
+
+            return diffPixels / (scalingFactor * scalingFactor);
+        }
+
+        private static Fast2DArray<byte> GetDifferences<TColorA, TColorB>(Image<TColorA> source, Image<TColorB> target, int scalingFactor)
+            where TColorA : struct, IPixel<TColorA>
+            where TColorB : struct, IPixel<TColorB>
+        {
+            Fast2DArray<byte> differences = new Fast2DArray<byte>(scalingFactor, scalingFactor);
+            Fast2DArray<byte> firstGray = source.GetGrayScaleValues(scalingFactor);
+            Fast2DArray<byte> secondGray = target.GetGrayScaleValues(scalingFactor);
+
+            for (int y = 0; y < scalingFactor; y++)
+            {
+                for (int x = 0; x < scalingFactor; x++)
+                {
+                    differences[x, y] = (byte)Math.Abs(firstGray[x, y] - secondGray[x, y]);
+                }
+            }
+
+            return differences;
+        }
+
+        private static Fast2DArray<byte> GetGrayScaleValues<TColorA>(this Image<TColorA> source, int scalingFactor)
+            where TColorA : struct, IPixel<TColorA>
+        {
+            byte[] buffer = new byte[4];
+            using (Image<TColorA> img = new Image<TColorA>(source).Resize(scalingFactor, scalingFactor).Grayscale())
+            {
+                using (PixelAccessor<TColorA> pixels = img.Lock())
+                {
+                    Fast2DArray<byte> grayScale = new Fast2DArray<byte>(scalingFactor, scalingFactor);
+                    for (int y = 0; y < scalingFactor; y++)
+                    {
+                        for (int x = 0; x < scalingFactor; x++)
+                        {
+                            pixels[x, y].ToXyzBytes(buffer, 0);
+                            grayScale[x, y] = buffer[1];
+                        }
+                    }
+
+                    return grayScale;
+                }
+            }
+        }
+    }
+}

--- a/tests/ImageSharp.Tests/TestUtilities/Attributes/WithTestPatternImageAttribute.cs
+++ b/tests/ImageSharp.Tests/TestUtilities/Attributes/WithTestPatternImageAttribute.cs
@@ -1,0 +1,38 @@
+﻿// <copyright file="WithBlankImagesAttribute.cs" company="James Jackson-South">
+// Copyright (c) James Jackson-South and contributors.
+// Licensed under the Apache License, Version 2.0.
+// </copyright>
+
+namespace ImageSharp.Tests
+{
+    using System;
+    using System.Reflection;
+
+    /// <summary>
+    /// Triggers passing <see cref="TestImageProvider{TColor}"/> instances which produce a blank image of size width * height.
+    /// One <see cref="TestImageProvider{TColor}"/> instance will be passed for each the pixel format defined by the pixelTypes parameter
+    /// </summary>
+    public class WithTestPatternImagesAttribute : ImageDataAttributeBase
+    {
+        /// <summary>
+        /// Triggers passing an <see cref="TestImageProvider{TColor}"/> that produces a test pattern image of size width * height
+        /// </summary>
+        /// <param name="width">The required width</param>
+        /// <param name="height">The required height</param>
+        /// <param name="pixelTypes">The requested parameter</param>
+        /// <param name="additionalParameters">Additional theory parameter values</param>
+        public WithTestPatternImagesAttribute(int width, int height, PixelTypes pixelTypes, params object[] additionalParameters)
+            : base(pixelTypes, additionalParameters)
+        {
+            this.Width = width;
+            this.Height = height;
+        }
+
+        public int Width { get; }
+        public int Height { get; }
+
+        protected override string GetFactoryMethodName(MethodInfo testMethod) => "TestPattern";
+
+        protected override object[] GetFactoryMethodArgs(MethodInfo testMethod, Type factoryType) => new object[] { this.Width, this.Height };
+    }
+}

--- a/tests/ImageSharp.Tests/TestUtilities/ImageProviders/BlankProvider.cs
+++ b/tests/ImageSharp.Tests/TestUtilities/ImageProviders/BlankProvider.cs
@@ -11,7 +11,7 @@ namespace ImageSharp.Tests
     public abstract partial class TestImageProvider<TColor>
         where TColor : struct, IPixel<TColor>
     {
-        private class BlankProvider : TestImageProvider<TColor>
+        private class BlankProvider : TestImageProvider<TColor>, IXunitSerializable
         {
             public BlankProvider(int width, int height)
             {

--- a/tests/ImageSharp.Tests/TestUtilities/ImageProviders/BlankProvider.cs
+++ b/tests/ImageSharp.Tests/TestUtilities/ImageProviders/BlankProvider.cs
@@ -6,6 +6,7 @@
 namespace ImageSharp.Tests
 {
     using System;
+    using Xunit.Abstractions;
 
     public abstract partial class TestImageProvider<TColor>
         where TColor : struct, IPixel<TColor>
@@ -17,14 +18,34 @@ namespace ImageSharp.Tests
                 this.Width = width;
                 this.Height = height;
             }
+            public BlankProvider()
+            {
+                this.Width = 100;
+                this.Height = 100;
+            }
 
             public override string SourceFileOrDescription => $"Blank{this.Width}x{this.Height}";
 
-            protected int Height { get; }
+            protected int Height { get; private set; }
 
-            protected int Width { get; }
+            protected int Width { get; private set; }
 
             public override Image<TColor> GetImage() => this.Factory.CreateImage(this.Width, this.Height);
+
+
+            public override void Deserialize(IXunitSerializationInfo info)
+            {
+                this.Width = info.GetValue<int>("width");
+                this.Height = info.GetValue<int>("height");
+                base.Deserialize(info);
+            }
+
+            public override void Serialize(IXunitSerializationInfo info)
+            {
+                info.AddValue("width", this.Width);
+                info.AddValue("height", this.Height);
+                base.Serialize(info);
+            }
         }
     }
 }

--- a/tests/ImageSharp.Tests/TestUtilities/ImageProviders/FileProvider.cs
+++ b/tests/ImageSharp.Tests/TestUtilities/ImageProviders/FileProvider.cs
@@ -7,11 +7,12 @@ namespace ImageSharp.Tests
 {
     using System;
     using System.Collections.Concurrent;
+    using Xunit.Abstractions;
 
     public abstract partial class TestImageProvider<TColor>
         where TColor : struct, IPixel<TColor>
     {
-        private class FileProvider : TestImageProvider<TColor>
+        private class FileProvider : TestImageProvider<TColor>, IXunitSerializable
         {
             // Need PixelTypes in the dictionary key, because result images of TestImageProvider<TColor>.FileProvider 
             // are shared between PixelTypes.Color & PixelTypes.StandardImageClass
@@ -33,6 +34,10 @@ namespace ImageSharp.Tests
                 this.filePath = filePath;
             }
 
+            public FileProvider()
+            {
+            }
+
             public override string SourceFileOrDescription => this.filePath;
 
             public override Image<TColor> GetImage()
@@ -48,6 +53,19 @@ namespace ImageSharp.Tests
                         });
 
                 return this.Factory.CreateImage(cachedImage);
+            }
+
+            public void Deserialize(IXunitSerializationInfo info)
+            {
+                this.filePath = info.GetValue<string>("path");
+
+                base.Deserialize(info); // must be called last
+            }
+
+            public void Serialize(IXunitSerializationInfo info)
+            {
+                base.Serialize(info);
+                info.AddValue("path", this.filePath);
             }
         }
     }

--- a/tests/ImageSharp.Tests/TestUtilities/ImageProviders/FileProvider.cs
+++ b/tests/ImageSharp.Tests/TestUtilities/ImageProviders/FileProvider.cs
@@ -55,14 +55,14 @@ namespace ImageSharp.Tests
                 return this.Factory.CreateImage(cachedImage);
             }
 
-            public void Deserialize(IXunitSerializationInfo info)
+            public override void Deserialize(IXunitSerializationInfo info)
             {
                 this.filePath = info.GetValue<string>("path");
 
                 base.Deserialize(info); // must be called last
             }
 
-            public void Serialize(IXunitSerializationInfo info)
+            public override void Serialize(IXunitSerializationInfo info)
             {
                 base.Serialize(info);
                 info.AddValue("path", this.filePath);

--- a/tests/ImageSharp.Tests/TestUtilities/ImageProviders/SolidProvider.cs
+++ b/tests/ImageSharp.Tests/TestUtilities/ImageProviders/SolidProvider.cs
@@ -6,6 +6,7 @@
 namespace ImageSharp.Tests
 {
     using System;
+    using Xunit.Abstractions;
 
     /// <summary>
     /// Provides <see cref="Image{TColor}" /> instances for parametric unit tests.
@@ -14,15 +15,15 @@ namespace ImageSharp.Tests
     public abstract partial class TestImageProvider<TColor>
         where TColor : struct, IPixel<TColor>
     {
-        private class SolidProvider : BlankProvider
+        private class SolidProvider : BlankProvider 
         {
-            private readonly byte a;
+            private byte a;
 
-            private readonly byte b;
+            private byte b;
 
-            private readonly byte g;
+            private byte g;
 
-            private readonly byte r;
+            private byte r;
 
             public SolidProvider(int width, int height, byte r, byte g, byte b, byte a)
                 : base(width, height)
@@ -31,6 +32,15 @@ namespace ImageSharp.Tests
                 this.g = g;
                 this.b = b;
                 this.a = a;
+            }
+
+            public SolidProvider()
+                : base()
+            {
+                this.r = 0;
+                this.g = 0;
+                this.b = 0;
+                this.a = 0;
             }
 
             public override string SourceFileOrDescription
@@ -43,6 +53,24 @@ namespace ImageSharp.Tests
                 color.PackFromBytes(this.r, this.g, this.b, this.a);
 
                 return image.Fill(color);
+            }
+
+            public override void Serialize(IXunitSerializationInfo info)
+            {
+                info.AddValue("red", this.r);
+                info.AddValue("green", this.g);
+                info.AddValue("blue", this.b);
+                info.AddValue("alpha", this.a);
+                base.Serialize(info);
+            }
+
+            public override void Deserialize(IXunitSerializationInfo info)
+            {
+                this.r = info.GetValue<byte>("red");
+                this.g = info.GetValue<byte>("green");
+                this.b = info.GetValue<byte>("blue");
+                this.a = info.GetValue<byte>("alpha");
+                base.Deserialize(info);
             }
         }
     }

--- a/tests/ImageSharp.Tests/TestUtilities/ImageProviders/TestImageProvider.cs
+++ b/tests/ImageSharp.Tests/TestUtilities/ImageProviders/TestImageProvider.cs
@@ -7,12 +7,13 @@ namespace ImageSharp.Tests
 {
     using System;
     using System.Reflection;
+    using Xunit.Abstractions;
 
     /// <summary>
     /// Provides <see cref="Image{TColor}" /> instances for parametric unit tests.
     /// </summary>
     /// <typeparam name="TColor">The pixel format of the image</typeparam>
-    public abstract partial class TestImageProvider<TColor>
+    public abstract partial class TestImageProvider<TColor> : IXunitSerializable
         where TColor : struct, IPixel<TColor>
     {
         public PixelTypes PixelType { get; private set; } = typeof(TColor).GetPixelType();
@@ -25,7 +26,9 @@ namespace ImageSharp.Tests
         public ImagingTestCaseUtility Utility { get; private set; }
 
         public GenericFactory<TColor> Factory { get; private set; } = new GenericFactory<TColor>();
-        
+        public string TypeName { get; private set; }
+        public string MethodName { get; private set; }
+
         public static TestImageProvider<TColor> TestPattern(
                 int width,
                 int height,
@@ -72,12 +75,30 @@ namespace ImageSharp.Tests
         /// </summary>
         public abstract Image<TColor> GetImage();
 
-        protected TestImageProvider<TColor> Init(MethodInfo testMethod, PixelTypes pixelTypeOverride)
+        public virtual void Deserialize(IXunitSerializationInfo info)
+        {
+            PixelTypes pixelType = info.GetValue<PixelTypes>("PixelType");
+            string typeName = info.GetValue<string>("TypeName");
+            string methodName = info.GetValue<string>("MethodName");
+
+            this.Init(typeName, methodName, pixelType);
+        }
+
+        public virtual void Serialize(IXunitSerializationInfo info)
+        {
+            info.AddValue("PixelType", this.PixelType);
+            info.AddValue("TypeName", this.TypeName);
+            info.AddValue("MethodName", this.MethodName);
+        }
+
+        protected TestImageProvider<TColor> Init(string typeName, string methodName, PixelTypes pixelTypeOverride)
         {
             if (pixelTypeOverride != PixelTypes.Undefined)
             {
                 this.PixelType = pixelTypeOverride;
             }
+            this.TypeName = typeName;
+            this.MethodName = methodName;
 
             if (pixelTypeOverride == PixelTypes.StandardImageClass)
             {
@@ -85,17 +106,22 @@ namespace ImageSharp.Tests
             }
 
             this.Utility = new ImagingTestCaseUtility()
-                               {
-                                   SourceFileOrDescription = this.SourceFileOrDescription,
-                                   PixelTypeName = this.PixelType.ToString()
-                               };
-
-            if (testMethod != null)
             {
-                this.Utility.Init(testMethod);
+                SourceFileOrDescription = this.SourceFileOrDescription,
+                PixelTypeName = this.PixelType.ToString()
+            };
+
+            if (methodName != null)
+            {
+                this.Utility.Init(typeName, methodName);
             }
 
             return this;
+        }
+
+        protected TestImageProvider<TColor> Init(MethodInfo testMethod, PixelTypes pixelTypeOverride)
+        {
+            return Init(testMethod?.DeclaringType.Name, testMethod?.Name, pixelTypeOverride);
         }
 
         public override string ToString()

--- a/tests/ImageSharp.Tests/TestUtilities/ImageProviders/TestImageProvider.cs
+++ b/tests/ImageSharp.Tests/TestUtilities/ImageProviders/TestImageProvider.cs
@@ -25,13 +25,20 @@ namespace ImageSharp.Tests
         public ImagingTestCaseUtility Utility { get; private set; }
 
         public GenericFactory<TColor> Factory { get; private set; } = new GenericFactory<TColor>();
-
-        public static TestImageProvider<TColor> Blank(
+        
+        public static TestImageProvider<TColor> TestPattern(
                 int width,
                 int height,
                 MethodInfo testMethod = null,
                 PixelTypes pixelTypeOverride = PixelTypes.Undefined)
-            => new BlankProvider(width, height).Init(testMethod, pixelTypeOverride);
+            => new TestPatternProvider(width, height).Init(testMethod, pixelTypeOverride);
+
+        public static TestImageProvider<TColor> Blank(
+                        int width,
+                        int height,
+                        MethodInfo testMethod = null,
+                        PixelTypes pixelTypeOverride = PixelTypes.Undefined)
+                    => new BlankProvider(width, height).Init(testMethod, pixelTypeOverride);
 
         public static TestImageProvider<TColor> File(
             string filePath,

--- a/tests/ImageSharp.Tests/TestUtilities/ImageProviders/TestImageProvider.cs
+++ b/tests/ImageSharp.Tests/TestUtilities/ImageProviders/TestImageProvider.cs
@@ -13,7 +13,7 @@ namespace ImageSharp.Tests
     /// Provides <see cref="Image{TColor}" /> instances for parametric unit tests.
     /// </summary>
     /// <typeparam name="TColor">The pixel format of the image</typeparam>
-    public abstract partial class TestImageProvider<TColor> : IXunitSerializable
+    public abstract partial class TestImageProvider<TColor> 
         where TColor : struct, IPixel<TColor>
     {
         public PixelTypes PixelType { get; private set; } = typeof(TColor).GetPixelType();

--- a/tests/ImageSharp.Tests/TestUtilities/ImageProviders/TestPatternProvider.cs
+++ b/tests/ImageSharp.Tests/TestUtilities/ImageProviders/TestPatternProvider.cs
@@ -8,6 +8,7 @@ namespace ImageSharp.Tests
     using System;
     using System.Collections.Generic;
     using System.Numerics;
+    using Xunit.Abstractions;
 
     public abstract partial class TestImageProvider<TColor>
         where TColor : struct, IPixel<TColor>
@@ -17,21 +18,21 @@ namespace ImageSharp.Tests
         /// A test image provider that produces test patterns.
         /// </summary>
         /// <typeparam name="TColor"></typeparam>
-        private class TestPatternProvider : TestImageProvider<TColor>
+        private class TestPatternProvider : BlankProvider
         {
             static Dictionary<string, Image<TColor>> testImages = new Dictionary<string, Image<TColor>>();
 
             public TestPatternProvider(int width, int height)
+                : base(width, height)
             {
-                this.Width = width;
-                this.Height = height;
+            }
+
+            public TestPatternProvider()
+                : base()
+            {
             }
 
             public override string SourceFileOrDescription => $"TestPattern{this.Width}x{this.Height}";
-
-            protected int Height { get; }
-
-            protected int Width { get; }
 
             public override Image<TColor> GetImage()
             {
@@ -43,9 +44,9 @@ namespace ImageSharp.Tests
                         DrawTestPattern(image);
                         testImages.Add(this.SourceFileOrDescription, image);
                     }
-
-                    return new Image<TColor>(testImages[this.SourceFileOrDescription]);
                 }
+
+                return new Image<TColor>(testImages[this.SourceFileOrDescription]);
             }
 
             /// <summary>
@@ -132,7 +133,7 @@ namespace ImageSharp.Tests
                     p = pstart;
                 }
             }
-            
+
             /// <summary>
             /// Fills the bottom left quadrent with 3 horizental bars in Red, Green and Blue with a alpha gradient from left (transparent) to right (solid).
             /// </summary>

--- a/tests/ImageSharp.Tests/TestUtilities/ImageProviders/TestPatternProvider.cs
+++ b/tests/ImageSharp.Tests/TestUtilities/ImageProviders/TestPatternProvider.cs
@@ -1,0 +1,184 @@
+﻿// <copyright file="BlankProvider.cs" company="James Jackson-South">
+// Copyright (c) James Jackson-South and contributors.
+// Licensed under the Apache License, Version 2.0.
+// </copyright>
+
+namespace ImageSharp.Tests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Numerics;
+
+    public abstract partial class TestImageProvider<TColor>
+        where TColor : struct, IPixel<TColor>
+    {
+        private class TestPatternProvider : TestImageProvider<TColor>
+        {
+            static Dictionary<string, Image<TColor>> testImages = new Dictionary<string, Image<TColor>>();
+
+            public TestPatternProvider(int width, int height)
+            {
+                this.Width = width;
+                this.Height = height;
+            }
+
+            public override string SourceFileOrDescription => $"TestPattern{this.Width}x{this.Height}";
+
+            protected int Height { get; }
+
+            protected int Width { get; }
+
+            public override Image<TColor> GetImage()
+            {
+                lock (testImages)
+                {
+                    if (!testImages.ContainsKey(this.SourceFileOrDescription))
+                    {
+                        var image = new Image<TColor>(this.Width, this.Height);
+                        DrawTestPattern(image);
+                        testImages.Add(this.SourceFileOrDescription, image);
+                    }
+
+                    return new Image<TColor>(testImages[this.SourceFileOrDescription]);
+                }
+            }
+
+            private static void DrawTestPattern(Image<TColor> image)
+            {
+                // first lets split the image into 4 quadrants
+                using (var pixels = image.Lock())
+                {
+                    BlackWhiteChecker(pixels); // top left
+                    HorizontalLines(pixels); // top right
+                    TransparentGradients(pixels); // bottom left
+                    Raninbow(pixels); // bottom right 
+                }
+            }
+
+            private static void HorizontalLines(PixelAccessor<TColor> pixels)
+            {
+                // topLeft 
+                int left = pixels.Width / 2;
+                int right = pixels.Width;
+                int top = 0;
+                int bottom = pixels.Height / 2;
+                int stride = pixels.Width / 12;
+                TColor[] c = {
+                        NamedColors<TColor>.HotPink,
+                        NamedColors<TColor>.Blue
+                    };
+                int p = 0;
+                for (var y = top; y < bottom; y++)
+                {
+                    for (var x = left; x < right; x++)
+                    {
+                        if (x % stride == 0)
+                        {
+                            p++;
+                            p = p % c.Length;
+                        }
+                        pixels[x, y] = c[p];
+                    }
+                }
+            }
+
+            private static void BlackWhiteChecker(PixelAccessor<TColor> pixels)
+            {
+                // topLeft 
+                int left = 0;
+                int right = pixels.Width / 2;
+                int top = 0;
+                int bottom = pixels.Height / 2;
+                int stride = pixels.Width / 6;
+                TColor[] c = {
+                        NamedColors<TColor>.Black,
+                        NamedColors<TColor>.White
+                    };
+
+                int p = 0;
+                for (var y = top; y < bottom; y++)
+                {
+                    if (y % stride == 0)
+                    {
+                        p++;
+                        p = p % c.Length;
+                    }
+                    var pstart = p;
+                    for (var x = left; x < right; x++)
+                    {
+                        if (x % stride == 0)
+                        {
+                            p++;
+                            p = p % c.Length;
+                        }
+                        pixels[x, y] = c[p];
+                    }
+                    p = pstart;
+                }
+            }
+
+            private static void TransparentGradients(PixelAccessor<TColor> pixels)
+            {
+                // topLeft 
+                int left = 0;
+                int right = pixels.Width / 2;
+                int top = pixels.Height / 2;
+                int bottom = pixels.Height;
+                int height = (int)Math.Ceiling(pixels.Height / 6f);
+
+                Vector4 red = Color.Red.ToVector4(); // use real color so we can see har it translates in the test pattern
+                Vector4 green = Color.Green.ToVector4(); // use real color so we can see har it translates in the test pattern
+                Vector4 blue = Color.Blue.ToVector4(); // use real color so we can see har it translates in the test pattern
+
+                TColor c = default(TColor);
+
+                for (var x = left; x < right; x++)
+                {
+                    blue.W = red.W = green.W = (float)x / (float)right;
+
+                    c.PackFromVector4(red);
+                    var topBand = top;
+                    for (var y = topBand; y < top + height; y++)
+                    {
+                        pixels[x, y] = c;
+                    }
+                    topBand = topBand + height;
+                    c.PackFromVector4(green);
+                    for (var y = topBand; y < topBand + height; y++)
+                    {
+                        pixels[x, y] = c;
+                    }
+                    topBand = topBand + height;
+                    c.PackFromVector4(blue);
+                    for (var y = topBand; y < bottom; y++)
+                    {
+                        pixels[x, y] = c;
+                    }
+                }
+
+            }
+            private static void Raninbow(PixelAccessor<TColor> pixels)
+            {
+                int left = pixels.Width / 2;
+                int right = pixels.Width;
+                int top = pixels.Height / 2;
+                int bottom = pixels.Height;
+
+                int pixelCount = left * top;
+                uint stepsPerPixel = (uint)(uint.MaxValue / pixelCount);
+                TColor c = default(TColor);
+                Color t = new Color(0);
+                uint inital = 0;
+                for (var x = left; x < right; x++)
+                    for (var y = top; y < bottom; y++)
+                    {
+                        t.PackedValue += stepsPerPixel;
+                        var v = t.ToVector4();
+                        //v.W = (x - left) / (float)left;
+                        c.PackFromVector4(v);
+                        pixels[x, y] = c;
+                    }
+            }
+        }
+    }
+}

--- a/tests/ImageSharp.Tests/TestUtilities/ImageProviders/TestPatternProvider.cs
+++ b/tests/ImageSharp.Tests/TestUtilities/ImageProviders/TestPatternProvider.cs
@@ -12,6 +12,11 @@ namespace ImageSharp.Tests
     public abstract partial class TestImageProvider<TColor>
         where TColor : struct, IPixel<TColor>
     {
+
+        /// <summary>
+        /// A test image provider that produces test patterns.
+        /// </summary>
+        /// <typeparam name="TColor"></typeparam>
         private class TestPatternProvider : TestImageProvider<TColor>
         {
             static Dictionary<string, Image<TColor>> testImages = new Dictionary<string, Image<TColor>>();
@@ -43,19 +48,26 @@ namespace ImageSharp.Tests
                 }
             }
 
+            /// <summary>
+            /// Draws the test pattern on an image by drawing 4 other patterns in the for quadrants of the image.
+            /// </summary>
+            /// <param name="image"></param>
             private static void DrawTestPattern(Image<TColor> image)
             {
                 // first lets split the image into 4 quadrants
                 using (PixelAccessor<TColor> pixels = image.Lock())
                 {
                     BlackWhiteChecker(pixels); // top left
-                    HorizontalLines(pixels); // top right
+                    VirticalBars(pixels); // top right
                     TransparentGradients(pixels); // bottom left
-                    Raninbow(pixels); // bottom right 
+                    Rainbow(pixels); // bottom right 
                 }
             }
-
-            private static void HorizontalLines(PixelAccessor<TColor> pixels)
+            /// <summary>
+            /// Fills the top right quadrant with alternating solid vertical bars.
+            /// </summary>
+            /// <param name="pixels"></param>
+            private static void VirticalBars(PixelAccessor<TColor> pixels)
             {
                 // topLeft 
                 int left = pixels.Width / 2;
@@ -82,6 +94,10 @@ namespace ImageSharp.Tests
                 }
             }
 
+            /// <summary>
+            /// fills the top left quadrant with a black and white checker board.
+            /// </summary>
+            /// <param name="pixels"></param>
             private static void BlackWhiteChecker(PixelAccessor<TColor> pixels)
             {
                 // topLeft 
@@ -116,7 +132,11 @@ namespace ImageSharp.Tests
                     p = pstart;
                 }
             }
-
+            
+            /// <summary>
+            /// Fills the bottom left quadrent with 3 horizental bars in Red, Green and Blue with a alpha gradient from left (transparent) to right (solid).
+            /// </summary>
+            /// <param name="pixels"></param>
             private static void TransparentGradients(PixelAccessor<TColor> pixels)
             {
                 // topLeft 
@@ -155,9 +175,14 @@ namespace ImageSharp.Tests
                         pixels[x, y] = c;
                     }
                 }
-
             }
-            private static void Raninbow(PixelAccessor<TColor> pixels)
+
+            /// <summary>
+            /// Fills the bottom right quadrant with all the colors producable by converting itterating over a uint and unpacking it.
+            /// A better algorithm could be used but it works
+            /// </summary>
+            /// <param name="pixels"></param>
+            private static void Rainbow(PixelAccessor<TColor> pixels)
             {
                 int left = pixels.Width / 2;
                 int right = pixels.Width;

--- a/tests/ImageSharp.Tests/TestUtilities/ImageProviders/TestPatternProvider.cs
+++ b/tests/ImageSharp.Tests/TestUtilities/ImageProviders/TestPatternProvider.cs
@@ -34,7 +34,7 @@ namespace ImageSharp.Tests
                 {
                     if (!testImages.ContainsKey(this.SourceFileOrDescription))
                     {
-                        var image = new Image<TColor>(this.Width, this.Height);
+                        Image<TColor> image = new Image<TColor>(this.Width, this.Height);
                         DrawTestPattern(image);
                         testImages.Add(this.SourceFileOrDescription, image);
                     }
@@ -46,7 +46,7 @@ namespace ImageSharp.Tests
             private static void DrawTestPattern(Image<TColor> image)
             {
                 // first lets split the image into 4 quadrants
-                using (var pixels = image.Lock())
+                using (PixelAccessor<TColor> pixels = image.Lock())
                 {
                     BlackWhiteChecker(pixels); // top left
                     HorizontalLines(pixels); // top right
@@ -68,9 +68,9 @@ namespace ImageSharp.Tests
                         NamedColors<TColor>.Blue
                     };
                 int p = 0;
-                for (var y = top; y < bottom; y++)
+                for (int y = top; y < bottom; y++)
                 {
-                    for (var x = left; x < right; x++)
+                    for (int x = left; x < right; x++)
                     {
                         if (x % stride == 0)
                         {
@@ -96,15 +96,15 @@ namespace ImageSharp.Tests
                     };
 
                 int p = 0;
-                for (var y = top; y < bottom; y++)
+                for (int y = top; y < bottom; y++)
                 {
                     if (y % stride == 0)
                     {
                         p++;
                         p = p % c.Length;
                     }
-                    var pstart = p;
-                    for (var x = left; x < right; x++)
+                    int pstart = p;
+                    for (int x = left; x < right; x++)
                     {
                         if (x % stride == 0)
                         {
@@ -132,25 +132,25 @@ namespace ImageSharp.Tests
 
                 TColor c = default(TColor);
 
-                for (var x = left; x < right; x++)
+                for (int x = left; x < right; x++)
                 {
                     blue.W = red.W = green.W = (float)x / (float)right;
 
                     c.PackFromVector4(red);
-                    var topBand = top;
-                    for (var y = topBand; y < top + height; y++)
+                    int topBand = top;
+                    for (int y = topBand; y < top + height; y++)
                     {
                         pixels[x, y] = c;
                     }
                     topBand = topBand + height;
                     c.PackFromVector4(green);
-                    for (var y = topBand; y < topBand + height; y++)
+                    for (int y = topBand; y < topBand + height; y++)
                     {
                         pixels[x, y] = c;
                     }
                     topBand = topBand + height;
                     c.PackFromVector4(blue);
-                    for (var y = topBand; y < bottom; y++)
+                    for (int y = topBand; y < bottom; y++)
                     {
                         pixels[x, y] = c;
                     }
@@ -168,12 +168,12 @@ namespace ImageSharp.Tests
                 uint stepsPerPixel = (uint)(uint.MaxValue / pixelCount);
                 TColor c = default(TColor);
                 Color t = new Color(0);
-                uint inital = 0;
-                for (var x = left; x < right; x++)
-                    for (var y = top; y < bottom; y++)
+
+                for (int x = left; x < right; x++)
+                    for (int y = top; y < bottom; y++)
                     {
                         t.PackedValue += stepsPerPixel;
-                        var v = t.ToVector4();
+                        Vector4 v = t.ToVector4();
                         //v.W = (x - left) / (float)left;
                         c.PackFromVector4(v);
                         pixels[x, y] = c;

--- a/tests/ImageSharp.Tests/TestUtilities/ImagingTestCaseUtility.cs
+++ b/tests/ImageSharp.Tests/TestUtilities/ImagingTestCaseUtility.cs
@@ -62,7 +62,7 @@ namespace ImageSharp.Tests
 
             if (string.IsNullOrWhiteSpace(extension))
             {
-                extension = ".bmp"; 
+                extension = ".bmp";
             }
 
             if (extension[0] != '.')
@@ -81,9 +81,9 @@ namespace ImageSharp.Tests
             tag = tag ?? string.Empty;
             if (tag != string.Empty)
             {
-                tag= '_' + tag;
+                tag = '_' + tag;
             }
-            
+
 
             return $"{this.GetTestOutputDir()}/{this.TestName}{pixName}{fn}{tag}{extension}";
         }
@@ -111,10 +111,15 @@ namespace ImageSharp.Tests
             }
         }
 
+        internal void Init(string typeName, string methodName)
+        {
+            this.TestGroupName = typeName;
+            this.TestName = methodName;
+        }
+
         internal void Init(MethodInfo method)
         {
-            this.TestGroupName = method.DeclaringType.Name;
-            this.TestName = method.Name;
+            this.Init(method.DeclaringType.Name, method.Name);
         }
 
         private static IImageFormat GetImageFormatByExtension(string extension)

--- a/tests/ImageSharp.Tests/TestUtilities/ImagingTestCaseUtility.cs
+++ b/tests/ImageSharp.Tests/TestUtilities/ImagingTestCaseUtility.cs
@@ -44,13 +44,26 @@ namespace ImageSharp.Tests
         /// </summary>
         /// <param name="extension"></param>
         /// <returns>The required extension</returns>
-        public string GetTestOutputFileName(string extension = null)
+        public string GetTestOutputFileName(string extension = null, string tag = null)
         {
             string fn = string.Empty;
 
+            if (string.IsNullOrWhiteSpace(extension))
+            {
+                extension = null;
+            }
+
             fn = Path.GetFileNameWithoutExtension(this.SourceFileOrDescription);
-            extension = extension ?? Path.GetExtension(this.SourceFileOrDescription);
-            extension = extension ?? ".bmp";
+
+            if (string.IsNullOrWhiteSpace(extension))
+            {
+                extension = Path.GetExtension(this.SourceFileOrDescription);
+            }
+
+            if (string.IsNullOrWhiteSpace(extension))
+            {
+                extension = ".bmp"; 
+            }
 
             if (extension[0] != '.')
             {
@@ -65,7 +78,14 @@ namespace ImageSharp.Tests
                 pixName = '_' + pixName;
             }
 
-            return $"{this.GetTestOutputDir()}/{this.TestName}{pixName}{fn}{extension}";
+            tag = tag ?? string.Empty;
+            if (tag != string.Empty)
+            {
+                tag= '_' + tag;
+            }
+            
+
+            return $"{this.GetTestOutputDir()}/{this.TestName}{pixName}{fn}{tag}{extension}";
         }
 
         /// <summary>
@@ -80,7 +100,7 @@ namespace ImageSharp.Tests
             where TColor : struct, IPixel<TColor>
         {
             string path = this.GetTestOutputFileName(extension);
-
+            extension = Path.GetExtension(path);
             IImageFormat format = GetImageFormatByExtension(extension);
 
             encoder = encoder ?? format.Encoder;
@@ -99,8 +119,8 @@ namespace ImageSharp.Tests
 
         private static IImageFormat GetImageFormatByExtension(string extension)
         {
-            extension = extension.ToLower();
-            return Configuration.Default.ImageFormats.First(f => f.SupportedExtensions.Contains(extension));
+            extension = extension?.TrimStart('.');
+            return Configuration.Default.ImageFormats.First(f => f.SupportedExtensions.Contains(extension, StringComparer.OrdinalIgnoreCase));
         }
 
         private string GetTestOutputDir()

--- a/tests/ImageSharp.Tests/TestUtilities/TestImageExtensions.cs
+++ b/tests/ImageSharp.Tests/TestUtilities/TestImageExtensions.cs
@@ -1,0 +1,20 @@
+﻿
+namespace ImageSharp.Tests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Text;
+
+    public static class TestImageExtensions
+    {
+        public static void DebugSave<TColor>(this Image<TColor> img, TestImageProvider<TColor> provider, string extension = "png")
+                        where TColor : struct, IPixel<TColor>
+        {
+            if(!bool.TryParse(Environment.GetEnvironmentVariable("CI"), out bool isCI) || !isCI)
+            {
+                // we are running locally then we want to save it out
+                provider.Utility.SaveTestOutputFile(img, extension);
+            }
+        }
+    }
+}


### PR DESCRIPTION

### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/JimBobSquarePants/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practise as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
This adds a helper image comparer class to testing to help us turn some of our none tests into real unit tests.

Add a couple of png smoke tests that encode and then decode an image in png then does a visual compare to verify they render the same as an example on how to use the comparer.