### PR TITLE
Use same conversion methods as libjpeg

### DIFF
--- a/src/ImageSharp/Formats/Jpeg/Components/Decoder/YCbCrToRgbTables.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Decoder/YCbCrToRgbTables.cs
@@ -1,0 +1,95 @@
+﻿// <copyright file="YCbCrToRgbTables.cs" company="James Jackson-South">
+// Copyright (c) James Jackson-South and contributors.
+// Licensed under the Apache License, Version 2.0.
+// </copyright>
+
+namespace ImageSharp.Formats.Jpg
+{
+    using System.Runtime.CompilerServices;
+
+    using ImageSharp.PixelFormats;
+
+    /// <summary>
+    /// Provides 8-bit lookup tables for converting from YCbCr to Rgb colorspace.
+    /// Methods to build the tables are based on libjpeg implementation.
+    /// </summary>
+    internal struct YCbCrToRgbTables
+    {
+        // Speediest right-shift on some machines and gives us enough accuracy at 4 decimal places.
+        private const int ScaleBits = 16;
+
+        private const int Half = 1 << (ScaleBits - 1);
+
+        private static readonly int[] CrRTable = new int[256];
+
+        private static readonly int[] CbBTable = new int[256];
+
+        private static readonly int[] CrGTable = new int[256];
+
+        private static readonly int[] CbGTable = new int[256];
+
+        /// <summary>
+        /// Optimized method to pack bytes to the image from the YCbCr color space.
+        /// </summary>
+        /// <typeparam name="TPixel">The pixel format.</typeparam>
+        /// <param name="packed">The packed pixel.</param>
+        /// <param name="y">The y luminance component.</param>
+        /// <param name="cb">The cb chroma component.</param>
+        /// <param name="cr">The cr chroma component.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Pack<TPixel>(ref TPixel packed, byte y, byte cb, byte cr)
+            where TPixel : struct, IPixel<TPixel>
+        {
+            // float r = MathF.Round(y + (1.402F * cr), MidpointRounding.AwayFromZero);
+            byte r = (byte)(y + CrRTable[cr]).Clamp(0, 255);
+
+            // float g = MathF.Round(y - (0.344136F * cb) - (0.714136F * cr), MidpointRounding.AwayFromZero);
+            // The values for the G calculation are left scaled up, since we must add them together before rounding.
+            byte g = (byte)(y + RightShift(CbGTable[cb] + CrGTable[cr])).Clamp(0, 255);
+
+            // float b = MathF.Round(y + (1.772F * cb), MidpointRounding.AwayFromZero);
+            byte b = (byte)(y + CbBTable[cb]).Clamp(0, 255);
+
+            packed.PackFromBytes(r, g, b, byte.MaxValue);
+        }
+
+        /// <summary>
+        /// Initializes the YCbCr tables
+        /// </summary>
+        /// <returns>The intialized <see cref="YCbCrToRgbTables"/></returns>
+        public YCbCrToRgbTables Init()
+        {
+            for (int i = 0, x = -128; i <= 255; i++, x++)
+            {
+                // i is the actual input pixel value, in the range 0..255
+                // The Cb or Cr value we are thinking of is x = i - 128
+                // Cr=>R value is nearest int to 1.402 * x
+                CrRTable[i] = RightShift((Fix(1.402F) * x) + Half);
+
+                // Cb=>B value is nearest int to 1.772 * x
+                CbBTable[i] = RightShift((Fix(1.772F) * x) + Half);
+
+                // Cr=>G value is scaled-up -0.714136286
+                CrGTable[i] = (-Fix(0.714136286F)) * x;
+
+                // Cb => G value is scaled - up - 0.344136286 * x
+                // We also add in Half so that need not do it in inner loop
+                CbGTable[i] = ((-Fix(0.344136286F)) * x) + Half;
+            }
+
+            return this;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static int Fix(float x)
+        {
+            return (int)((x * (1L << ScaleBits)) + 0.5F);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static int RightShift(int x)
+        {
+            return x >> ScaleBits;
+        }
+    }
+}

--- a/src/ImageSharp/Formats/Jpeg/Components/Decoder/YCbCrToRgbTables.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Decoder/YCbCrToRgbTables.cs
@@ -6,78 +6,92 @@
 namespace ImageSharp.Formats.Jpg
 {
     using System.Runtime.CompilerServices;
-
     using ImageSharp.PixelFormats;
 
     /// <summary>
     /// Provides 8-bit lookup tables for converting from YCbCr to Rgb colorspace.
     /// Methods to build the tables are based on libjpeg implementation.
     /// </summary>
-    internal struct YCbCrToRgbTables
+    internal unsafe struct YCbCrToRgbTables
     {
+        /// <summary>
+        /// The red red-chrominance table
+        /// </summary>
+        public fixed int CrRTable[256];
+
+        /// <summary>
+        /// The blue blue-chrominance table
+        /// </summary>
+        public fixed int CbBTable[256];
+
+        /// <summary>
+        /// The green red-chrominance table
+        /// </summary>
+        public fixed int CrGTable[256];
+
+        /// <summary>
+        /// The green blue-chrominance table
+        /// </summary>
+        public fixed int CbGTable[256];
+
         // Speediest right-shift on some machines and gives us enough accuracy at 4 decimal places.
         private const int ScaleBits = 16;
 
         private const int Half = 1 << (ScaleBits - 1);
 
-        private static readonly int[] CrRTable = new int[256];
+        /// <summary>
+        /// Initializes the YCbCr tables
+        /// </summary>
+        /// <returns>The intialized <see cref="YCbCrToRgbTables"/></returns>
+        public static YCbCrToRgbTables Create()
+        {
+            YCbCrToRgbTables tables = default(YCbCrToRgbTables);
 
-        private static readonly int[] CbBTable = new int[256];
+            for (int i = 0, x = -128; i <= 255; i++, x++)
+            {
+                // i is the actual input pixel value, in the range 0..255
+                // The Cb or Cr value we are thinking of is x = i - 128
+                // Cr=>R value is nearest int to 1.402 * x
+                tables.CrRTable[i] = RightShift((Fix(1.402F) * x) + Half);
 
-        private static readonly int[] CrGTable = new int[256];
+                // Cb=>B value is nearest int to 1.772 * x
+                tables.CbBTable[i] = RightShift((Fix(1.772F) * x) + Half);
 
-        private static readonly int[] CbGTable = new int[256];
+                // Cr=>G value is scaled-up -0.714136286
+                tables.CrGTable[i] = (-Fix(0.714136286F)) * x;
+
+                // Cb => G value is scaled - up - 0.344136286 * x
+                // We also add in Half so that need not do it in inner loop
+                tables.CbGTable[i] = ((-Fix(0.344136286F)) * x) + Half;
+            }
+
+            return tables;
+        }
 
         /// <summary>
         /// Optimized method to pack bytes to the image from the YCbCr color space.
         /// </summary>
         /// <typeparam name="TPixel">The pixel format.</typeparam>
         /// <param name="packed">The packed pixel.</param>
+        /// <param name="tables">The reference to the tables instance.</param>
         /// <param name="y">The y luminance component.</param>
         /// <param name="cb">The cb chroma component.</param>
         /// <param name="cr">The cr chroma component.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void Pack<TPixel>(ref TPixel packed, byte y, byte cb, byte cr)
+        public static void Pack<TPixel>(ref TPixel packed, YCbCrToRgbTables* tables, byte y, byte cb, byte cr)
             where TPixel : struct, IPixel<TPixel>
         {
             // float r = MathF.Round(y + (1.402F * cr), MidpointRounding.AwayFromZero);
-            byte r = (byte)(y + CrRTable[cr]).Clamp(0, 255);
+            byte r = (byte)(y + tables->CrRTable[cr]).Clamp(0, 255);
 
             // float g = MathF.Round(y - (0.344136F * cb) - (0.714136F * cr), MidpointRounding.AwayFromZero);
             // The values for the G calculation are left scaled up, since we must add them together before rounding.
-            byte g = (byte)(y + RightShift(CbGTable[cb] + CrGTable[cr])).Clamp(0, 255);
+            byte g = (byte)(y + RightShift(tables->CbGTable[cb] + tables->CrGTable[cr])).Clamp(0, 255);
 
             // float b = MathF.Round(y + (1.772F * cb), MidpointRounding.AwayFromZero);
-            byte b = (byte)(y + CbBTable[cb]).Clamp(0, 255);
+            byte b = (byte)(y + tables->CbBTable[cb]).Clamp(0, 255);
 
             packed.PackFromBytes(r, g, b, byte.MaxValue);
-        }
-
-        /// <summary>
-        /// Initializes the YCbCr tables
-        /// </summary>
-        /// <returns>The intialized <see cref="YCbCrToRgbTables"/></returns>
-        public YCbCrToRgbTables Init()
-        {
-            for (int i = 0, x = -128; i <= 255; i++, x++)
-            {
-                // i is the actual input pixel value, in the range 0..255
-                // The Cb or Cr value we are thinking of is x = i - 128
-                // Cr=>R value is nearest int to 1.402 * x
-                CrRTable[i] = RightShift((Fix(1.402F) * x) + Half);
-
-                // Cb=>B value is nearest int to 1.772 * x
-                CbBTable[i] = RightShift((Fix(1.772F) * x) + Half);
-
-                // Cr=>G value is scaled-up -0.714136286
-                CrGTable[i] = (-Fix(0.714136286F)) * x;
-
-                // Cb => G value is scaled - up - 0.344136286 * x
-                // We also add in Half so that need not do it in inner loop
-                CbGTable[i] = ((-Fix(0.344136286F)) * x) + Half;
-            }
-
-            return this;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/ImageSharp/Formats/Jpeg/Components/Encoder/RgbToYCbCrTables.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Encoder/RgbToYCbCrTables.cs
@@ -1,0 +1,106 @@
+﻿// <copyright file="RgbToYCbCrTables.cs" company="James Jackson-South">
+// Copyright (c) James Jackson-South and contributors.
+// Licensed under the Apache License, Version 2.0.
+// </copyright>
+
+namespace ImageSharp.Formats.Jpg
+{
+    using System.Runtime.CompilerServices;
+
+    /// <summary>
+    /// Provides 8-bit lookup tables for converting from Rgb to YCbCr colorspace.
+    /// Methods to build the tables are based on libjpeg implementation.
+    /// </summary>
+    internal struct RgbToYCbCrTables
+    {
+        // Speediest right-shift on some machines and gives us enough accuracy at 4 decimal places.
+        private const int ScaleBits = 16;
+
+        private const int GYOffset = 256;
+
+        private const int BYOffset = 2 * 256;
+
+        private const int RCbOffset = 3 * 256;
+
+        private const int GCbOffset = 4 * 256;
+
+        private const int BCbOffset = 5 * 256;
+
+        // B=>Cb and R=>Cr are the same
+        private const int RCrOffset = BCbOffset;
+
+        private const int GCrOffset = 6 * 256;
+
+        private const int BCrOffset = 7 * 256;
+
+        private const int CBCrOffset = 128 << ScaleBits;
+
+        private const int Half = 1 << (ScaleBits - 1);
+
+        private static readonly int[] YCbCrTable = new int[8 * 256];
+
+        /// <summary>
+        /// Optimized method to allocates the correct y, cb, and cr values to the DCT blocks from the given r, g, b values.
+        /// </summary>
+        /// <param name="yBlockRaw">The The luminance block.</param>
+        /// <param name="cbBlockRaw">The red chroma block.</param>
+        /// <param name="crBlockRaw">The blue chroma block.</param>
+        /// <param name="index">The current index.</param>
+        /// <param name="r">The red value.</param>
+        /// <param name="g">The green value.</param>
+        /// <param name="b">The blue value.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public unsafe void Allocate(ref float* yBlockRaw, ref float* cbBlockRaw, ref float* crBlockRaw, int index, int r, int g, int b)
+        {
+            // float y = (0.299F * r) + (0.587F * g) + (0.114F * b);
+            yBlockRaw[index] = (YCbCrTable[r] + YCbCrTable[g + GYOffset] + YCbCrTable[b + BYOffset]) >> ScaleBits;
+
+            // float cb = 128F + ((-0.168736F * r) - (0.331264F * g) + (0.5F * b));
+            cbBlockRaw[index] = (YCbCrTable[r + RCbOffset] + YCbCrTable[g + GCbOffset] + YCbCrTable[b + BCbOffset]) >> ScaleBits;
+
+            // float b = MathF.Round(y + (1.772F * cb), MidpointRounding.AwayFromZero);
+            crBlockRaw[index] = (YCbCrTable[r + RCrOffset] + YCbCrTable[g + GCrOffset] + YCbCrTable[b + BCrOffset]) >> ScaleBits;
+        }
+
+        /// <summary>
+        /// Initializes the YCbCr tables
+        /// </summary>
+        /// <returns>The intialized <see cref="RgbToYCbCrTables"/></returns>
+        public RgbToYCbCrTables Init()
+        {
+            for (int i = 0; i <= 255; i++)
+            {
+                // The values for the calculations are left scaled up since we must add them together before rounding.
+                YCbCrTable[i] = Fix(0.299F) * i;
+                YCbCrTable[i + GYOffset] = Fix(0.587F) * i;
+                YCbCrTable[i + BYOffset] = (Fix(0.114F) * i) + Half;
+                YCbCrTable[i + RCbOffset] = (-Fix(0.168735892F)) * i;
+                YCbCrTable[i + GCbOffset] = (-Fix(0.331264108F)) * i;
+
+                // We use a rounding fudge - factor of 0.5 - epsilon for Cb and Cr.
+                // This ensures that the maximum output will round to 255
+                // not 256, and thus that we don't have to range-limit.
+                //
+                // B=>Cb and R=>Cr tables are the same
+                YCbCrTable[i + BCbOffset] = (Fix(0.5F) * i) + CBCrOffset + Half - 1;
+
+                YCbCrTable[i + GCrOffset] = (-Fix(0.418687589F)) * i;
+                YCbCrTable[i + BCrOffset] = (-Fix(0.081312411F)) * i;
+            }
+
+            return this;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static int Fix(float x)
+        {
+            return (int)((x * (1L << ScaleBits)) + 0.5F);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static int RightShift(int x)
+        {
+            return x >> ScaleBits;
+        }
+    }
+}

--- a/src/ImageSharp/Formats/Jpeg/Components/Encoder/RgbToYCbCrTables.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Encoder/RgbToYCbCrTables.cs
@@ -11,33 +11,86 @@ namespace ImageSharp.Formats.Jpg
     /// Provides 8-bit lookup tables for converting from Rgb to YCbCr colorspace.
     /// Methods to build the tables are based on libjpeg implementation.
     /// </summary>
-    internal struct RgbToYCbCrTables
+    internal unsafe struct RgbToYCbCrTables
     {
+        /// <summary>
+        /// The red luminance table
+        /// </summary>
+        public fixed int YRTable[256];
+
+        /// <summary>
+        /// The green luminance table
+        /// </summary>
+        public fixed int YGTable[256];
+
+        /// <summary>
+        /// The blue luminance table
+        /// </summary>
+        public fixed int YBTable[256];
+
+        /// <summary>
+        /// The red blue-chrominance table
+        /// </summary>
+        public fixed int CbRTable[256];
+
+        /// <summary>
+        /// The green blue-chrominance table
+        /// </summary>
+        public fixed int CbGTable[256];
+
+        /// <summary>
+        /// The blue blue-chrominance table
+        /// B=>Cb and R=>Cr are the same
+        /// </summary>
+        public fixed int CbBTable[256];
+
+        /// <summary>
+        /// The green red-chrominance table
+        /// </summary>
+        public fixed int CrGTable[256];
+
+        /// <summary>
+        /// The blue red-chrominance table
+        /// </summary>
+        public fixed int CrBTable[256];
+
         // Speediest right-shift on some machines and gives us enough accuracy at 4 decimal places.
         private const int ScaleBits = 16;
-
-        private const int GYOffset = 256;
-
-        private const int BYOffset = 2 * 256;
-
-        private const int RCbOffset = 3 * 256;
-
-        private const int GCbOffset = 4 * 256;
-
-        private const int BCbOffset = 5 * 256;
-
-        // B=>Cb and R=>Cr are the same
-        private const int RCrOffset = BCbOffset;
-
-        private const int GCrOffset = 6 * 256;
-
-        private const int BCrOffset = 7 * 256;
 
         private const int CBCrOffset = 128 << ScaleBits;
 
         private const int Half = 1 << (ScaleBits - 1);
 
-        private static readonly int[] YCbCrTable = new int[8 * 256];
+        /// <summary>
+        /// Initializes the YCbCr tables
+        /// </summary>
+        /// <returns>The intialized <see cref="RgbToYCbCrTables"/></returns>
+        public static RgbToYCbCrTables Create()
+        {
+            RgbToYCbCrTables tables = default(RgbToYCbCrTables);
+
+            for (int i = 0; i <= 255; i++)
+            {
+                // The values for the calculations are left scaled up since we must add them together before rounding.
+                tables.YRTable[i] = Fix(0.299F) * i;
+                tables.YGTable[i] = Fix(0.587F) * i;
+                tables.YBTable[i] = (Fix(0.114F) * i) + Half;
+                tables.CbRTable[i] = (-Fix(0.168735892F)) * i;
+                tables.CbGTable[i] = (-Fix(0.331264108F)) * i;
+
+                // We use a rounding fudge - factor of 0.5 - epsilon for Cb and Cr.
+                // This ensures that the maximum output will round to 255
+                // not 256, and thus that we don't have to range-limit.
+                //
+                // B=>Cb and R=>Cr tables are the same
+                tables.CbBTable[i] = (Fix(0.5F) * i) + CBCrOffset + Half - 1;
+
+                tables.CrGTable[i] = (-Fix(0.418687589F)) * i;
+                tables.CrBTable[i] = (-Fix(0.081312411F)) * i;
+            }
+
+            return tables;
+        }
 
         /// <summary>
         /// Optimized method to allocates the correct y, cb, and cr values to the DCT blocks from the given r, g, b values.
@@ -45,50 +98,22 @@ namespace ImageSharp.Formats.Jpg
         /// <param name="yBlockRaw">The The luminance block.</param>
         /// <param name="cbBlockRaw">The red chroma block.</param>
         /// <param name="crBlockRaw">The blue chroma block.</param>
+        /// <param name="tables">The reference to the tables instance.</param>
         /// <param name="index">The current index.</param>
         /// <param name="r">The red value.</param>
         /// <param name="g">The green value.</param>
         /// <param name="b">The blue value.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public unsafe void Allocate(ref float* yBlockRaw, ref float* cbBlockRaw, ref float* crBlockRaw, int index, int r, int g, int b)
+        public static void Allocate(ref float* yBlockRaw, ref float* cbBlockRaw, ref float* crBlockRaw, RgbToYCbCrTables* tables, int index, int r, int g, int b)
         {
             // float y = (0.299F * r) + (0.587F * g) + (0.114F * b);
-            yBlockRaw[index] = (YCbCrTable[r] + YCbCrTable[g + GYOffset] + YCbCrTable[b + BYOffset]) >> ScaleBits;
+            yBlockRaw[index] = (tables->YRTable[r] + tables->YGTable[g] + tables->YBTable[b]) >> ScaleBits;
 
             // float cb = 128F + ((-0.168736F * r) - (0.331264F * g) + (0.5F * b));
-            cbBlockRaw[index] = (YCbCrTable[r + RCbOffset] + YCbCrTable[g + GCbOffset] + YCbCrTable[b + BCbOffset]) >> ScaleBits;
+            cbBlockRaw[index] = (tables->CbRTable[r] + tables->CbGTable[g] + tables->CbBTable[b]) >> ScaleBits;
 
             // float b = MathF.Round(y + (1.772F * cb), MidpointRounding.AwayFromZero);
-            crBlockRaw[index] = (YCbCrTable[r + RCrOffset] + YCbCrTable[g + GCrOffset] + YCbCrTable[b + BCrOffset]) >> ScaleBits;
-        }
-
-        /// <summary>
-        /// Initializes the YCbCr tables
-        /// </summary>
-        /// <returns>The intialized <see cref="RgbToYCbCrTables"/></returns>
-        public RgbToYCbCrTables Init()
-        {
-            for (int i = 0; i <= 255; i++)
-            {
-                // The values for the calculations are left scaled up since we must add them together before rounding.
-                YCbCrTable[i] = Fix(0.299F) * i;
-                YCbCrTable[i + GYOffset] = Fix(0.587F) * i;
-                YCbCrTable[i + BYOffset] = (Fix(0.114F) * i) + Half;
-                YCbCrTable[i + RCbOffset] = (-Fix(0.168735892F)) * i;
-                YCbCrTable[i + GCbOffset] = (-Fix(0.331264108F)) * i;
-
-                // We use a rounding fudge - factor of 0.5 - epsilon for Cb and Cr.
-                // This ensures that the maximum output will round to 255
-                // not 256, and thus that we don't have to range-limit.
-                //
-                // B=>Cb and R=>Cr tables are the same
-                YCbCrTable[i + BCbOffset] = (Fix(0.5F) * i) + CBCrOffset + Half - 1;
-
-                YCbCrTable[i + GCrOffset] = (-Fix(0.418687589F)) * i;
-                YCbCrTable[i + BCrOffset] = (-Fix(0.081312411F)) * i;
-            }
-
-            return this;
+            crBlockRaw[index] = (tables->CbBTable[r] + tables->CrGTable[g] + tables->CrBTable[b]) >> ScaleBits;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/ImageSharp/Formats/Jpeg/Components/Encoder/RgbToYCbCrTables.cs
+++ b/src/ImageSharp/Formats/Jpeg/Components/Encoder/RgbToYCbCrTables.cs
@@ -104,7 +104,7 @@ namespace ImageSharp.Formats.Jpg
         /// <param name="g">The green value.</param>
         /// <param name="b">The blue value.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Allocate(ref float* yBlockRaw, ref float* cbBlockRaw, ref float* crBlockRaw, RgbToYCbCrTables* tables, int index, int r, int g, int b)
+        public static void Allocate(ref float* yBlockRaw, ref float* cbBlockRaw, ref float* crBlockRaw, ref RgbToYCbCrTables* tables, int index, int r, int g, int b)
         {
             // float y = (0.299F * r) + (0.587F * g) + (0.114F * b);
             yBlockRaw[index] = (tables->YRTable[r] + tables->YGTable[g] + tables->YBTable[b]) >> ScaleBits;

--- a/src/ImageSharp/Formats/Jpeg/JpegEncoderCore.cs
+++ b/src/ImageSharp/Formats/Jpeg/JpegEncoderCore.cs
@@ -23,11 +23,6 @@ namespace ImageSharp.Formats
         private const int QuantizationTableCount = 2;
 
         /// <summary>
-        /// Lookup tables for converting Rgb to YCbCr
-        /// </summary>
-        private static readonly RgbToYCbCrTables RgbToYCbCrTables = default(RgbToYCbCrTables).Init();
-
-        /// <summary>
         /// Counts the number of bits needed to hold an integer.
         /// </summary>
         private static readonly uint[] BitCountLut =
@@ -105,6 +100,11 @@ namespace ImageSharp.Formats
                         99, 99, 99, 99, 99, 99, 99, 99,
                     }
             };
+
+        /// <summary>
+        /// Lookup tables for converting Rgb to YCbCr
+        /// </summary>
+        private static RgbToYCbCrTables rgbToYCbCrTables = RgbToYCbCrTables.Create();
 
         /// <summary>
         /// A scratch buffer to reduce allocations.
@@ -288,6 +288,7 @@ namespace ImageSharp.Formats
         /// </summary>
         /// <typeparam name="TPixel">The pixel format.</typeparam>
         /// <param name="pixels">The pixel accessor.</param>
+        /// <param name="tables">The reference to the tables instance.</param>
         /// <param name="x">The x-position within the image.</param>
         /// <param name="y">The y-position within the image.</param>
         /// <param name="yBlock">The luminance block.</param>
@@ -296,6 +297,7 @@ namespace ImageSharp.Formats
         /// <param name="rgbBytes">Temporal <see cref="PixelArea{TPixel}"/> provided by the caller</param>
         private static void ToYCbCr<TPixel>(
             PixelAccessor<TPixel> pixels,
+            RgbToYCbCrTables* tables,
             int x,
             int y,
             Block8x8F* yBlock,
@@ -326,7 +328,7 @@ namespace ImageSharp.Formats
 
                     int index = j8 + i;
 
-                    RgbToYCbCrTables.Allocate(ref yBlockRaw, ref cbBlockRaw, ref crBlockRaw, index, r, g, b);
+                    RgbToYCbCrTables.Allocate(ref yBlockRaw, ref cbBlockRaw, ref crBlockRaw, tables, index, r, g, b);
 
                     dataIdx += 3;
                 }
@@ -447,38 +449,41 @@ namespace ImageSharp.Formats
             // ReSharper disable once InconsistentNaming
             int prevDCY = 0, prevDCCb = 0, prevDCCr = 0;
 
-            using (PixelArea<TPixel> rgbBytes = new PixelArea<TPixel>(8, 8, ComponentOrder.Xyz))
+            fixed (RgbToYCbCrTables* tables = &rgbToYCbCrTables)
             {
-                for (int y = 0; y < pixels.Height; y += 8)
+                using (PixelArea<TPixel> rgbBytes = new PixelArea<TPixel>(8, 8, ComponentOrder.Xyz))
                 {
-                    for (int x = 0; x < pixels.Width; x += 8)
+                    for (int y = 0; y < pixels.Height; y += 8)
                     {
-                        ToYCbCr(pixels, x, y, &b, &cb, &cr, rgbBytes);
+                        for (int x = 0; x < pixels.Width; x += 8)
+                        {
+                            ToYCbCr(pixels, tables, x, y, &b, &cb, &cr, rgbBytes);
 
-                        prevDCY = this.WriteBlock(
-                            QuantIndex.Luminance,
-                            prevDCY,
-                            &b,
-                            &temp1,
-                            &temp2,
-                            &onStackLuminanceQuantTable,
-                            unzig.Data);
-                        prevDCCb = this.WriteBlock(
-                            QuantIndex.Chrominance,
-                            prevDCCb,
-                            &cb,
-                            &temp1,
-                            &temp2,
-                            &onStackChrominanceQuantTable,
-                            unzig.Data);
-                        prevDCCr = this.WriteBlock(
-                            QuantIndex.Chrominance,
-                            prevDCCr,
-                            &cr,
-                            &temp1,
-                            &temp2,
-                            &onStackChrominanceQuantTable,
-                            unzig.Data);
+                            prevDCY = this.WriteBlock(
+                                QuantIndex.Luminance,
+                                prevDCY,
+                                &b,
+                                &temp1,
+                                &temp2,
+                                &onStackLuminanceQuantTable,
+                                unzig.Data);
+                            prevDCCb = this.WriteBlock(
+                                QuantIndex.Chrominance,
+                                prevDCCb,
+                                &cb,
+                                &temp1,
+                                &temp2,
+                                &onStackChrominanceQuantTable,
+                                unzig.Data);
+                            prevDCCr = this.WriteBlock(
+                                QuantIndex.Chrominance,
+                                prevDCCr,
+                                &cr,
+                                &temp1,
+                                &temp2,
+                                &onStackChrominanceQuantTable,
+                                unzig.Data);
+                        }
                     }
                 }
             }
@@ -820,49 +825,51 @@ namespace ImageSharp.Formats
 
             // ReSharper disable once InconsistentNaming
             int prevDCY = 0, prevDCCb = 0, prevDCCr = 0;
-
-            using (PixelArea<TPixel> rgbBytes = new PixelArea<TPixel>(8, 8, ComponentOrder.Xyz))
+            fixed (RgbToYCbCrTables* tables = &rgbToYCbCrTables)
             {
-                for (int y = 0; y < pixels.Height; y += 16)
+                using (PixelArea<TPixel> rgbBytes = new PixelArea<TPixel>(8, 8, ComponentOrder.Xyz))
                 {
-                    for (int x = 0; x < pixels.Width; x += 16)
+                    for (int y = 0; y < pixels.Height; y += 16)
                     {
-                        for (int i = 0; i < 4; i++)
+                        for (int x = 0; x < pixels.Width; x += 16)
                         {
-                            int xOff = (i & 1) * 8;
-                            int yOff = (i & 2) * 4;
+                            for (int i = 0; i < 4; i++)
+                            {
+                                int xOff = (i & 1) * 8;
+                                int yOff = (i & 2) * 4;
 
-                            ToYCbCr(pixels, x + xOff, y + yOff, &b, cbPtr + i, crPtr + i, rgbBytes);
+                                ToYCbCr(pixels, tables, x + xOff, y + yOff, &b, cbPtr + i, crPtr + i, rgbBytes);
 
-                            prevDCY = this.WriteBlock(
-                                QuantIndex.Luminance,
-                                prevDCY,
+                                prevDCY = this.WriteBlock(
+                                    QuantIndex.Luminance,
+                                    prevDCY,
+                                    &b,
+                                    &temp1,
+                                    &temp2,
+                                    &onStackLuminanceQuantTable,
+                                    unzig.Data);
+                            }
+
+                            Block8x8F.Scale16X16To8X8(&b, cbPtr);
+                            prevDCCb = this.WriteBlock(
+                                QuantIndex.Chrominance,
+                                prevDCCb,
                                 &b,
                                 &temp1,
                                 &temp2,
-                                &onStackLuminanceQuantTable,
+                                &onStackChrominanceQuantTable,
+                                unzig.Data);
+
+                            Block8x8F.Scale16X16To8X8(&b, crPtr);
+                            prevDCCr = this.WriteBlock(
+                                QuantIndex.Chrominance,
+                                prevDCCr,
+                                &b,
+                                &temp1,
+                                &temp2,
+                                &onStackChrominanceQuantTable,
                                 unzig.Data);
                         }
-
-                        Block8x8F.Scale16X16To8X8(&b, cbPtr);
-                        prevDCCb = this.WriteBlock(
-                            QuantIndex.Chrominance,
-                            prevDCCb,
-                            &b,
-                            &temp1,
-                            &temp2,
-                            &onStackChrominanceQuantTable,
-                            unzig.Data);
-
-                        Block8x8F.Scale16X16To8X8(&b, crPtr);
-                        prevDCCr = this.WriteBlock(
-                            QuantIndex.Chrominance,
-                            prevDCCr,
-                            &b,
-                            &temp1,
-                            &temp2,
-                            &onStackChrominanceQuantTable,
-                            unzig.Data);
                     }
                 }
             }

--- a/src/ImageSharp/Formats/Jpeg/JpegEncoderCore.cs
+++ b/src/ImageSharp/Formats/Jpeg/JpegEncoderCore.cs
@@ -328,7 +328,7 @@ namespace ImageSharp.Formats
 
                     int index = j8 + i;
 
-                    RgbToYCbCrTables.Allocate(ref yBlockRaw, ref cbBlockRaw, ref crBlockRaw, tables, index, r, g, b);
+                    RgbToYCbCrTables.Allocate(ref yBlockRaw, ref cbBlockRaw, ref crBlockRaw, ref tables, index, r, g, b);
 
                     dataIdx += 3;
                 }

--- a/tests/ImageSharp.Tests/Colors/RgbaVectorTransformTests.cs
+++ b/tests/ImageSharp.Tests/Colors/RgbaVectorTransformTests.cs
@@ -36,13 +36,13 @@ namespace ImageSharp.Tests.Colors
         [Fact]
         public void Multiply()
         {
-            Assert.Equal(RgbaVector.Multiply(Backdrop, RgbaVector.Black).ToVector4(), Rgba32.Black.ToVector4(), FloatComparer);
+            Assert.Equal(RgbaVector.Multiply(Backdrop, RgbaVector.Black).ToVector4(), RgbaVector.Black.ToVector4(), FloatComparer);
             Assert.Equal(RgbaVector.Multiply(Backdrop, RgbaVector.White).ToVector4(), Backdrop.ToVector4(), FloatComparer);
 
             RgbaVector multiply = RgbaVector.Multiply(Backdrop, Source);
             Assert.Equal(multiply.ToVector4(), new RgbaVector(0, 41, 0).ToVector4(), FloatComparer);
         }
-
+ 
         [Fact]
         public void Screen()
         {


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/JimBobSquarePants/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practise as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
This PR improves the accuracy of our YCbCr->Rgb->YcbCr conversions by using the same approach to building lookup tables that libjpeg turbo does. There's very little speed difference to our prior methods ~0.5ms on encode. 

See the following for reference.
https://github.com/libjpeg-turbo/libjpeg-turbo/blob/077e5bb4e0f6761c034e7c1f7e7a4120f580f1a0/jdcolor.c#L211

https://github.com/libjpeg-turbo/libjpeg-turbo/blob/077e5bb4e0f6761c034e7c1f7e7a4120f580f1a0/jccolor.c#L198

With this merged I believe we can close #82 and #155

Here's a comparision between the System.Drawing and Previous ImageSharp outputs and our new one.

**System.Drawing**
![sys-draw](https://cloud.githubusercontent.com/assets/385879/25419624/1ee3f92c-2a97-11e7-9a29-844ff415c952.jpg)

**ImageSharp Current 1.0.0-alpha7-00012**
![isharp-current](https://cloud.githubusercontent.com/assets/385879/25419687/714937ae-2a97-11e7-9bb1-23d5b40df93c.jpg)

**This PR**
![isharp-pr](https://cloud.githubusercontent.com/assets/385879/25419813/3e918ab8-2a98-11e7-8be8-301ca74dbf7b.jpg)

You'll notice the green tint is completely gone and the image much more clear. 
<!-- Thanks for contributing to ImageSharp! -->
