### PR TITLE
Fix alpha channel generation for indexed PNGs

### DIFF
--- a/src/ImageSharp/Formats/Png/IPngEncoderOptions.cs
+++ b/src/ImageSharp/Formats/Png/IPngEncoderOptions.cs
@@ -41,11 +41,6 @@ namespace ImageSharp.Formats
         IQuantizer Quantizer { get; }
 
         /// <summary>
-        /// Gets the transparency threshold.
-        /// </summary>
-        byte Threshold { get; }
-
-        /// <summary>
         /// Gets a value indicating whether this instance should write
         /// gamma information to the stream.
         /// </summary>

--- a/src/ImageSharp/Formats/Png/IPngEncoderOptions.cs
+++ b/src/ImageSharp/Formats/Png/IPngEncoderOptions.cs
@@ -41,6 +41,11 @@ namespace ImageSharp.Formats
         IQuantizer Quantizer { get; }
 
         /// <summary>
+        /// Gets the transparency threshold.
+        /// </summary>
+        byte Threshold { get; }
+
+        /// <summary>
         /// Gets a value indicating whether this instance should write
         /// gamma information to the stream.
         /// </summary>

--- a/src/ImageSharp/Formats/Png/PngEncoderCore.cs
+++ b/src/ImageSharp/Formats/Png/PngEncoderCore.cs
@@ -495,7 +495,7 @@ namespace ImageSharp.Formats
 
             // Grab the palette and write it to the stream.
             TColor[] palette = quantized.Palette;
-            byte pixelCount = (byte)palette.Length;
+            byte pixelCount = palette.Length.ToByte();
 
             // Get max colors for bit depth.
             int colorTableLength = (int)Math.Pow(2, header.BitDepth) * 3;
@@ -517,6 +517,11 @@ namespace ImageSharp.Formats
                         colorTable[offset] = bytes[0];
                         colorTable[offset + 1] = bytes[1];
                         colorTable[offset + 2] = bytes[2];
+
+                        if (alpha > this.options.Threshold)
+                        {
+                            alpha = 255;
+                        }
 
                         anyAlpha = anyAlpha || alpha < 255;
                         alphaTable[i] = alpha;

--- a/src/ImageSharp/Formats/Png/PngEncoderCore.cs
+++ b/src/ImageSharp/Formats/Png/PngEncoderCore.cs
@@ -529,17 +529,18 @@ namespace ImageSharp.Formats
                 }
 
                 this.WriteChunk(stream, PngChunkTypes.Palette, colorTable, 0, colorTableLength);
+
+                // Write the transparency data
+                if (anyAlpha)
+                {
+                    this.WriteChunk(stream, PngChunkTypes.PaletteAlpha, alphaTable, 0, pixelCount);
+                }
             }
             finally
             {
                 ArrayPool<byte>.Shared.Return(colorTable);
+                ArrayPool<byte>.Shared.Return(alphaTable);
                 ArrayPool<byte>.Shared.Return(bytes);
-            }
-
-            // Write the transparency data
-            if (anyAlpha)
-            {
-                this.WriteChunk(stream, PngChunkTypes.PaletteAlpha, alphaTable, 0, pixelCount);
             }
 
             return quantized;

--- a/src/ImageSharp/Formats/Png/PngEncoderCore.cs
+++ b/src/ImageSharp/Formats/Png/PngEncoderCore.cs
@@ -495,35 +495,31 @@ namespace ImageSharp.Formats
 
             // Grab the palette and write it to the stream.
             TColor[] palette = quantized.Palette;
-            int pixelCount = palette.Length;
-            List<byte> transparentPixels = new List<byte>();
+            byte pixelCount = (byte)palette.Length;
 
             // Get max colors for bit depth.
             int colorTableLength = (int)Math.Pow(2, header.BitDepth) * 3;
             byte[] colorTable = ArrayPool<byte>.Shared.Rent(colorTableLength);
+            byte[] alphaTable = ArrayPool<byte>.Shared.Rent(pixelCount);
             byte[] bytes = ArrayPool<byte>.Shared.Rent(4);
-
+            bool anyAlpha = false;
             try
             {
-                for (int i = 0; i < pixelCount; i++)
+                for (byte i = 0; i < pixelCount; i++)
                 {
-                    int offset = i * 3;
-                    palette[i].ToXyzwBytes(bytes, 0);
-
-                    int alpha = bytes[3];
-
-                    colorTable[offset] = bytes[0];
-                    colorTable[offset + 1] = bytes[1];
-                    colorTable[offset + 2] = bytes[2];
-
-                    if (alpha < 255 && alpha <= this.options.Threshold)
+                    if (quantized.Pixels.Contains(i))
                     {
-                        // Ensure the index is actually being used in our array.
-                        // I'd like to find a faster way of doing this.
-                        if (quantized.Pixels.Contains((byte)i))
-                        {
-                            transparentPixels.Add((byte)i);
-                        }
+                        int offset = i * 3;
+                        palette[i].ToXyzwBytes(bytes, 0);
+
+                        byte alpha = bytes[3];
+
+                        colorTable[offset] = bytes[0];
+                        colorTable[offset + 1] = bytes[1];
+                        colorTable[offset + 2] = bytes[2];
+
+                        anyAlpha = anyAlpha || alpha < 255;
+                        alphaTable[i] = alpha;
                     }
                 }
 
@@ -536,9 +532,9 @@ namespace ImageSharp.Formats
             }
 
             // Write the transparency data
-            if (transparentPixels.Any())
+            if (anyAlpha)
             {
-                this.WriteChunk(stream, PngChunkTypes.PaletteAlpha, transparentPixels.ToArray());
+                this.WriteChunk(stream, PngChunkTypes.PaletteAlpha, alphaTable, 0, pixelCount);
             }
 
             return quantized;

--- a/src/ImageSharp/Formats/Png/PngEncoderOptions.cs
+++ b/src/ImageSharp/Formats/Png/PngEncoderOptions.cs
@@ -58,6 +58,11 @@ namespace ImageSharp.Formats
         public IQuantizer Quantizer { get; set; }
 
         /// <summary>
+        /// Gets or sets the transparency threshold.
+        /// </summary>
+        public byte Threshold { get; set; } = 255;
+
+        /// <summary>
         /// Gets or sets a value indicating whether this instance should write
         /// gamma information to the stream. The default value is false.
         /// </summary>

--- a/src/ImageSharp/Formats/Png/PngEncoderOptions.cs
+++ b/src/ImageSharp/Formats/Png/PngEncoderOptions.cs
@@ -58,11 +58,6 @@ namespace ImageSharp.Formats
         public IQuantizer Quantizer { get; set; }
 
         /// <summary>
-        /// Gets or sets the transparency threshold.
-        /// </summary>
-        public byte Threshold { get; set; } = 0;
-
-        /// <summary>
         /// Gets or sets a value indicating whether this instance should write
         /// gamma information to the stream. The default value is false.
         /// </summary>

--- a/tests/ImageSharp.Tests/Formats/Png/PngSmokeTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Png/PngSmokeTests.cs
@@ -59,6 +59,46 @@ namespace ImageSharp.Tests.Formats.Png
         }
 
         [Theory]
+        [WithTestPatternImages(100, 100, PixelTypes.Color)]
+        public void CanSaveIndexedPngTwice<TColor>(TestImageProvider<TColor> provider)
+            where TColor : struct, IPixel<TColor>
+        {
+            // does saving a file then repoening mean both files are identical???
+            using (Image<TColor> source = provider.GetImage())
+            using (MemoryStream ms = new MemoryStream())
+            {
+                // image.Save(provider.Utility.GetTestOutputFileName("bmp"));
+                source.MetaData.Quality = 256;
+                source.Save(ms, new PngEncoder());
+                ms.Position = 0;
+                using (Image img1 = Image.Load(ms, new PngDecoder()))
+                {
+                    using (MemoryStream ms2 = new MemoryStream())
+                    {
+                        img1.Save(ms2, new PngEncoder());
+                        ms2.Position = 0;
+                        using (Image img2 = Image.Load(ms2, new PngDecoder()))
+                        {
+                            using (PixelAccessor<Color> pixels1 = img1.Lock())
+                            using (PixelAccessor<Color> pixels2 = img2.Lock())
+                            {
+                                for (int y = 0; y < img1.Height; y++)
+                                {
+                                    for (int x = 0; x < img1.Width; x++)
+                                    {
+                                        Assert.Equal(pixels1[x, y], pixels2[x, y]);
+                                    }
+                                }
+                            }
+                            // img2.Save(provider.Utility.GetTestOutputFileName("bmp", "_loaded"), new BmpEncoder());
+                            ImageComparer.CheckSimilarity(source, img2);
+                        }
+                    }
+                }
+            }
+        }
+
+        [Theory]
         [WithTestPatternImages(300, 300, PixelTypes.All)]
         public void Resize<TColor>(TestImageProvider<TColor> provider)
             where TColor : struct, IPixel<TColor>

--- a/tests/ImageSharp.Tests/Formats/Png/PngSmokeTests.cs
+++ b/tests/ImageSharp.Tests/Formats/Png/PngSmokeTests.cs
@@ -13,6 +13,7 @@ namespace ImageSharp.Tests.Formats.Png
     using ImageSharp.Formats;
     using System.Linq;
     using ImageSharp.IO;
+    using System.Numerics;
 
     public class PngSmokeTests
     {
@@ -67,15 +68,19 @@ namespace ImageSharp.Tests.Formats.Png
             using (Image<TColor> source = provider.GetImage())
             using (MemoryStream ms = new MemoryStream())
             {
-                // image.Save(provider.Utility.GetTestOutputFileName("bmp"));
                 source.MetaData.Quality = 256;
-                source.Save(ms, new PngEncoder());
+                source.Save(ms, new PngEncoder(), new PngEncoderOptions {
+                    Threshold = 200
+                });
                 ms.Position = 0;
                 using (Image img1 = Image.Load(ms, new PngDecoder()))
                 {
                     using (MemoryStream ms2 = new MemoryStream())
                     {
-                        img1.Save(ms2, new PngEncoder());
+                        img1.Save(ms2, new PngEncoder(), new PngEncoderOptions
+                        {
+                            Threshold = 200
+                        });
                         ms2.Position = 0;
                         using (Image img2 = Image.Load(ms2, new PngDecoder()))
                         {
@@ -90,8 +95,6 @@ namespace ImageSharp.Tests.Formats.Png
                                     }
                                 }
                             }
-                            // img2.Save(provider.Utility.GetTestOutputFileName("bmp", "_loaded"), new BmpEncoder());
-                            ImageComparer.CheckSimilarity(source, img2);
                         }
                     }
                 }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/JimBobSquarePants/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practise as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description

Fixes how we generate the alpha channel for Indexed PNGs.

Based on info from [the W3C png spec](https://www.w3.org/TR/PNG/#11transinfo) the alpha channel should have an entry per index entry (if any alpha required).

This leaves me with the understanding that a `Threshold` amount doesn't make much sense but left it in for now but changed its default so it retains the entire set of values.

### Observations

Applying this fix makes me notice 2 things;
1. The OctreeQuantizer seems to introduce some odd difference in the alpha values of the indexed 
pixels.
2. The OctreeQuantizer will produce compound errors between encodings even if the the number of different colors in the image is already below the threshold. i.e. encode indexed, decode, and with no changes encode as indexed again does not produce exactly the same pixel data. 

### Related Issues
Fixes #170