### PR TITLE
Performance improvements for PNG Decoding

### DIFF
--- a/src/ImageSharp/Formats/Png/PngDecoderCore.cs
+++ b/src/ImageSharp/Formats/Png/PngDecoderCore.cs
@@ -657,17 +657,7 @@ namespace ImageSharp.Formats
 
                 case PngColorType.Rgb:
 
-                    for (int x = 0; x < this.header.Width; x++)
-                    {
-                        int offset = 1 + (x * this.bytesPerPixel);
-
-                        byte r = defilteredScanline[offset];
-                        byte g = defilteredScanline[offset + this.bytesPerSample];
-                        byte b = defilteredScanline[offset + (2 * this.bytesPerSample)];
-
-                        color.PackFromBytes(r, g, b, 255);
-                        pixels[x, this.currentRow] = color;
-                    }
+                    BulkPixelOperations<TPixel>.Instance.PackFromXyzBytes(scanlineBuffer, pixelBuffer, this.header.Width);
 
                     break;
 

--- a/src/ImageSharp/Formats/Png/PngDecoderCore.cs
+++ b/src/ImageSharp/Formats/Png/PngDecoderCore.cs
@@ -577,7 +577,7 @@ namespace ImageSharp.Formats
         {
             TPixel color = default(TPixel);
             BufferSpan<TPixel> pixelBuffer = pixels.GetRowSpan(this.currentRow);
-            BufferSpan<byte> scanlineBuffer = new BufferSpan<byte>(defilteredScanline);
+            BufferSpan<byte> scanlineBuffer = new BufferSpan<byte>(defilteredScanline, 1);
             switch (this.PngColorType)
             {
                 case PngColorType.Grayscale:

--- a/src/ImageSharp/Formats/Png/PngEncoderCore.cs
+++ b/src/ImageSharp/Formats/Png/PngEncoderCore.cs
@@ -181,7 +181,7 @@ namespace ImageSharp.Formats
             {
                 Width = image.Width,
                 Height = image.Height,
-                ColorType = (byte)this.pngColorType,
+                ColorType = this.pngColorType,
                 BitDepth = this.bitDepth,
                 FilterMethod = 0, // None
                 CompressionMethod = 0,
@@ -462,7 +462,7 @@ namespace ImageSharp.Formats
             WriteInteger(this.chunkDataBuffer, 4, header.Height);
 
             this.chunkDataBuffer[8] = header.BitDepth;
-            this.chunkDataBuffer[9] = header.ColorType;
+            this.chunkDataBuffer[9] = (byte)header.ColorType;
             this.chunkDataBuffer[10] = header.CompressionMethod;
             this.chunkDataBuffer[11] = header.FilterMethod;
             this.chunkDataBuffer[12] = (byte)header.InterlaceMethod;

--- a/src/ImageSharp/Formats/Png/PngHeader.cs
+++ b/src/ImageSharp/Formats/Png/PngHeader.cs
@@ -34,7 +34,7 @@ namespace ImageSharp.Formats
         /// image data. Color type codes represent sums of the following values:
         /// 1 (palette used), 2 (color used), and 4 (alpha channel used).
         /// </summary>
-        public byte ColorType { get; set; }
+        public PngColorType ColorType { get; set; }
 
         /// <summary>
         /// Gets or sets the compression method.

--- a/src/ImageSharp/Formats/Png/Zlib/Adler32.cs
+++ b/src/ImageSharp/Formats/Png/Zlib/Adler32.cs
@@ -132,18 +132,13 @@ namespace ImageSharp.Formats
                 throw new ArgumentOutOfRangeException(nameof(count), "cannot be negative");
             }
 
-            if (offset >= buffer.Length)
-            {
-                throw new ArgumentOutOfRangeException(nameof(offset), "not a valid index into buffer");
-            }
-
             if (offset + count > buffer.Length)
             {
                 throw new ArgumentOutOfRangeException(nameof(count), "exceeds buffer size");
             }
 
             // (By Per Bothner)
-            uint s1 = this.checksum & 0xFFFF;
+            uint s1 = this.checksum;
             uint s2 = this.checksum >> 16;
 
             while (count > 0)
@@ -151,16 +146,12 @@ namespace ImageSharp.Formats
                 // We can defer the modulo operation:
                 // s1 maximally grows from 65521 to 65521 + 255 * 3800
                 // s2 maximally grows by 3800 * median(s1) = 2090079800 < 2^31
-                int n = 3800;
-                if (n > count)
-                {
-                    n = count;
-                }
+                int n = Math.Min(3800, count);
 
                 count -= n;
-                while (--n >= 0)
+                while (--n > -1)
                 {
-                    s1 = s1 + (uint)(buffer[offset++] & 0xff);
+                    s1 = s1 + buffer[offset++];
                     s2 = s2 + s1;
                 }
 

--- a/src/ImageSharp/Formats/Png/Zlib/DeframeStream.cs
+++ b/src/ImageSharp/Formats/Png/Zlib/DeframeStream.cs
@@ -1,0 +1,121 @@
+﻿namespace ImageSharp.Formats
+{
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Text;
+
+    /// <summary>
+    /// Provides methods and properties for deframing streams from PNGs.
+    /// </summary>
+    internal class DeframeStream : Stream
+    {
+        /// <summary>
+        /// The inner raw memory stream
+        /// </summary>
+        private readonly Stream innerStream;
+
+        /// <summary>
+        /// The compressed stream sitting over the top of the deframer
+        /// </summary>
+        private ZlibInflateStream compressedStream;
+
+        /// <summary>
+        /// The current data remaining to be read
+        /// </summary>
+        private int currentDataRemaining;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DeframeStream"/> class.
+        /// </summary>
+        /// <param name="innerStream">The inner raw stream</param>
+        public DeframeStream(Stream innerStream)
+        {
+            this.innerStream = innerStream;
+        }
+
+        /// <inheritdoc/>
+        public override bool CanRead => this.innerStream.CanRead;
+
+        /// <inheritdoc/>
+        public override bool CanSeek => false;
+
+        /// <inheritdoc/>
+        public override bool CanWrite => throw new NotSupportedException();
+
+        /// <inheritdoc/>
+        public override long Length => throw new NotSupportedException();
+
+        /// <inheritdoc/>
+        public override long Position { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+
+        /// <summary>
+        /// Gets the compressed stream over the deframed inner stream
+        /// </summary>
+        public ZlibInflateStream CompressedStream => this.compressedStream;
+
+        /// <summary>
+        /// Adds new bytes from a frame found in the original stream
+        /// </summary>
+        /// <param name="bytes">blabla</param>
+        public void AllocateNewBytes(int bytes)
+        {
+            this.currentDataRemaining = bytes;
+            if (this.compressedStream == null)
+            {
+                this.compressedStream = new ZlibInflateStream(this);
+            }
+        }
+
+        /// <inheritdoc/>
+        public override void Flush()
+        {
+            throw new NotSupportedException();
+        }
+
+        /// <inheritdoc/>
+        public override int ReadByte()
+        {
+            this.currentDataRemaining--;
+            return this.innerStream.ReadByte();
+        }
+
+        /// <inheritdoc/>
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            if (this.currentDataRemaining == 0)
+            {
+                return 0;
+            }
+
+            int bytesToRead = Math.Min(count, this.currentDataRemaining);
+            this.currentDataRemaining -= bytesToRead;
+            return this.innerStream.Read(buffer, offset, bytesToRead);
+        }
+
+        /// <inheritdoc/>
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            throw new NotSupportedException();
+        }
+
+        /// <inheritdoc/>
+        public override void SetLength(long value)
+        {
+            throw new NotSupportedException();
+        }
+
+        /// <inheritdoc/>
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            throw new NotSupportedException();
+        }
+
+        /// <inheritdoc/>
+        protected override void Dispose(bool disposing)
+        {
+            this.compressedStream.Dispose();
+            base.Dispose(disposing);
+        }
+    }
+}


### PR DESCRIPTION
Stop the copy from deframing to inflate
Removed the pixel by pixel processing for RgbWithAlpha
Cleaned up the Crc check on the inflated stream

Down from ~4x slower than the native System.Drawing method to ~2.5x slower.