### PR TITLE
Update to use MathsF

### DIFF
--- a/src/ImageSharp.Drawing/Brushes/ImageBrush{TColor}.cs
+++ b/src/ImageSharp.Drawing/Brushes/ImageBrush{TColor}.cs
@@ -80,7 +80,7 @@ namespace ImageSharp.Drawing.Brushes
                 this.source = image.Lock();
                 this.xLength = image.Width;
                 this.yLength = image.Height;
-                this.offset = new Vector2((float)Math.Max(Math.Floor(region.Top), 0), (float)Math.Max(Math.Floor(region.Left), 0));
+                this.offset = new Vector2(MathF.Max(MathF.Floor(region.Top), 0), MathF.Max(MathF.Floor(region.Left), 0));
             }
 
             /// <summary>

--- a/src/ImageSharp.Drawing/Paths/RectangleExtensions.cs
+++ b/src/ImageSharp.Drawing/Paths/RectangleExtensions.cs
@@ -19,10 +19,10 @@ namespace ImageSharp.Drawing
         /// <returns>A <see cref="Rectangle"/> representation of this <see cref="SixLabors.Shapes.Rectangle"/></returns>
         public static Rectangle Convert(this SixLabors.Shapes.Rectangle source)
         {
-            int left = (int)Math.Floor(source.Left);
-            int right = (int)Math.Ceiling(source.Right);
-            int top = (int)Math.Floor(source.Top);
-            int bottom = (int)Math.Ceiling(source.Bottom);
+            int left = (int)MathF.Floor(source.Left);
+            int right = (int)MathF.Ceiling(source.Right);
+            int top = (int)MathF.Floor(source.Top);
+            int bottom = (int)MathF.Ceiling(source.Bottom);
             return new Rectangle(left, top, right - left, bottom - top);
         }
     }

--- a/src/ImageSharp.Drawing/Pens/Pen{TColor}.cs
+++ b/src/ImageSharp.Drawing/Pens/Pen{TColor}.cs
@@ -241,7 +241,7 @@ namespace ImageSharp.Drawing.Pens
                             float distanceFromStart = length - start;
                             float distanceFromEnd = end - length;
 
-                            float closestEdge = Math.Min(distanceFromStart, distanceFromEnd);
+                            float closestEdge = MathF.Min(distanceFromStart, distanceFromEnd);
 
                             float distanceAcross = closestEdge;
 

--- a/src/ImageSharp.Drawing/Processors/FillRegionProcessor.cs
+++ b/src/ImageSharp.Drawing/Processors/FillRegionProcessor.cs
@@ -128,8 +128,8 @@ namespace ImageSharp.Drawing.Processors
                                 // points will be paired up
                                 float scanStart = buffer[point] - minX;
                                 float scanEnd = buffer[point + 1] - minX;
-                                int startX = (int)Math.Floor(scanStart);
-                                int endX = (int)Math.Floor(scanEnd);
+                                int startX = (int)MathF.Floor(scanStart);
+                                int endX = (int)MathF.Floor(scanEnd);
 
                                 if (startX >= 0 && startX < scanline.Length)
                                 {

--- a/src/ImageSharp/Colors/ColorspaceTransforms.cs
+++ b/src/ImageSharp/Colors/ColorspaceTransforms.cs
@@ -105,12 +105,12 @@ namespace ImageSharp
             float s = color.S;
             float v = color.V;
 
-            if (Math.Abs(s) < Constants.Epsilon)
+            if (MathF.Abs(s) < Constants.Epsilon)
             {
                 return new Color(v, v, v, 1);
             }
 
-            float h = (Math.Abs(color.H - 360) < Constants.Epsilon) ? 0 : color.H / 60;
+            float h = (MathF.Abs(color.H - 360) < Constants.Epsilon) ? 0 : color.H / 60;
             int i = (int)Math.Truncate(h);
             float f = h - i;
 
@@ -178,9 +178,9 @@ namespace ImageSharp
             float s = color.S;
             float l = color.L;
 
-            if (Math.Abs(l) > Constants.Epsilon)
+            if (MathF.Abs(l) > Constants.Epsilon)
             {
-                if (Math.Abs(s) < Constants.Epsilon)
+                if (MathF.Abs(s) < Constants.Epsilon)
                 {
                     r = g = b = l;
                 }

--- a/src/ImageSharp/Colors/PackedPixel/Bgr565.cs
+++ b/src/ImageSharp/Colors/PackedPixel/Bgr565.cs
@@ -110,9 +110,9 @@ namespace ImageSharp
         public void ToXyzBytes(byte[] bytes, int startIndex)
         {
             Vector4 vector = this.ToVector4() * 255F;
-            bytes[startIndex] = (byte)(float)Math.Round(vector.X);
-            bytes[startIndex + 1] = (byte)(float)Math.Round(vector.Y);
-            bytes[startIndex + 2] = (byte)(float)Math.Round(vector.Z);
+            bytes[startIndex] = (byte)MathF.Round(vector.X);
+            bytes[startIndex + 1] = (byte)MathF.Round(vector.Y);
+            bytes[startIndex + 2] = (byte)MathF.Round(vector.Z);
         }
 
         /// <inheritdoc />
@@ -120,10 +120,10 @@ namespace ImageSharp
         public void ToXyzwBytes(byte[] bytes, int startIndex)
         {
             Vector4 vector = this.ToVector4() * 255F;
-            bytes[startIndex] = (byte)(float)Math.Round(vector.X);
-            bytes[startIndex + 1] = (byte)(float)Math.Round(vector.Y);
-            bytes[startIndex + 2] = (byte)(float)Math.Round(vector.Z);
-            bytes[startIndex + 3] = (byte)(float)Math.Round(vector.W);
+            bytes[startIndex] = (byte)MathF.Round(vector.X);
+            bytes[startIndex + 1] = (byte)MathF.Round(vector.Y);
+            bytes[startIndex + 2] = (byte)MathF.Round(vector.Z);
+            bytes[startIndex + 3] = (byte)MathF.Round(vector.W);
         }
 
         /// <inheritdoc />
@@ -131,9 +131,9 @@ namespace ImageSharp
         public void ToZyxBytes(byte[] bytes, int startIndex)
         {
             Vector4 vector = this.ToVector4() * 255F;
-            bytes[startIndex] = (byte)(float)Math.Round(vector.Z);
-            bytes[startIndex + 1] = (byte)(float)Math.Round(vector.Y);
-            bytes[startIndex + 2] = (byte)(float)Math.Round(vector.X);
+            bytes[startIndex] = (byte)MathF.Round(vector.Z);
+            bytes[startIndex + 1] = (byte)MathF.Round(vector.Y);
+            bytes[startIndex + 2] = (byte)MathF.Round(vector.X);
         }
 
         /// <inheritdoc />
@@ -141,10 +141,10 @@ namespace ImageSharp
         public void ToZyxwBytes(byte[] bytes, int startIndex)
         {
             Vector4 vector = this.ToVector4() * 255F;
-            bytes[startIndex] = (byte)(float)Math.Round(vector.Z);
-            bytes[startIndex + 1] = (byte)(float)Math.Round(vector.Y);
-            bytes[startIndex + 2] = (byte)(float)Math.Round(vector.X);
-            bytes[startIndex + 3] = (byte)(float)Math.Round(vector.W);
+            bytes[startIndex] = (byte)MathF.Round(vector.Z);
+            bytes[startIndex + 1] = (byte)MathF.Round(vector.Y);
+            bytes[startIndex + 2] = (byte)MathF.Round(vector.X);
+            bytes[startIndex + 3] = (byte)MathF.Round(vector.W);
         }
 
         /// <inheritdoc />

--- a/src/ImageSharp/Colors/PackedPixel/NormalizedShort2.cs
+++ b/src/ImageSharp/Colors/PackedPixel/NormalizedShort2.cs
@@ -127,8 +127,8 @@ namespace ImageSharp
             vector += Round;
             vector = Vector4.Clamp(vector, Vector4.Zero, MaxBytes);
 
-            bytes[startIndex] = (byte)(float)Math.Round(vector.X);
-            bytes[startIndex + 1] = (byte)(float)Math.Round(vector.Y);
+            bytes[startIndex] = (byte)MathF.Round(vector.X);
+            bytes[startIndex + 1] = (byte)MathF.Round(vector.Y);
             bytes[startIndex + 2] = 0;
         }
 
@@ -143,8 +143,8 @@ namespace ImageSharp
             vector += Round;
             vector = Vector4.Clamp(vector, Vector4.Zero, MaxBytes);
 
-            bytes[startIndex] = (byte)(float)Math.Round(vector.X);
-            bytes[startIndex + 1] = (byte)(float)Math.Round(vector.Y);
+            bytes[startIndex] = (byte)MathF.Round(vector.X);
+            bytes[startIndex + 1] = (byte)MathF.Round(vector.Y);
             bytes[startIndex + 2] = 0;
             bytes[startIndex + 3] = 255;
         }
@@ -161,8 +161,8 @@ namespace ImageSharp
             vector = Vector4.Clamp(vector, Vector4.Zero, MaxBytes);
 
             bytes[startIndex] = 0;
-            bytes[startIndex + 1] = (byte)(float)Math.Round(vector.Y);
-            bytes[startIndex + 2] = (byte)(float)Math.Round(vector.X);
+            bytes[startIndex + 1] = (byte)MathF.Round(vector.Y);
+            bytes[startIndex + 2] = (byte)MathF.Round(vector.X);
         }
 
         /// <inheritdoc />
@@ -177,8 +177,8 @@ namespace ImageSharp
             vector = Vector4.Clamp(vector, Vector4.Zero, MaxBytes);
 
             bytes[startIndex] = 0;
-            bytes[startIndex + 1] = (byte)(float)Math.Round(vector.Y);
-            bytes[startIndex + 2] = (byte)(float)Math.Round(vector.X);
+            bytes[startIndex + 1] = (byte)MathF.Round(vector.Y);
+            bytes[startIndex + 2] = (byte)MathF.Round(vector.X);
             bytes[startIndex + 3] = 255;
         }
 
@@ -237,8 +237,8 @@ namespace ImageSharp
 
             // Clamp the value between min and max values
             // Round rather than truncate.
-            uint word2 = (uint)((int)(float)Math.Round(x * MaxPos).Clamp(MinNeg, MaxPos) & 0xFFFF);
-            uint word1 = (uint)(((int)(float)Math.Round(y * MaxPos).Clamp(MinNeg, MaxPos) & 0xFFFF) << 0x10);
+            uint word2 = (uint)((int)MathF.Round(x * MaxPos).Clamp(MinNeg, MaxPos) & 0xFFFF);
+            uint word1 = (uint)(((int)MathF.Round(y * MaxPos).Clamp(MinNeg, MaxPos) & 0xFFFF) << 0x10);
 
             return word2 | word1;
         }

--- a/src/ImageSharp/Colors/PackedPixel/NormalizedShort4.cs
+++ b/src/ImageSharp/Colors/PackedPixel/NormalizedShort4.cs
@@ -135,9 +135,9 @@ namespace ImageSharp
             vector += Round;
             vector = Vector4.Clamp(vector, Vector4.Zero, MaxBytes);
 
-            bytes[startIndex] = (byte)(float)Math.Round(vector.X);
-            bytes[startIndex + 1] = (byte)(float)Math.Round(vector.Y);
-            bytes[startIndex + 2] = (byte)(float)Math.Round(vector.Z);
+            bytes[startIndex] = (byte)MathF.Round(vector.X);
+            bytes[startIndex + 1] = (byte)MathF.Round(vector.Y);
+            bytes[startIndex + 2] = (byte)MathF.Round(vector.Z);
         }
 
         /// <inheritdoc />
@@ -151,10 +151,10 @@ namespace ImageSharp
             vector += Round;
             vector = Vector4.Clamp(vector, Vector4.Zero, MaxBytes);
 
-            bytes[startIndex] = (byte)(float)Math.Round(vector.X);
-            bytes[startIndex + 1] = (byte)(float)Math.Round(vector.Y);
-            bytes[startIndex + 2] = (byte)(float)Math.Round(vector.Z);
-            bytes[startIndex + 3] = (byte)(float)Math.Round(vector.W);
+            bytes[startIndex] = (byte)MathF.Round(vector.X);
+            bytes[startIndex + 1] = (byte)MathF.Round(vector.Y);
+            bytes[startIndex + 2] = (byte)MathF.Round(vector.Z);
+            bytes[startIndex + 3] = (byte)MathF.Round(vector.W);
         }
 
         /// <inheritdoc />
@@ -168,9 +168,9 @@ namespace ImageSharp
             vector += Round;
             vector = Vector4.Clamp(vector, Vector4.Zero, MaxBytes);
 
-            bytes[startIndex] = (byte)(float)Math.Round(vector.Z);
-            bytes[startIndex + 1] = (byte)(float)Math.Round(vector.Y);
-            bytes[startIndex + 2] = (byte)(float)Math.Round(vector.X);
+            bytes[startIndex] = (byte)MathF.Round(vector.Z);
+            bytes[startIndex + 1] = (byte)MathF.Round(vector.Y);
+            bytes[startIndex + 2] = (byte)MathF.Round(vector.X);
         }
 
         /// <inheritdoc />
@@ -184,10 +184,10 @@ namespace ImageSharp
             vector += Round;
             vector = Vector4.Clamp(vector, Vector4.Zero, MaxBytes);
 
-            bytes[startIndex] = (byte)(float)Math.Round(vector.Z);
-            bytes[startIndex + 1] = (byte)(float)Math.Round(vector.Y);
-            bytes[startIndex + 2] = (byte)(float)Math.Round(vector.X);
-            bytes[startIndex + 3] = (byte)(float)Math.Round(vector.W);
+            bytes[startIndex] = (byte)MathF.Round(vector.Z);
+            bytes[startIndex + 1] = (byte)MathF.Round(vector.Y);
+            bytes[startIndex + 2] = (byte)MathF.Round(vector.X);
+            bytes[startIndex + 3] = (byte)MathF.Round(vector.W);
         }
 
         /// <inheritdoc />
@@ -231,10 +231,10 @@ namespace ImageSharp
             const float MinNeg = -MaxPos;
 
             // Clamp the value between min and max values
-            ulong word4 = ((ulong)(float)Math.Round(x * MaxPos).Clamp(MinNeg, MaxPos) & 0xFFFF) << 0x00;
-            ulong word3 = ((ulong)(float)Math.Round(y * MaxPos).Clamp(MinNeg, MaxPos) & 0xFFFF) << 0x10;
-            ulong word2 = ((ulong)(float)Math.Round(z * MaxPos).Clamp(MinNeg, MaxPos) & 0xFFFF) << 0x20;
-            ulong word1 = ((ulong)(float)Math.Round(w * MaxPos).Clamp(MinNeg, MaxPos) & 0xFFFF) << 0x30;
+            ulong word4 = ((ulong)MathF.Round(x * MaxPos).Clamp(MinNeg, MaxPos) & 0xFFFF) << 0x00;
+            ulong word3 = ((ulong)MathF.Round(y * MaxPos).Clamp(MinNeg, MaxPos) & 0xFFFF) << 0x10;
+            ulong word2 = ((ulong)MathF.Round(z * MaxPos).Clamp(MinNeg, MaxPos) & 0xFFFF) << 0x20;
+            ulong word1 = ((ulong)MathF.Round(w * MaxPos).Clamp(MinNeg, MaxPos) & 0xFFFF) << 0x30;
 
             return word4 | word3 | word2 | word1;
         }

--- a/src/ImageSharp/Colors/PackedPixel/Rgba1010102.cs
+++ b/src/ImageSharp/Colors/PackedPixel/Rgba1010102.cs
@@ -109,9 +109,9 @@ namespace ImageSharp
         {
             Vector4 vector = this.ToVector4() * 255F;
 
-            bytes[startIndex] = (byte)(float)Math.Round(vector.X);
-            bytes[startIndex + 1] = (byte)(float)Math.Round(vector.Y);
-            bytes[startIndex + 2] = (byte)(float)Math.Round(vector.Z);
+            bytes[startIndex] = (byte)MathF.Round(vector.X);
+            bytes[startIndex + 1] = (byte)MathF.Round(vector.Y);
+            bytes[startIndex + 2] = (byte)MathF.Round(vector.Z);
         }
 
         /// <inheritdoc />
@@ -120,10 +120,10 @@ namespace ImageSharp
         {
             Vector4 vector = this.ToVector4() * 255F;
 
-            bytes[startIndex] = (byte)(float)Math.Round(vector.X);
-            bytes[startIndex + 1] = (byte)(float)Math.Round(vector.Y);
-            bytes[startIndex + 2] = (byte)(float)Math.Round(vector.Z);
-            bytes[startIndex + 3] = (byte)(float)Math.Round(vector.W);
+            bytes[startIndex] = (byte)MathF.Round(vector.X);
+            bytes[startIndex + 1] = (byte)MathF.Round(vector.Y);
+            bytes[startIndex + 2] = (byte)MathF.Round(vector.Z);
+            bytes[startIndex + 3] = (byte)MathF.Round(vector.W);
         }
 
         /// <inheritdoc />
@@ -132,9 +132,9 @@ namespace ImageSharp
         {
             Vector4 vector = this.ToVector4() * 255F;
 
-            bytes[startIndex] = (byte)(float)Math.Round(vector.Z);
-            bytes[startIndex + 1] = (byte)(float)Math.Round(vector.Y);
-            bytes[startIndex + 2] = (byte)(float)Math.Round(vector.X);
+            bytes[startIndex] = (byte)MathF.Round(vector.Z);
+            bytes[startIndex + 1] = (byte)MathF.Round(vector.Y);
+            bytes[startIndex + 2] = (byte)MathF.Round(vector.X);
         }
 
         /// <inheritdoc />
@@ -143,10 +143,10 @@ namespace ImageSharp
         {
             Vector4 vector = this.ToVector4() * 255F;
 
-            bytes[startIndex] = (byte)(float)Math.Round(vector.Z);
-            bytes[startIndex + 1] = (byte)(float)Math.Round(vector.Y);
-            bytes[startIndex + 2] = (byte)(float)Math.Round(vector.X);
-            bytes[startIndex + 3] = (byte)(float)Math.Round(vector.W);
+            bytes[startIndex] = (byte)MathF.Round(vector.Z);
+            bytes[startIndex + 1] = (byte)MathF.Round(vector.Y);
+            bytes[startIndex + 2] = (byte)MathF.Round(vector.X);
+            bytes[startIndex + 3] = (byte)MathF.Round(vector.W);
         }
 
         /// <inheritdoc />

--- a/src/ImageSharp/Colors/PackedPixel/Rgba64.cs
+++ b/src/ImageSharp/Colors/PackedPixel/Rgba64.cs
@@ -108,9 +108,9 @@ namespace ImageSharp
         {
             Vector4 vector = this.ToVector4() * 255F;
 
-            bytes[startIndex] = (byte)(float)Math.Round(vector.X);
-            bytes[startIndex + 1] = (byte)(float)Math.Round(vector.Y);
-            bytes[startIndex + 2] = (byte)(float)Math.Round(vector.Z);
+            bytes[startIndex] = (byte)MathF.Round(vector.X);
+            bytes[startIndex + 1] = (byte)MathF.Round(vector.Y);
+            bytes[startIndex + 2] = (byte)MathF.Round(vector.Z);
         }
 
         /// <inheritdoc />
@@ -119,10 +119,10 @@ namespace ImageSharp
         {
             Vector4 vector = this.ToVector4() * 255F;
 
-            bytes[startIndex] = (byte)(float)Math.Round(vector.X);
-            bytes[startIndex + 1] = (byte)(float)Math.Round(vector.Y);
-            bytes[startIndex + 2] = (byte)(float)Math.Round(vector.Z);
-            bytes[startIndex + 3] = (byte)(float)Math.Round(vector.W);
+            bytes[startIndex] = (byte)MathF.Round(vector.X);
+            bytes[startIndex + 1] = (byte)MathF.Round(vector.Y);
+            bytes[startIndex + 2] = (byte)MathF.Round(vector.Z);
+            bytes[startIndex + 3] = (byte)MathF.Round(vector.W);
         }
 
         /// <inheritdoc />
@@ -131,9 +131,9 @@ namespace ImageSharp
         {
             Vector4 vector = this.ToVector4() * 255F;
 
-            bytes[startIndex] = (byte)(float)Math.Round(vector.Z);
-            bytes[startIndex + 1] = (byte)(float)Math.Round(vector.Y);
-            bytes[startIndex + 2] = (byte)(float)Math.Round(vector.X);
+            bytes[startIndex] = (byte)MathF.Round(vector.Z);
+            bytes[startIndex + 1] = (byte)MathF.Round(vector.Y);
+            bytes[startIndex + 2] = (byte)MathF.Round(vector.X);
         }
 
         /// <inheritdoc />
@@ -142,10 +142,10 @@ namespace ImageSharp
         {
             Vector4 vector = this.ToVector4() * 255F;
 
-            bytes[startIndex] = (byte)(float)Math.Round(vector.Z);
-            bytes[startIndex + 1] = (byte)(float)Math.Round(vector.Y);
-            bytes[startIndex + 2] = (byte)(float)Math.Round(vector.X);
-            bytes[startIndex + 3] = (byte)(float)Math.Round(vector.W);
+            bytes[startIndex] = (byte)MathF.Round(vector.Z);
+            bytes[startIndex + 1] = (byte)MathF.Round(vector.Y);
+            bytes[startIndex + 2] = (byte)MathF.Round(vector.X);
+            bytes[startIndex + 3] = (byte)MathF.Round(vector.W);
         }
 
         /// <inheritdoc />

--- a/src/ImageSharp/Colors/PackedPixel/Short2.cs
+++ b/src/ImageSharp/Colors/PackedPixel/Short2.cs
@@ -125,8 +125,8 @@ namespace ImageSharp
             vector += Round;
             vector = Vector2.Clamp(vector, Vector2.Zero, MaxBytes);
 
-            bytes[startIndex] = (byte)(float)Math.Round(vector.X);
-            bytes[startIndex + 1] = (byte)(float)Math.Round(vector.Y);
+            bytes[startIndex] = (byte)MathF.Round(vector.X);
+            bytes[startIndex + 1] = (byte)MathF.Round(vector.Y);
             bytes[startIndex + 2] = 0;
         }
 
@@ -141,8 +141,8 @@ namespace ImageSharp
             vector += Round;
             vector = Vector2.Clamp(vector, Vector2.Zero, MaxBytes);
 
-            bytes[startIndex] = (byte)(float)Math.Round(vector.X);
-            bytes[startIndex + 1] = (byte)(float)Math.Round(vector.Y);
+            bytes[startIndex] = (byte)MathF.Round(vector.X);
+            bytes[startIndex + 1] = (byte)MathF.Round(vector.Y);
             bytes[startIndex + 2] = 0;
             bytes[startIndex + 3] = 255;
         }
@@ -159,8 +159,8 @@ namespace ImageSharp
             vector = Vector2.Clamp(vector, Vector2.Zero, MaxBytes);
 
             bytes[startIndex] = 0;
-            bytes[startIndex + 1] = (byte)(float)Math.Round(vector.Y);
-            bytes[startIndex + 2] = (byte)(float)Math.Round(vector.X);
+            bytes[startIndex + 1] = (byte)MathF.Round(vector.Y);
+            bytes[startIndex + 2] = (byte)MathF.Round(vector.X);
         }
 
         /// <inheritdoc />
@@ -175,8 +175,8 @@ namespace ImageSharp
             vector = Vector2.Clamp(vector, Vector2.Zero, MaxBytes);
 
             bytes[startIndex] = 0;
-            bytes[startIndex + 1] = (byte)(float)Math.Round(vector.Y);
-            bytes[startIndex + 2] = (byte)(float)Math.Round(vector.X);
+            bytes[startIndex + 1] = (byte)MathF.Round(vector.Y);
+            bytes[startIndex + 2] = (byte)MathF.Round(vector.X);
             bytes[startIndex + 3] = 255;
         }
 

--- a/src/ImageSharp/Colors/PackedPixel/Short4.cs
+++ b/src/ImageSharp/Colors/PackedPixel/Short4.cs
@@ -131,9 +131,9 @@ namespace ImageSharp
             vector += Round;
             vector = Vector4.Clamp(vector, Vector4.Zero, MaxBytes);
 
-            bytes[startIndex] = (byte)(float)Math.Round(vector.X);
-            bytes[startIndex + 1] = (byte)(float)Math.Round(vector.Y);
-            bytes[startIndex + 2] = (byte)(float)Math.Round(vector.Z);
+            bytes[startIndex] = (byte)MathF.Round(vector.X);
+            bytes[startIndex + 1] = (byte)MathF.Round(vector.Y);
+            bytes[startIndex + 2] = (byte)MathF.Round(vector.Z);
         }
 
         /// <inheritdoc />
@@ -147,10 +147,10 @@ namespace ImageSharp
             vector += Round;
             vector = Vector4.Clamp(vector, Vector4.Zero, MaxBytes);
 
-            bytes[startIndex] = (byte)(float)Math.Round(vector.X);
-            bytes[startIndex + 1] = (byte)(float)Math.Round(vector.Y);
-            bytes[startIndex + 2] = (byte)(float)Math.Round(vector.Z);
-            bytes[startIndex + 3] = (byte)(float)Math.Round(vector.W);
+            bytes[startIndex] = (byte)MathF.Round(vector.X);
+            bytes[startIndex + 1] = (byte)MathF.Round(vector.Y);
+            bytes[startIndex + 2] = (byte)MathF.Round(vector.Z);
+            bytes[startIndex + 3] = (byte)MathF.Round(vector.W);
         }
 
         /// <inheritdoc />
@@ -164,9 +164,9 @@ namespace ImageSharp
             vector += Round;
             vector = Vector4.Clamp(vector, Vector4.Zero, MaxBytes);
 
-            bytes[startIndex] = (byte)(float)Math.Round(vector.Z);
-            bytes[startIndex + 1] = (byte)(float)Math.Round(vector.Y);
-            bytes[startIndex + 2] = (byte)(float)Math.Round(vector.X);
+            bytes[startIndex] = (byte)MathF.Round(vector.Z);
+            bytes[startIndex + 1] = (byte)MathF.Round(vector.Y);
+            bytes[startIndex + 2] = (byte)MathF.Round(vector.X);
         }
 
         /// <inheritdoc />
@@ -180,10 +180,10 @@ namespace ImageSharp
             vector += Round;
             vector = Vector4.Clamp(vector, Vector4.Zero, MaxBytes);
 
-            bytes[startIndex] = (byte)(float)Math.Round(vector.Z);
-            bytes[startIndex + 1] = (byte)(float)Math.Round(vector.Y);
-            bytes[startIndex + 2] = (byte)(float)Math.Round(vector.X);
-            bytes[startIndex + 3] = (byte)(float)Math.Round(vector.W);
+            bytes[startIndex] = (byte)MathF.Round(vector.Z);
+            bytes[startIndex + 1] = (byte)MathF.Round(vector.Y);
+            bytes[startIndex + 2] = (byte)MathF.Round(vector.X);
+            bytes[startIndex + 3] = (byte)MathF.Round(vector.W);
         }
 
         /// <inheritdoc />

--- a/src/ImageSharp/Colors/Spaces/CieLab.cs
+++ b/src/ImageSharp/Colors/Spaces/CieLab.cs
@@ -95,11 +95,11 @@ namespace ImageSharp.Colors.Spaces
             // y /= 1F;
             z /= 1.08883F;
 
-            x = x > 0.008856F ? (float)Math.Pow(x, 0.3333333F) : ((903.3F * x) + 16F) / 116F;
-            y = y > 0.008856F ? (float)Math.Pow(y, 0.3333333F) : ((903.3F * y) + 16F) / 116F;
-            z = z > 0.008856F ? (float)Math.Pow(z, 0.3333333F) : ((903.3F * z) + 16F) / 116F;
+            x = x > 0.008856F ? MathF.Pow(x, 0.3333333F) : ((903.3F * x) + 16F) / 116F;
+            y = y > 0.008856F ? MathF.Pow(y, 0.3333333F) : ((903.3F * y) + 16F) / 116F;
+            z = z > 0.008856F ? MathF.Pow(z, 0.3333333F) : ((903.3F * z) + 16F) / 116F;
 
-            float l = Math.Max(0, (116F * y) - 16F);
+            float l = MathF.Max(0, (116F * y) - 16F);
             float a = 500F * (x - y);
             float b = 200F * (y - z);
 

--- a/src/ImageSharp/Colors/Spaces/Cmyk.cs
+++ b/src/ImageSharp/Colors/Spaces/Cmyk.cs
@@ -93,9 +93,9 @@ namespace ImageSharp.Colors.Spaces
             float m = 1f - (color.G / 255F);
             float y = 1f - (color.B / 255F);
 
-            float k = Math.Min(c, Math.Min(m, y));
+            float k = MathF.Min(c, MathF.Min(m, y));
 
-            if (Math.Abs(k - 1.0f) <= Constants.Epsilon)
+            if (MathF.Abs(k - 1.0f) <= Constants.Epsilon)
             {
                 return new Cmyk(0, 0, 0, 1);
             }

--- a/src/ImageSharp/Colors/Spaces/Hsl.cs
+++ b/src/ImageSharp/Colors/Spaces/Hsl.cs
@@ -83,27 +83,27 @@ namespace ImageSharp.Colors.Spaces
             float g = color.G / 255F;
             float b = color.B / 255F;
 
-            float max = Math.Max(r, Math.Max(g, b));
-            float min = Math.Min(r, Math.Min(g, b));
+            float max = MathF.Max(r, MathF.Max(g, b));
+            float min = MathF.Min(r, MathF.Min(g, b));
             float chroma = max - min;
             float h = 0;
             float s = 0;
             float l = (max + min) / 2;
 
-            if (Math.Abs(chroma) < Constants.Epsilon)
+            if (MathF.Abs(chroma) < Constants.Epsilon)
             {
                 return new Hsl(0, s, l);
             }
 
-            if (Math.Abs(r - max) < Constants.Epsilon)
+            if (MathF.Abs(r - max) < Constants.Epsilon)
             {
                 h = (g - b) / chroma;
             }
-            else if (Math.Abs(g - max) < Constants.Epsilon)
+            else if (MathF.Abs(g - max) < Constants.Epsilon)
             {
                 h = 2 + ((b - r) / chroma);
             }
-            else if (Math.Abs(b - max) < Constants.Epsilon)
+            else if (MathF.Abs(b - max) < Constants.Epsilon)
             {
                 h = 4 + ((r - g) / chroma);
             }

--- a/src/ImageSharp/Colors/Spaces/Hsv.cs
+++ b/src/ImageSharp/Colors/Spaces/Hsv.cs
@@ -83,27 +83,27 @@ namespace ImageSharp.Colors.Spaces
             float g = color.G / 255F;
             float b = color.B / 255F;
 
-            float max = Math.Max(r, Math.Max(g, b));
-            float min = Math.Min(r, Math.Min(g, b));
+            float max = MathF.Max(r, MathF.Max(g, b));
+            float min = MathF.Min(r, MathF.Min(g, b));
             float chroma = max - min;
             float h = 0;
             float s = 0;
             float v = max;
 
-            if (Math.Abs(chroma) < Constants.Epsilon)
+            if (MathF.Abs(chroma) < Constants.Epsilon)
             {
                 return new Hsv(0, s, v);
             }
 
-            if (Math.Abs(r - max) < Constants.Epsilon)
+            if (MathF.Abs(r - max) < Constants.Epsilon)
             {
                 h = (g - b) / chroma;
             }
-            else if (Math.Abs(g - max) < Constants.Epsilon)
+            else if (MathF.Abs(g - max) < Constants.Epsilon)
             {
                 h = 2 + ((b - r) / chroma);
             }
-            else if (Math.Abs(b - max) < Constants.Epsilon)
+            else if (MathF.Abs(b - max) < Constants.Epsilon)
             {
                 h = 4 + ((r - g) / chroma);
             }

--- a/src/ImageSharp/Colors/Vector4BlendTransforms.cs
+++ b/src/ImageSharp/Colors/Vector4BlendTransforms.cs
@@ -5,7 +5,6 @@
 
 namespace ImageSharp
 {
-    using System;
     using System.Numerics;
 
     /// <summary>
@@ -198,13 +197,13 @@ namespace ImageSharp
             amount = amount.Clamp(0, 1);
 
             // Santize on zero alpha
-            if (Math.Abs(backdrop.W) < Constants.Epsilon)
+            if (MathF.Abs(backdrop.W) < Constants.Epsilon)
             {
                 source.W *= amount;
                 return source;
             }
 
-            if (Math.Abs(source.W) < Constants.Epsilon)
+            if (MathF.Abs(source.W) < Constants.Epsilon)
             {
                 return backdrop;
             }
@@ -248,7 +247,7 @@ namespace ImageSharp
         /// </returns>
         private static float BlendSoftLight(float b, float s)
         {
-            return s <= .5F ? ((2F * b * s) + (b * b * (1F - (2F * s)))) : (float)((Math.Sqrt(b) * ((2F * s) - 1F)) + (2F * b * (1F - s)));
+            return s <= .5F ? ((2F * b * s) + (b * b * (1F - (2F * s)))) : (MathF.Sqrt(b) * ((2F * s) - 1F)) + (2F * b * (1F - s));
         }
 
         /// <summary>
@@ -261,7 +260,7 @@ namespace ImageSharp
         /// </returns>
         private static float BlendDodge(float b, float s)
         {
-            return Math.Abs(s - 1F) < Constants.Epsilon ? s : Math.Min(b / (1F - s), 1F);
+            return MathF.Abs(s - 1F) < Constants.Epsilon ? s : MathF.Min(b / (1F - s), 1F);
         }
 
         /// <summary>
@@ -274,7 +273,7 @@ namespace ImageSharp
         /// </returns>
         private static float BlendBurn(float b, float s)
         {
-            return Math.Abs(s) < Constants.Epsilon ? s : Math.Max(1F - ((1F - b) / s), 0F);
+            return MathF.Abs(s) < Constants.Epsilon ? s : MathF.Max(1F - ((1F - b) / s), 0F);
         }
 
         /// <summary>

--- a/src/ImageSharp/Common/Extensions/Vector4Extensions.cs
+++ b/src/ImageSharp/Common/Extensions/Vector4Extensions.cs
@@ -57,7 +57,7 @@ namespace ImageSharp
                 return signal * 12.92F;
             }
 
-            return (1.055F * (float)Math.Pow(signal, 0.41666666F)) - 0.055F;
+            return (1.055F * MathF.Pow(signal, 0.41666666F)) - 0.055F;
         }
 
         /// <summary>
@@ -77,7 +77,7 @@ namespace ImageSharp
                 return signal / 12.92F;
             }
 
-            return (float)Math.Pow((signal + 0.055F) / 1.055F, 2.4F);
+            return MathF.Pow((signal + 0.055F) / 1.055F, 2.4F);
         }
     }
 }

--- a/src/ImageSharp/Common/Helpers/ImageMaths.cs
+++ b/src/ImageSharp/Common/Helpers/ImageMaths.cs
@@ -53,13 +53,13 @@ namespace ImageSharp
         public static float Gaussian(float x, float sigma)
         {
             const float Numerator = 1.0f;
-            float denominator = (float)(Math.Sqrt(2 * Math.PI) * sigma);
+            float denominator = MathF.Sqrt(2 * MathF.PI) * sigma;
 
             float exponentNumerator = -x * x;
             float exponentDenominator = (float)(2 * Math.Pow(sigma, 2));
 
             float left = Numerator / denominator;
-            float right = (float)Math.Exp(exponentNumerator / exponentDenominator);
+            float right = MathF.Exp(exponentNumerator / exponentDenominator);
 
             return left * right;
         }
@@ -110,10 +110,10 @@ namespace ImageSharp
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static float SinC(float x)
         {
-            if (Math.Abs(x) > Constants.Epsilon)
+            if (MathF.Abs(x) > Constants.Epsilon)
             {
-                x *= (float)Math.PI;
-                return Clean((float)Math.Sin(x) / x);
+                x *= MathF.PI;
+                return Clean(MathF.Sin(x) / x);
             }
 
             return 1.0f;
@@ -129,7 +129,7 @@ namespace ImageSharp
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static float DegreesToRadians(float degrees)
         {
-            return degrees * (float)(Math.PI / 180);
+            return degrees * (MathF.PI / 180);
         }
 
         /// <summary>
@@ -196,19 +196,19 @@ namespace ImageSharp
             switch (channel)
             {
                 case RgbaComponent.R:
-                    delegateFunc = (pixels, x, y, b) => Math.Abs(pixels[x, y].ToVector4().X - b) > Constants.Epsilon;
+                    delegateFunc = (pixels, x, y, b) => MathF.Abs(pixels[x, y].ToVector4().X - b) > Constants.Epsilon;
                     break;
 
                 case RgbaComponent.G:
-                    delegateFunc = (pixels, x, y, b) => Math.Abs(pixels[x, y].ToVector4().Y - b) > Constants.Epsilon;
+                    delegateFunc = (pixels, x, y, b) => MathF.Abs(pixels[x, y].ToVector4().Y - b) > Constants.Epsilon;
                     break;
 
                 case RgbaComponent.B:
-                    delegateFunc = (pixels, x, y, b) => Math.Abs(pixels[x, y].ToVector4().Z - b) > Constants.Epsilon;
+                    delegateFunc = (pixels, x, y, b) => MathF.Abs(pixels[x, y].ToVector4().Z - b) > Constants.Epsilon;
                     break;
 
                 default:
-                    delegateFunc = (pixels, x, y, b) => Math.Abs(pixels[x, y].ToVector4().W - b) > Constants.Epsilon;
+                    delegateFunc = (pixels, x, y, b) => MathF.Abs(pixels[x, y].ToVector4().W - b) > Constants.Epsilon;
                     break;
             }
 
@@ -297,7 +297,7 @@ namespace ImageSharp
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static float Clean(float x)
         {
-            if (Math.Abs(x) < Constants.Epsilon)
+            if (MathF.Abs(x) < Constants.Epsilon)
             {
                 return 0F;
             }

--- a/src/ImageSharp/Common/Helpers/MathF.cs
+++ b/src/ImageSharp/Common/Helpers/MathF.cs
@@ -1,0 +1,144 @@
+﻿// <copyright file="MathF.cs" company="James Jackson-South">
+// Copyright (c) James Jackson-South and contributors.
+// Licensed under the Apache License, Version 2.0.
+// </copyright>
+
+namespace ImageSharp
+{
+    using System;
+    using System.Runtime.CompilerServices;
+
+    /// <summary>
+    /// Provides single-precision floating point constants and static methods for trigonometric, logarithmic, and other common mathematical functions.
+    /// </summary>
+    // ReSharper disable InconsistentNaming
+    internal static class MathF
+    {
+        /// <summary>
+        /// Represents the ratio of the circumference of a circle to its diameter, specified by the constant, π.
+        /// </summary>
+        public const float PI = (float)Math.PI;
+
+        /// <summary>Returns the absolute value of a single-precision floating-point number.</summary>
+        /// <param name="f">A number that is greater than or equal to <see cref="F:System.Single.MinValue" />, but less than or equal to <see cref="F:System.Single.MaxValue" />.</param>
+        /// <returns>A single-precision floating-point number, x, such that 0 ≤ x ≤<see cref="F:System.Single.MaxValue" />.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float Abs(float f)
+        {
+            return Math.Abs(f);
+        }
+
+        /// <summary>Returns the smallest integral value that is greater than or equal to the specified single-precision floating-point number.</summary>
+        /// <param name="f">A single-precision floating-point number. </param>
+        /// <returns>The smallest integral value that is greater than or equal to <paramref name="f" />.
+        /// If <paramref name="f" /> is equal to <see cref="F:System.Single.NaN" />, <see cref="F:System.Single.NegativeInfinity" />,
+        /// or <see cref="F:System.Single.PositiveInfinity" />, that value is returned.
+        /// Note that this method returns a <see cref="T:System.Single" /> instead of an integral type.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float Ceiling(float f)
+        {
+            return (float)Math.Ceiling(f);
+        }
+
+        /// <summary>Returns e raised to the specified power.</summary>
+        /// <param name="f">A number specifying a power.</param>
+        /// <returns>
+        /// The number e raised to the power <paramref name="f" />.
+        /// If <paramref name="f" /> equals <see cref="F:System.Single.NaN" /> or <see cref="F:System.Single.PositiveInfinity" />, that value is returned.
+        /// If <paramref name="f" /> equals <see cref="F:System.Single.NegativeInfinity" />, 0 is returned.
+        /// </returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float Exp(float f)
+        {
+            return (float)Math.Exp(f);
+        }
+
+        /// <summary>Returns the largest integer less than or equal to the specified single-precision floating-point number.</summary>
+        /// <param name="f">A single-precision floating-point number. </param>
+        /// <returns>The largest integer less than or equal to <paramref name="f" />.
+        /// If <paramref name="f" /> is equal to <see cref="F:System.Single.NaN" />, <see cref="F:System.Single.NegativeInfinity" />,
+        /// or <see cref="F:System.Single.PositiveInfinity" />, that value is returned.
+        /// </returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float Floor(float f)
+        {
+            return (float)Math.Floor(f);
+        }
+
+        /// <summary>Returns the larger of two single-precision floating-point numbers.</summary>
+        /// <param name="val1">The first of two single-precision floating-point numbers to compare. </param>
+        /// <param name="val2">The second of two single-precision floating-point numbers to compare. </param>
+        /// <returns>Parameter <paramref name="val1" /> or <paramref name="val2" />, whichever is larger.
+        /// If <paramref name="val1" />, or <paramref name="val2" />, or both <paramref name="val1" /> and <paramref name="val2" /> are
+        /// equal to <see cref="F:System.Single.NaN" />, <see cref="F:System.Single.NaN" /> is returned.
+        /// </returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float Max(float val1, float val2)
+        {
+            return Math.Max(val1, val2);
+        }
+
+        /// <summary>Returns the smaller of two single-precision floating-point numbers.</summary>
+        /// <param name="val1">The first of two single-precision floating-point numbers to compare. </param>
+        /// <param name="val2">The second of two single-precision floating-point numbers to compare. </param>
+        /// <returns>Parameter <paramref name="val1" /> or <paramref name="val2" />, whichever is smaller.
+        /// If <paramref name="val1" />, <paramref name="val2" />, or both <paramref name="val1" /> and <paramref name="val2" /> are equal
+        /// to <see cref="F:System.Single.NaN" />, <see cref="F:System.Single.NaN" /> is returned.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float Min(float val1, float val2)
+        {
+            return Math.Min(val1, val2);
+        }
+
+        /// <summary>Returns a specified number raised to the specified power.</summary>
+        /// <param name="x">A single-precision floating-point number to be raised to a power. </param>
+        /// <param name="y">A single-precision floating-point number that specifies a power. </param>
+        /// <returns>The number <paramref name="x" /> raised to the power <paramref name="y" />.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float Pow(float x, float y)
+        {
+            return (float)Math.Pow(x, y);
+        }
+
+        /// <summary>Rounds a single-precision floating-point value to the nearest integral value.</summary>
+        /// <param name="f">A single-precision floating-point number to be rounded. </param>
+        /// <returns>
+        /// The integer nearest <paramref name="f" />.
+        /// If the fractional component of <paramref name="f" /> is halfway between two integers, one of which is even and the other odd, then the even number is returned.
+        /// Note that this method returns a <see cref="T:System.Single" /> instead of an integral type.
+        /// </returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float Round(float f)
+        {
+            return (float)Math.Round(f);
+        }
+
+        /// <summary>Returns the sine of the specified angle.</summary>
+        /// <param name="f">An angle, measured in radians. </param>
+        /// <returns>
+        /// The sine of <paramref name="f" />.
+        /// If <paramref name="f" /> is equal to <see cref="F:System.Single.NaN" />, <see cref="F:System.Single.NegativeInfinity" />,
+        /// or <see cref="F:System.Single.PositiveInfinity" />, this method returns <see cref="F:System.Single.NaN" />.
+        /// </returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float Sin(float f)
+        {
+            return (float)Math.Sin(f);
+        }
+
+        /// <summary>Returns the square root of a specified number.</summary>
+        /// <param name="f">The number whose square root is to be found. </param>
+        /// <returns>
+        /// One of the values in the following table.
+        /// <paramref name="f" /> parameter Return value Zero or positive The positive square root of <paramref name="f" />.
+        /// Negative <see cref="F:System.Single.NaN" />Equals <see cref="F:System.Single.NaN" />
+        /// <see cref="F:System.Single.NaN" />Equals <see cref="F:System.Single.PositiveInfinity" />
+        /// <see cref="F:System.Single.PositiveInfinity" />
+        /// </returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float Sqrt(float f)
+        {
+            return (float)Math.Sqrt(f);
+        }
+    }
+}

--- a/src/ImageSharp/Processing/Processors/Convolution/Convolution2DProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/Convolution2DProcessor.cs
@@ -108,9 +108,9 @@ namespace ImageSharp.Processing.Processors
                                 }
                             }
 
-                            float red = (float)Math.Sqrt((rX * rX) + (rY * rY));
-                            float green = (float)Math.Sqrt((gX * gX) + (gY * gY));
-                            float blue = (float)Math.Sqrt((bX * bX) + (bY * bY));
+                            float red = MathF.Sqrt((rX * rX) + (rY * rY));
+                            float green = MathF.Sqrt((gX * gX) + (gY * gY));
+                            float blue = MathF.Sqrt((bX * bX) + (bY * bY));
 
                             TColor packed = default(TColor);
                             packed.PackFromVector4(new Vector4(red, green, blue, sourcePixels[x, y].ToVector4().W));

--- a/src/ImageSharp/Processing/Processors/Effects/BackgroundColorProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Effects/BackgroundColorProcessor.cs
@@ -77,7 +77,7 @@ namespace ImageSharp.Processing.Processors
                                 color = Vector4BlendTransforms.PremultipliedLerp(backgroundColor, color, .5F);
                             }
 
-                            if (Math.Abs(a) < Constants.Epsilon)
+                            if (MathF.Abs(a) < Constants.Epsilon)
                             {
                                 color = backgroundColor;
                             }

--- a/src/ImageSharp/Processing/Processors/Effects/OilPaintingProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Effects/OilPaintingProcessor.cs
@@ -139,9 +139,9 @@ namespace ImageSharp.Processing.Processors
                                         }
                                     }
 
-                                    float red = Math.Abs(redBin[maxIndex] / maxIntensity);
-                                    float green = Math.Abs(greenBin[maxIndex] / maxIntensity);
-                                    float blue = Math.Abs(blueBin[maxIndex] / maxIntensity);
+                                    float red = MathF.Abs(redBin[maxIndex] / maxIntensity);
+                                    float green = MathF.Abs(greenBin[maxIndex] / maxIntensity);
+                                    float blue = MathF.Abs(blueBin[maxIndex] / maxIntensity);
 
                                     TColor packed = default(TColor);
                                     packed.PackFromVector4(new Vector4(red, green, blue, sourcePixels[x, y].ToVector4().W));

--- a/src/ImageSharp/Processing/Processors/Overlays/GlowProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Overlays/GlowProcessor.cs
@@ -44,7 +44,7 @@ namespace ImageSharp.Processing.Processors
             int endX = sourceRectangle.Right;
             TColor glowColor = this.GlowColor;
             Vector2 centre = Rectangle.Center(sourceRectangle).ToVector2();
-            float maxDistance = this.Radius > 0 ? Math.Min(this.Radius, sourceRectangle.Width * .5F) : sourceRectangle.Width * .5F;
+            float maxDistance = this.Radius > 0 ? MathF.Min(this.Radius, sourceRectangle.Width * .5F) : sourceRectangle.Width * .5F;
 
             // Align start/end positions.
             int minX = Math.Max(0, startX);

--- a/src/ImageSharp/Processing/Processors/Overlays/VignetteProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Overlays/VignetteProcessor.cs
@@ -49,9 +49,9 @@ namespace ImageSharp.Processing.Processors
             int endX = sourceRectangle.Right;
             TColor vignetteColor = this.VignetteColor;
             Vector2 centre = Rectangle.Center(sourceRectangle).ToVector2();
-            float rX = this.RadiusX > 0 ? Math.Min(this.RadiusX, sourceRectangle.Width * .5F) : sourceRectangle.Width * .5F;
-            float rY = this.RadiusY > 0 ? Math.Min(this.RadiusY, sourceRectangle.Height * .5F) : sourceRectangle.Height * .5F;
-            float maxDistance = (float)Math.Sqrt((rX * rX) + (rY * rY));
+            float rX = this.RadiusX > 0 ? MathF.Min(this.RadiusX, sourceRectangle.Width * .5F) : sourceRectangle.Width * .5F;
+            float rY = this.RadiusY > 0 ? MathF.Min(this.RadiusY, sourceRectangle.Height * .5F) : sourceRectangle.Height * .5F;
+            float maxDistance = MathF.Sqrt((rX * rX) + (rY * rY));
 
             // Align start/end positions.
             int minX = Math.Max(0, startX);

--- a/src/ImageSharp/Processing/Processors/Transforms/ResamplingWeightedProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/ResamplingWeightedProcessor.cs
@@ -86,7 +86,7 @@ namespace ImageSharp.Processing.Processors
             }
 
             IResampler sampler = this.Sampler;
-            float radius = (float)Math.Ceiling(scale * sampler.Radius);
+            float radius = MathF.Ceiling(scale * sampler.Radius);
             WeightsBuffer result = new WeightsBuffer(sourceSize, destinationSize);
 
             for (int i = 0; i < destinationSize; i++)

--- a/src/ImageSharp/Processing/Processors/Transforms/RotateProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/RotateProcessor.cs
@@ -71,7 +71,7 @@ namespace ImageSharp.Processing.Processors
         /// <inheritdoc/>
         protected override void BeforeApply(ImageBase<TColor> source, Rectangle sourceRectangle)
         {
-            if (Math.Abs(this.Angle) < Constants.Epsilon || Math.Abs(this.Angle - 90) < Constants.Epsilon || Math.Abs(this.Angle - 180) < Constants.Epsilon || Math.Abs(this.Angle - 270) < Constants.Epsilon)
+            if (MathF.Abs(this.Angle) < Constants.Epsilon || MathF.Abs(this.Angle - 90) < Constants.Epsilon || MathF.Abs(this.Angle - 180) < Constants.Epsilon || MathF.Abs(this.Angle - 270) < Constants.Epsilon)
             {
                 return;
             }
@@ -90,25 +90,25 @@ namespace ImageSharp.Processing.Processors
         /// <returns>The <see cref="bool"/></returns>
         private bool OptimizedApply(ImageBase<TColor> source)
         {
-            if (Math.Abs(this.Angle) < Constants.Epsilon)
+            if (MathF.Abs(this.Angle) < Constants.Epsilon)
             {
                 // No need to do anything so return.
                 return true;
             }
 
-            if (Math.Abs(this.Angle - 90) < Constants.Epsilon)
+            if (MathF.Abs(this.Angle - 90) < Constants.Epsilon)
             {
                 this.Rotate90(source);
                 return true;
             }
 
-            if (Math.Abs(this.Angle - 180) < Constants.Epsilon)
+            if (MathF.Abs(this.Angle - 180) < Constants.Epsilon)
             {
                 this.Rotate180(source);
                 return true;
             }
 
-            if (Math.Abs(this.Angle - 270) < Constants.Epsilon)
+            if (MathF.Abs(this.Angle - 270) < Constants.Epsilon)
             {
                 this.Rotate270(source);
                 return true;

--- a/src/ImageSharp/Processing/Transforms/Options/ResizeHelper.cs
+++ b/src/ImageSharp/Processing/Transforms/Options/ResizeHelper.cs
@@ -65,7 +65,7 @@ namespace ImageSharp.Processing
                 return new Rectangle(0, 0, source.Width, source.Height);
             }
 
-            double ratio;
+            float ratio;
             int sourceWidth = source.Width;
             int sourceHeight = source.Height;
 
@@ -75,8 +75,8 @@ namespace ImageSharp.Processing
             int destinationHeight = height;
 
             // Fractional variants for preserving aspect ratio.
-            double percentHeight = Math.Abs(height / (double)sourceHeight);
-            double percentWidth = Math.Abs(width / (double)sourceWidth);
+            float percentHeight = MathF.Abs(height / (float)sourceHeight);
+            float percentWidth = MathF.Abs(width / (float)sourceWidth);
 
             if (percentHeight < percentWidth)
             {
@@ -84,7 +84,7 @@ namespace ImageSharp.Processing
 
                 if (options.CenterCoordinates.Any())
                 {
-                    double center = -(ratio * sourceHeight) * options.CenterCoordinates.First();
+                    float center = -(ratio * sourceHeight) * options.CenterCoordinates.First();
                     destinationY = (int)center + (height / 2);
 
                     if (destinationY > 0)
@@ -117,7 +117,7 @@ namespace ImageSharp.Processing
                     }
                 }
 
-                destinationHeight = (int)Math.Ceiling(sourceHeight * percentWidth);
+                destinationHeight = (int)MathF.Ceiling(sourceHeight * percentWidth);
             }
             else
             {
@@ -125,7 +125,7 @@ namespace ImageSharp.Processing
 
                 if (options.CenterCoordinates.Any())
                 {
-                    double center = -(ratio * sourceWidth) * options.CenterCoordinates.ToArray()[1];
+                    float center = -(ratio * sourceWidth) * options.CenterCoordinates.ToArray()[1];
                     destinationX = (int)center + (width / 2);
 
                     if (destinationX > 0)
@@ -158,7 +158,7 @@ namespace ImageSharp.Processing
                     }
                 }
 
-                destinationWidth = (int)Math.Ceiling(sourceWidth * percentHeight);
+                destinationWidth = (int)MathF.Ceiling(sourceWidth * percentHeight);
             }
 
             return new Rectangle(destinationX, destinationY, destinationWidth, destinationHeight);
@@ -184,7 +184,7 @@ namespace ImageSharp.Processing
                 return new Rectangle(0, 0, source.Width, source.Height);
             }
 
-            double ratio;
+            float ratio;
             int sourceWidth = source.Width;
             int sourceHeight = source.Height;
 
@@ -194,8 +194,8 @@ namespace ImageSharp.Processing
             int destinationHeight = height;
 
             // Fractional variants for preserving aspect ratio.
-            double percentHeight = Math.Abs(height / (double)sourceHeight);
-            double percentWidth = Math.Abs(width / (double)sourceWidth);
+            float percentHeight = MathF.Abs(height / (float)sourceHeight);
+            float percentWidth = MathF.Abs(width / (float)sourceWidth);
 
             if (percentHeight < percentWidth)
             {
@@ -269,8 +269,8 @@ namespace ImageSharp.Processing
             int sourceHeight = source.Height;
 
             // Fractional variants for preserving aspect ratio.
-            double percentHeight = Math.Abs(height / (double)sourceHeight);
-            double percentWidth = Math.Abs(width / (double)sourceWidth);
+            float percentHeight = MathF.Abs(height / (float)sourceHeight);
+            float percentWidth = MathF.Abs(width / (float)sourceWidth);
 
             int boxPadHeight = height > 0 ? height : Convert.ToInt32(sourceHeight * percentWidth);
             int boxPadWidth = width > 0 ? width : Convert.ToInt32(sourceWidth * percentHeight);
@@ -350,12 +350,12 @@ namespace ImageSharp.Processing
             int destinationHeight = height;
 
             // Fractional variants for preserving aspect ratio.
-            double percentHeight = Math.Abs(height / (double)source.Height);
-            double percentWidth = Math.Abs(width / (double)source.Width);
+            float percentHeight = MathF.Abs(height / (float)source.Height);
+            float percentWidth = MathF.Abs(width / (float)source.Width);
 
-            // Integers must be cast to doubles to get needed precision
-            double ratio = (double)options.Size.Height / options.Size.Width;
-            double sourceRatio = (double)source.Height / source.Width;
+            // Integers must be cast to floats to get needed precision
+            float ratio = (float)options.Size.Height / options.Size.Width;
+            float sourceRatio = (float)source.Height / source.Width;
 
             if (sourceRatio < ratio)
             {
@@ -397,7 +397,7 @@ namespace ImageSharp.Processing
                 return new Rectangle(0, 0, source.Width, source.Height);
             }
 
-            double sourceRatio = (double)source.Height / source.Width;
+            float sourceRatio = (float)source.Height / source.Width;
 
             // Find the shortest distance to go.
             int widthDiff = source.Width - width;

--- a/src/ImageSharp/Quantizers/Octree/Quantizer.cs
+++ b/src/ImageSharp/Quantizers/Octree/Quantizer.cs
@@ -171,7 +171,7 @@ namespace ImageSharp.Quantizers
                 leastDistance = distance;
 
                 // And if it's an exact match, exit the loop
-                if (Math.Abs(distance) < Constants.Epsilon)
+                if (MathF.Abs(distance) < Constants.Epsilon)
                 {
                     break;
                 }

--- a/tests/ImageSharp.Tests/Helpers/MathFTests.cs
+++ b/tests/ImageSharp.Tests/Helpers/MathFTests.cs
@@ -1,0 +1,69 @@
+﻿namespace ImageSharp.Tests.Helpers
+{
+    using System;
+
+    using Xunit;
+
+    public class MathFTests
+    {
+        [Fact]
+        public void MathF_PI_Is_Equal()
+        {
+            Assert.Equal(MathF.PI, (float)Math.PI);
+        }
+
+        [Fact]
+        public void MathF_Ceililng_Is_Equal()
+        {
+            Assert.Equal(MathF.Ceiling(0.3333F), (float)Math.Ceiling(0.3333F));
+        }
+
+        [Fact]
+        public void MathF_Abs_Is_Equal()
+        {
+            Assert.Equal(MathF.Abs(-0.3333F), (float)Math.Abs(-0.3333F));
+        }
+
+        [Fact]
+        public void MathF_Exp_Is_Equal()
+        {
+            Assert.Equal(MathF.Exp(1.2345F), (float)Math.Exp(1.2345F));
+        }
+
+        [Fact]
+        public void MathF_Floor_Is_Equal()
+        {
+            Assert.Equal(MathF.Floor(1.2345F), (float)Math.Floor(1.2345F));
+        }
+
+        [Fact]
+        public void MathF_Min_Is_Equal()
+        {
+            Assert.Equal(MathF.Min(1.2345F, 5.4321F), (float)Math.Min(1.2345F, 5.4321F));
+        }
+
+        [Fact]
+        public void MathF_Max_Is_Equal()
+        {
+            Assert.Equal(MathF.Max(1.2345F, 5.4321F), (float)Math.Max(1.2345F, 5.4321F));
+        }
+
+        [Fact]
+        public void MathF_Pow_Is_Equal()
+        {
+            Assert.Equal(MathF.Pow(1.2345F, 5.4321F), (float)Math.Pow(1.2345F, 5.4321F));
+        }
+
+        [Fact]
+        public void MathF_Sin_Is_Equal()
+        {
+            Assert.Equal(MathF.Sin(1.2345F), (float)Math.Sin(1.2345F));
+        }
+
+        [Fact]
+        public void MathF_Sqrt_Is_Equal()
+        {
+            Assert.Equal(MathF.Sqrt(2F), (float)Math.Sqrt(2F));
+        }
+    }
+}


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/JimBobSquarePants/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practise as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
This update updates all existing code that used floating point `System.Math` methods to use our own internal `MathF` class. This reduces the noise in the codebase, makes intent more obvious and improves testability of the libraries.

I've aggressively inlined each method so there should be no slowdown.

I can add extra tests for the new class but I think the increased coverage from it's use should probably be enough.

<!-- Thanks for contributing to ImageSharp! -->
