### PR TITLE
Fix for off by one for indexed pngs

### DIFF
--- a/src/ImageSharp/Formats/Png/PngDecoderCore.cs
+++ b/src/ImageSharp/Formats/Png/PngDecoderCore.cs
@@ -579,7 +579,7 @@ namespace ImageSharp.Formats
                         // channel and we should try to read it.
                         for (int x = 0; x < this.header.Width; x++)
                         {
-                            int index = newScanline[x];
+                            int index = newScanline[x + 1];
                             int pixelOffset = index * 3;
 
                             byte a = this.paletteAlpha.Length > index ? this.paletteAlpha[index] : (byte)255;
@@ -603,7 +603,7 @@ namespace ImageSharp.Formats
                     {
                         for (int x = 0; x < this.header.Width; x++)
                         {
-                            int index = newScanline[x];
+                            int index = newScanline[x + 1];
                             int pixelOffset = index * 3;
 
                             byte r = this.palette[pixelOffset];


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/JimBobSquarePants/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practise as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
Fixes #166 meaning that index pngs offset the first pixel of each row and fill that value with what ever color is in index 0 of the palette.

I think this is correct based on the fact we always add an extra byte to the scanline and when we encode the bytes with skip the first index.

See https://github.com/JimBobSquarePants/ImageSharp/blob/7d348667d6341e6a770e607cae94ff68df0176bc/src/ImageSharp/Formats/Png/Filters/NoneFilter.cs#L40
and https://github.com/JimBobSquarePants/ImageSharp/blob/7d348667d6341e6a770e607cae94ff68df0176bc/src/ImageSharp/Formats/Png/PngDecoderCore.cs#L350


_**DISCLAIMER** I don't know enough about the png format to know which side is correct should the first item be skipped or is it a bug in the encoder putting writing the scanline at the wrong location._



