### PR TITLE
Change BitCovnerter to be processor endianness aware

### DIFF
--- a/src/ImageSharp/IO/EndianBitConverter.cs
+++ b/src/ImageSharp/IO/EndianBitConverter.cs
@@ -16,12 +16,12 @@ namespace ImageSharp.IO
         /// <summary>
         /// The little-endian bit converter.
         /// </summary>
-        public static readonly LittleEndianBitConverter LittleEndianConverter = new LittleEndianBitConverter();
+        public static readonly NativeBitConverter NativeEndianConverter = new NativeBitConverter();
 
         /// <summary>
         /// The big-endian bit converter.
         /// </summary>
-        public static readonly BigEndianBitConverter BigEndianConverter = new BigEndianBitConverter();
+        public static readonly ReversedBitConverter ReverseEndianConverter = new ReversedBitConverter();
 
         /// <summary>
         /// Gets the byte order ("endianness") in which data is converted using this class.
@@ -49,9 +49,25 @@ namespace ImageSharp.IO
             switch (endianness)
             {
                 case Endianness.LittleEndian:
-                    return LittleEndianConverter;
+                    if (BitConverter.IsLittleEndian)
+                    {
+                        return NativeEndianConverter;
+                    }
+                    else
+                    {
+                        return ReverseEndianConverter;
+                    }
+
                 case Endianness.BigEndian:
-                    return BigEndianConverter;
+                    if (BitConverter.IsLittleEndian)
+                    {
+                        return ReverseEndianConverter;
+                    }
+                    else
+                    {
+                        return NativeEndianConverter;
+                    }
+
                 default:
                     throw new ArgumentException("Not a valid form of Endianness", nameof(endianness));
             }

--- a/src/ImageSharp/IO/NativeBitConverter.cs
+++ b/src/ImageSharp/IO/NativeBitConverter.cs
@@ -5,21 +5,23 @@
 
 namespace ImageSharp.IO
 {
+    using System;
+
     /// <summary>
     /// Implementation of EndianBitConverter which converts to/from little-endian byte arrays.
     /// </summary>
-    internal sealed class LittleEndianBitConverter : EndianBitConverter
+    internal sealed class NativeBitConverter : EndianBitConverter
     {
         /// <inheritdoc/>
         public override Endianness Endianness
         {
-            get { return Endianness.LittleEndian; }
+            get { return BitConverter.IsLittleEndian ? Endianness.LittleEndian : Endianness.BigEndian; }
         }
 
         /// <inheritdoc/>
         public override bool IsLittleEndian
         {
-            get { return true; }
+            get { return BitConverter.IsLittleEndian; }
         }
 
         /// <inheritdoc/>

--- a/src/ImageSharp/IO/ReversedBitConverter.cs
+++ b/src/ImageSharp/IO/ReversedBitConverter.cs
@@ -5,21 +5,23 @@
 
 namespace ImageSharp.IO
 {
+    using System;
+
     /// <summary>
     /// Implementation of EndianBitConverter which converts to/from big-endian byte arrays.
     /// </summary>
-    internal sealed class BigEndianBitConverter : EndianBitConverter
+    internal sealed class ReversedBitConverter : EndianBitConverter
     {
         /// <inheritdoc/>
         public override Endianness Endianness
         {
-            get { return Endianness.BigEndian; }
+            get { return BitConverter.IsLittleEndian ? Endianness.BigEndian : Endianness.LittleEndian; }
         }
 
         /// <inheritdoc/>
         public override bool IsLittleEndian
         {
-            get { return false; }
+            get { return !BitConverter.IsLittleEndian; }
         }
 
         /// <inheritdoc/>

--- a/tests/ImageSharp.Tests/IO/BigEndianBitConverter.CopyBytesTests.cs
+++ b/tests/ImageSharp.Tests/IO/BigEndianBitConverter.CopyBytesTests.cs
@@ -17,37 +17,37 @@ namespace ImageSharp.Tests.IO
         [Fact]
         public void CopyToWithNullBufferThrowsException()
         {
-            Assert.Throws<ArgumentNullException>(() => EndianBitConverter.BigEndianConverter.CopyBytes(false, null, 0));
-            Assert.Throws<ArgumentNullException>(() => EndianBitConverter.BigEndianConverter.CopyBytes((short)42, null, 0));
-            Assert.Throws<ArgumentNullException>(() => EndianBitConverter.BigEndianConverter.CopyBytes((ushort)42, null, 0));
-            Assert.Throws<ArgumentNullException>(() => EndianBitConverter.BigEndianConverter.CopyBytes(42, null, 0));
-            Assert.Throws<ArgumentNullException>(() => EndianBitConverter.BigEndianConverter.CopyBytes(42u, null, 0));
-            Assert.Throws<ArgumentNullException>(() => EndianBitConverter.BigEndianConverter.CopyBytes(42L, null, 0));
-            Assert.Throws<ArgumentNullException>(() => EndianBitConverter.BigEndianConverter.CopyBytes((ulong)42L, null, 0));
+            Assert.Throws<ArgumentNullException>(() => EndianBitConverter.GetConverter(Endianness.BigEndian).CopyBytes(false, null, 0));
+            Assert.Throws<ArgumentNullException>(() => EndianBitConverter.GetConverter(Endianness.BigEndian).CopyBytes((short)42, null, 0));
+            Assert.Throws<ArgumentNullException>(() => EndianBitConverter.GetConverter(Endianness.BigEndian).CopyBytes((ushort)42, null, 0));
+            Assert.Throws<ArgumentNullException>(() => EndianBitConverter.GetConverter(Endianness.BigEndian).CopyBytes(42, null, 0));
+            Assert.Throws<ArgumentNullException>(() => EndianBitConverter.GetConverter(Endianness.BigEndian).CopyBytes(42u, null, 0));
+            Assert.Throws<ArgumentNullException>(() => EndianBitConverter.GetConverter(Endianness.BigEndian).CopyBytes(42L, null, 0));
+            Assert.Throws<ArgumentNullException>(() => EndianBitConverter.GetConverter(Endianness.BigEndian).CopyBytes((ulong)42L, null, 0));
         }
 
         [Fact]
         public void CopyToWithIndexTooBigThrowsException()
         {
-            Assert.Throws<ArgumentOutOfRangeException>(() => EndianBitConverter.BigEndianConverter.CopyBytes(false, new byte[1], 1));
-            Assert.Throws<ArgumentOutOfRangeException>(() => EndianBitConverter.BigEndianConverter.CopyBytes((short)42, new byte[2], 1));
-            Assert.Throws<ArgumentOutOfRangeException>(() => EndianBitConverter.BigEndianConverter.CopyBytes((ushort)42, new byte[2], 1));
-            Assert.Throws<ArgumentOutOfRangeException>(() => EndianBitConverter.BigEndianConverter.CopyBytes(42, new byte[4], 1));
-            Assert.Throws<ArgumentOutOfRangeException>(() => EndianBitConverter.BigEndianConverter.CopyBytes(42u, new byte[4], 1));
-            Assert.Throws<ArgumentOutOfRangeException>(() => EndianBitConverter.BigEndianConverter.CopyBytes(42L, new byte[8], 1));
-            Assert.Throws<ArgumentOutOfRangeException>(() => EndianBitConverter.BigEndianConverter.CopyBytes((ulong)42L, new byte[8], 1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => EndianBitConverter.GetConverter(Endianness.BigEndian).CopyBytes(false, new byte[1], 1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => EndianBitConverter.GetConverter(Endianness.BigEndian).CopyBytes((short)42, new byte[2], 1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => EndianBitConverter.GetConverter(Endianness.BigEndian).CopyBytes((ushort)42, new byte[2], 1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => EndianBitConverter.GetConverter(Endianness.BigEndian).CopyBytes(42, new byte[4], 1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => EndianBitConverter.GetConverter(Endianness.BigEndian).CopyBytes(42u, new byte[4], 1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => EndianBitConverter.GetConverter(Endianness.BigEndian).CopyBytes(42L, new byte[8], 1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => EndianBitConverter.GetConverter(Endianness.BigEndian).CopyBytes((ulong)42L, new byte[8], 1));
         }
 
         [Fact]
         public void CopyToWithBufferTooSmallThrowsException()
         {
-            Assert.Throws<ArgumentOutOfRangeException>(() => EndianBitConverter.BigEndianConverter.CopyBytes(false, new byte[0], 0));
-            Assert.Throws<ArgumentOutOfRangeException>(() => EndianBitConverter.BigEndianConverter.CopyBytes((short)42, new byte[1], 0));
-            Assert.Throws<ArgumentOutOfRangeException>(() => EndianBitConverter.BigEndianConverter.CopyBytes((ushort)42, new byte[1], 0));
-            Assert.Throws<ArgumentOutOfRangeException>(() => EndianBitConverter.BigEndianConverter.CopyBytes(42, new byte[3], 0));
-            Assert.Throws<ArgumentOutOfRangeException>(() => EndianBitConverter.BigEndianConverter.CopyBytes(42u, new byte[3], 0));
-            Assert.Throws<ArgumentOutOfRangeException>(() => EndianBitConverter.BigEndianConverter.CopyBytes(42L, new byte[7], 0));
-            Assert.Throws<ArgumentOutOfRangeException>(() => EndianBitConverter.BigEndianConverter.CopyBytes((ulong)42L, new byte[7], 0));
+            Assert.Throws<ArgumentOutOfRangeException>(() => EndianBitConverter.GetConverter(Endianness.BigEndian).CopyBytes(false, new byte[0], 0));
+            Assert.Throws<ArgumentOutOfRangeException>(() => EndianBitConverter.GetConverter(Endianness.BigEndian).CopyBytes((short)42, new byte[1], 0));
+            Assert.Throws<ArgumentOutOfRangeException>(() => EndianBitConverter.GetConverter(Endianness.BigEndian).CopyBytes((ushort)42, new byte[1], 0));
+            Assert.Throws<ArgumentOutOfRangeException>(() => EndianBitConverter.GetConverter(Endianness.BigEndian).CopyBytes(42, new byte[3], 0));
+            Assert.Throws<ArgumentOutOfRangeException>(() => EndianBitConverter.GetConverter(Endianness.BigEndian).CopyBytes(42u, new byte[3], 0));
+            Assert.Throws<ArgumentOutOfRangeException>(() => EndianBitConverter.GetConverter(Endianness.BigEndian).CopyBytes(42L, new byte[7], 0));
+            Assert.Throws<ArgumentOutOfRangeException>(() => EndianBitConverter.GetConverter(Endianness.BigEndian).CopyBytes((ulong)42L, new byte[7], 0));
         }
 
         /// <summary>
@@ -58,9 +58,9 @@ namespace ImageSharp.Tests.IO
         {
             byte[] buffer = new byte[1];
 
-            EndianBitConverter.BigEndianConverter.CopyBytes(false, buffer, 0);
+            EndianBitConverter.GetConverter(Endianness.BigEndian).CopyBytes(false, buffer, 0);
             this.CheckBytes(new byte[] { 0 }, buffer);
-            EndianBitConverter.BigEndianConverter.CopyBytes(true, buffer, 0);
+            EndianBitConverter.GetConverter(Endianness.BigEndian).CopyBytes(true, buffer, 0);
             this.CheckBytes(new byte[] { 1 }, buffer);
         }
 
@@ -72,15 +72,15 @@ namespace ImageSharp.Tests.IO
         {
             byte[] buffer = new byte[2];
 
-            EndianBitConverter.BigEndianConverter.CopyBytes((short)0, buffer, 0);
+            EndianBitConverter.GetConverter(Endianness.BigEndian).CopyBytes((short)0, buffer, 0);
             this.CheckBytes(new byte[] { 0, 0 }, buffer);
-            EndianBitConverter.BigEndianConverter.CopyBytes((short)1, buffer, 0);
+            EndianBitConverter.GetConverter(Endianness.BigEndian).CopyBytes((short)1, buffer, 0);
             this.CheckBytes(new byte[] { 0, 1 }, buffer);
-            EndianBitConverter.BigEndianConverter.CopyBytes((short)256, buffer, 0);
+            EndianBitConverter.GetConverter(Endianness.BigEndian).CopyBytes((short)256, buffer, 0);
             this.CheckBytes(new byte[] { 1, 0 }, buffer);
-            EndianBitConverter.BigEndianConverter.CopyBytes((short)-1, buffer, 0);
+            EndianBitConverter.GetConverter(Endianness.BigEndian).CopyBytes((short)-1, buffer, 0);
             this.CheckBytes(new byte[] { 255, 255 }, buffer);
-            EndianBitConverter.BigEndianConverter.CopyBytes((short)257, buffer, 0);
+            EndianBitConverter.GetConverter(Endianness.BigEndian).CopyBytes((short)257, buffer, 0);
             this.CheckBytes(new byte[] { 1, 1 }, buffer);
         }
 
@@ -92,15 +92,15 @@ namespace ImageSharp.Tests.IO
         {
             byte[] buffer = new byte[2];
 
-            EndianBitConverter.BigEndianConverter.CopyBytes((ushort)0, buffer, 0);
+            EndianBitConverter.GetConverter(Endianness.BigEndian).CopyBytes((ushort)0, buffer, 0);
             this.CheckBytes(new byte[] { 0, 0 }, buffer);
-            EndianBitConverter.BigEndianConverter.CopyBytes((ushort)1, buffer, 0);
+            EndianBitConverter.GetConverter(Endianness.BigEndian).CopyBytes((ushort)1, buffer, 0);
             this.CheckBytes(new byte[] { 0, 1 }, buffer);
-            EndianBitConverter.BigEndianConverter.CopyBytes((ushort)256, buffer, 0);
+            EndianBitConverter.GetConverter(Endianness.BigEndian).CopyBytes((ushort)256, buffer, 0);
             this.CheckBytes(new byte[] { 1, 0 }, buffer);
-            EndianBitConverter.BigEndianConverter.CopyBytes(ushort.MaxValue, buffer, 0);
+            EndianBitConverter.GetConverter(Endianness.BigEndian).CopyBytes(ushort.MaxValue, buffer, 0);
             this.CheckBytes(new byte[] { 255, 255 }, buffer);
-            EndianBitConverter.BigEndianConverter.CopyBytes((ushort)257, buffer, 0);
+            EndianBitConverter.GetConverter(Endianness.BigEndian).CopyBytes((ushort)257, buffer, 0);
             this.CheckBytes(new byte[] { 1, 1 }, buffer);
         }
 
@@ -112,19 +112,19 @@ namespace ImageSharp.Tests.IO
         {
             byte[] buffer = new byte[4];
 
-            EndianBitConverter.BigEndianConverter.CopyBytes(0, buffer, 0);
+            EndianBitConverter.GetConverter(Endianness.BigEndian).CopyBytes(0, buffer, 0);
             this.CheckBytes(new byte[] { 0, 0, 0, 0 }, buffer);
-            EndianBitConverter.BigEndianConverter.CopyBytes(1, buffer, 0);
+            EndianBitConverter.GetConverter(Endianness.BigEndian).CopyBytes(1, buffer, 0);
             this.CheckBytes(new byte[] { 0, 0, 0, 1 }, buffer);
-            EndianBitConverter.BigEndianConverter.CopyBytes(256, buffer, 0);
+            EndianBitConverter.GetConverter(Endianness.BigEndian).CopyBytes(256, buffer, 0);
             this.CheckBytes(new byte[] { 0, 0, 1, 0 }, buffer);
-            EndianBitConverter.BigEndianConverter.CopyBytes(65536, buffer, 0);
+            EndianBitConverter.GetConverter(Endianness.BigEndian).CopyBytes(65536, buffer, 0);
             this.CheckBytes(new byte[] { 0, 1, 0, 0 }, buffer);
-            EndianBitConverter.BigEndianConverter.CopyBytes(16777216, buffer, 0);
+            EndianBitConverter.GetConverter(Endianness.BigEndian).CopyBytes(16777216, buffer, 0);
             this.CheckBytes(new byte[] { 1, 0, 0, 0 }, buffer);
-            EndianBitConverter.BigEndianConverter.CopyBytes(-1, buffer, 0);
+            EndianBitConverter.GetConverter(Endianness.BigEndian).CopyBytes(-1, buffer, 0);
             this.CheckBytes(new byte[] { 255, 255, 255, 255 }, buffer);
-            EndianBitConverter.BigEndianConverter.CopyBytes(257, buffer, 0);
+            EndianBitConverter.GetConverter(Endianness.BigEndian).CopyBytes(257, buffer, 0);
             this.CheckBytes(new byte[] { 0, 0, 1, 1 }, buffer);
         }
 
@@ -136,19 +136,19 @@ namespace ImageSharp.Tests.IO
         {
             byte[] buffer = new byte[4];
 
-            EndianBitConverter.BigEndianConverter.CopyBytes((uint)0, buffer, 0);
+            EndianBitConverter.GetConverter(Endianness.BigEndian).CopyBytes((uint)0, buffer, 0);
             this.CheckBytes(new byte[] { 0, 0, 0, 0 }, buffer);
-            EndianBitConverter.BigEndianConverter.CopyBytes((uint)1, buffer, 0);
+            EndianBitConverter.GetConverter(Endianness.BigEndian).CopyBytes((uint)1, buffer, 0);
             this.CheckBytes(new byte[] { 0, 0, 0, 1 }, buffer);
-            EndianBitConverter.BigEndianConverter.CopyBytes((uint)256, buffer, 0);
+            EndianBitConverter.GetConverter(Endianness.BigEndian).CopyBytes((uint)256, buffer, 0);
             this.CheckBytes(new byte[] { 0, 0, 1, 0 }, buffer);
-            EndianBitConverter.BigEndianConverter.CopyBytes((uint)65536, buffer, 0);
+            EndianBitConverter.GetConverter(Endianness.BigEndian).CopyBytes((uint)65536, buffer, 0);
             this.CheckBytes(new byte[] { 0, 1, 0, 0 }, buffer);
-            EndianBitConverter.BigEndianConverter.CopyBytes((uint)16777216, buffer, 0);
+            EndianBitConverter.GetConverter(Endianness.BigEndian).CopyBytes((uint)16777216, buffer, 0);
             this.CheckBytes(new byte[] { 1, 0, 0, 0 }, buffer);
-            EndianBitConverter.BigEndianConverter.CopyBytes(uint.MaxValue, buffer, 0);
+            EndianBitConverter.GetConverter(Endianness.BigEndian).CopyBytes(uint.MaxValue, buffer, 0);
             this.CheckBytes(new byte[] { 255, 255, 255, 255 }, buffer);
-            EndianBitConverter.BigEndianConverter.CopyBytes((uint)257, buffer, 0);
+            EndianBitConverter.GetConverter(Endianness.BigEndian).CopyBytes((uint)257, buffer, 0);
             this.CheckBytes(new byte[] { 0, 0, 1, 1 }, buffer);
         }
 
@@ -160,27 +160,27 @@ namespace ImageSharp.Tests.IO
         {
             byte[] buffer = new byte[8];
 
-            EndianBitConverter.BigEndianConverter.CopyBytes(0L, buffer, 0);
+            EndianBitConverter.GetConverter(Endianness.BigEndian).CopyBytes(0L, buffer, 0);
             this.CheckBytes(new byte[] { 0, 0, 0, 0, 0, 0, 0, 0 }, buffer);
-            EndianBitConverter.BigEndianConverter.CopyBytes(1L, buffer, 0);
+            EndianBitConverter.GetConverter(Endianness.BigEndian).CopyBytes(1L, buffer, 0);
             this.CheckBytes(new byte[] { 0, 0, 0, 0, 0, 0, 0, 1 }, buffer);
-            EndianBitConverter.BigEndianConverter.CopyBytes(256L, buffer, 0);
+            EndianBitConverter.GetConverter(Endianness.BigEndian).CopyBytes(256L, buffer, 0);
             this.CheckBytes(new byte[] { 0, 0, 0, 0, 0, 0, 1, 0 }, buffer);
-            EndianBitConverter.BigEndianConverter.CopyBytes(65536L, buffer, 0);
+            EndianBitConverter.GetConverter(Endianness.BigEndian).CopyBytes(65536L, buffer, 0);
             this.CheckBytes(new byte[] { 0, 0, 0, 0, 0, 1, 0, 0 }, buffer);
-            EndianBitConverter.BigEndianConverter.CopyBytes(16777216L, buffer, 0);
+            EndianBitConverter.GetConverter(Endianness.BigEndian).CopyBytes(16777216L, buffer, 0);
             this.CheckBytes(new byte[] { 0, 0, 0, 0, 1, 0, 0, 0 }, buffer);
-            EndianBitConverter.BigEndianConverter.CopyBytes(4294967296L, buffer, 0);
+            EndianBitConverter.GetConverter(Endianness.BigEndian).CopyBytes(4294967296L, buffer, 0);
             this.CheckBytes(new byte[] { 0, 0, 0, 1, 0, 0, 0, 0 }, buffer);
-            EndianBitConverter.BigEndianConverter.CopyBytes(1099511627776L, buffer, 0);
+            EndianBitConverter.GetConverter(Endianness.BigEndian).CopyBytes(1099511627776L, buffer, 0);
             this.CheckBytes(new byte[] { 0, 0, 1, 0, 0, 0, 0, 0 }, buffer);
-            EndianBitConverter.BigEndianConverter.CopyBytes(1099511627776L * 256, buffer, 0);
+            EndianBitConverter.GetConverter(Endianness.BigEndian).CopyBytes(1099511627776L * 256, buffer, 0);
             this.CheckBytes(new byte[] { 0, 1, 0, 0, 0, 0, 0, 0 }, buffer);
-            EndianBitConverter.BigEndianConverter.CopyBytes(1099511627776L * 256 * 256, buffer, 0);
+            EndianBitConverter.GetConverter(Endianness.BigEndian).CopyBytes(1099511627776L * 256 * 256, buffer, 0);
             this.CheckBytes(new byte[] { 1, 0, 0, 0, 0, 0, 0, 0 }, buffer);
-            EndianBitConverter.BigEndianConverter.CopyBytes(-1L, buffer, 0);
+            EndianBitConverter.GetConverter(Endianness.BigEndian).CopyBytes(-1L, buffer, 0);
             this.CheckBytes(new byte[] { 255, 255, 255, 255, 255, 255, 255, 255 }, buffer);
-            EndianBitConverter.BigEndianConverter.CopyBytes(257L, buffer, 0);
+            EndianBitConverter.GetConverter(Endianness.BigEndian).CopyBytes(257L, buffer, 0);
             this.CheckBytes(new byte[] { 0, 0, 0, 0, 0, 0, 1, 1 }, buffer);
         }
 
@@ -192,27 +192,27 @@ namespace ImageSharp.Tests.IO
         {
             byte[] buffer = new byte[8];
 
-            EndianBitConverter.BigEndianConverter.CopyBytes(0UL, buffer, 0);
+            EndianBitConverter.GetConverter(Endianness.BigEndian).CopyBytes(0UL, buffer, 0);
             this.CheckBytes(new byte[] { 0, 0, 0, 0, 0, 0, 0, 0 }, buffer);
-            EndianBitConverter.BigEndianConverter.CopyBytes(1UL, buffer, 0);
+            EndianBitConverter.GetConverter(Endianness.BigEndian).CopyBytes(1UL, buffer, 0);
             this.CheckBytes(new byte[] { 0, 0, 0, 0, 0, 0, 0, 1 }, buffer);
-            EndianBitConverter.BigEndianConverter.CopyBytes(256UL, buffer, 0);
+            EndianBitConverter.GetConverter(Endianness.BigEndian).CopyBytes(256UL, buffer, 0);
             this.CheckBytes(new byte[] { 0, 0, 0, 0, 0, 0, 1, 0 }, buffer);
-            EndianBitConverter.BigEndianConverter.CopyBytes(65536UL, buffer, 0);
+            EndianBitConverter.GetConverter(Endianness.BigEndian).CopyBytes(65536UL, buffer, 0);
             this.CheckBytes(new byte[] { 0, 0, 0, 0, 0, 1, 0, 0 }, buffer);
-            EndianBitConverter.BigEndianConverter.CopyBytes(16777216UL, buffer, 0);
+            EndianBitConverter.GetConverter(Endianness.BigEndian).CopyBytes(16777216UL, buffer, 0);
             this.CheckBytes(new byte[] { 0, 0, 0, 0, 1, 0, 0, 0 }, buffer);
-            EndianBitConverter.BigEndianConverter.CopyBytes(4294967296UL, buffer, 0);
+            EndianBitConverter.GetConverter(Endianness.BigEndian).CopyBytes(4294967296UL, buffer, 0);
             this.CheckBytes(new byte[] { 0, 0, 0, 1, 0, 0, 0, 0 }, buffer);
-            EndianBitConverter.BigEndianConverter.CopyBytes(1099511627776UL, buffer, 0);
+            EndianBitConverter.GetConverter(Endianness.BigEndian).CopyBytes(1099511627776UL, buffer, 0);
             this.CheckBytes(new byte[] { 0, 0, 1, 0, 0, 0, 0, 0 }, buffer);
-            EndianBitConverter.BigEndianConverter.CopyBytes(1099511627776UL * 256, buffer, 0);
+            EndianBitConverter.GetConverter(Endianness.BigEndian).CopyBytes(1099511627776UL * 256, buffer, 0);
             this.CheckBytes(new byte[] { 0, 1, 0, 0, 0, 0, 0, 0 }, buffer);
-            EndianBitConverter.BigEndianConverter.CopyBytes(1099511627776UL * 256 * 256, buffer, 0);
+            EndianBitConverter.GetConverter(Endianness.BigEndian).CopyBytes(1099511627776UL * 256 * 256, buffer, 0);
             this.CheckBytes(new byte[] { 1, 0, 0, 0, 0, 0, 0, 0 }, buffer);
-            EndianBitConverter.BigEndianConverter.CopyBytes(ulong.MaxValue, buffer, 0);
+            EndianBitConverter.GetConverter(Endianness.BigEndian).CopyBytes(ulong.MaxValue, buffer, 0);
             this.CheckBytes(new byte[] { 255, 255, 255, 255, 255, 255, 255, 255 }, buffer);
-            EndianBitConverter.BigEndianConverter.CopyBytes(257UL, buffer, 0);
+            EndianBitConverter.GetConverter(Endianness.BigEndian).CopyBytes(257UL, buffer, 0);
             this.CheckBytes(new byte[] { 0, 0, 0, 0, 0, 0, 1, 1 }, buffer);
         }
 

--- a/tests/ImageSharp.Tests/IO/BigEndianBitConverter.GetBytesTests.cs
+++ b/tests/ImageSharp.Tests/IO/BigEndianBitConverter.GetBytesTests.cs
@@ -19,8 +19,8 @@ namespace ImageSharp.Tests.IO
         [Fact]
         public void GetBytesBoolean()
         {
-            this.CheckBytes(new byte[] { 0 }, EndianBitConverter.BigEndianConverter.GetBytes(false));
-            this.CheckBytes(new byte[] { 1 }, EndianBitConverter.BigEndianConverter.GetBytes(true));
+            this.CheckBytes(new byte[] { 0 }, EndianBitConverter.GetConverter(Endianness.BigEndian).GetBytes(false));
+            this.CheckBytes(new byte[] { 1 }, EndianBitConverter.GetConverter(Endianness.BigEndian).GetBytes(true));
         }
 
         /// <summary>
@@ -29,11 +29,11 @@ namespace ImageSharp.Tests.IO
         [Fact]
         public void GetBytesShort()
         {
-            this.CheckBytes(new byte[] { 0, 0 }, EndianBitConverter.BigEndianConverter.GetBytes((short)0));
-            this.CheckBytes(new byte[] { 0, 1 }, EndianBitConverter.BigEndianConverter.GetBytes((short)1));
-            this.CheckBytes(new byte[] { 1, 0 }, EndianBitConverter.BigEndianConverter.GetBytes((short)256));
-            this.CheckBytes(new byte[] { 255, 255 }, EndianBitConverter.BigEndianConverter.GetBytes((short)-1));
-            this.CheckBytes(new byte[] { 1, 1 }, EndianBitConverter.BigEndianConverter.GetBytes((short)257));
+            this.CheckBytes(new byte[] { 0, 0 }, EndianBitConverter.GetConverter(Endianness.BigEndian).GetBytes((short)0));
+            this.CheckBytes(new byte[] { 0, 1 }, EndianBitConverter.GetConverter(Endianness.BigEndian).GetBytes((short)1));
+            this.CheckBytes(new byte[] { 1, 0 }, EndianBitConverter.GetConverter(Endianness.BigEndian).GetBytes((short)256));
+            this.CheckBytes(new byte[] { 255, 255 }, EndianBitConverter.GetConverter(Endianness.BigEndian).GetBytes((short)-1));
+            this.CheckBytes(new byte[] { 1, 1 }, EndianBitConverter.GetConverter(Endianness.BigEndian).GetBytes((short)257));
         }
 
         /// <summary>
@@ -42,11 +42,11 @@ namespace ImageSharp.Tests.IO
         [Fact]
         public void GetBytesUShort()
         {
-            this.CheckBytes(new byte[] { 0, 0 }, EndianBitConverter.BigEndianConverter.GetBytes((ushort)0));
-            this.CheckBytes(new byte[] { 0, 1 }, EndianBitConverter.BigEndianConverter.GetBytes((ushort)1));
-            this.CheckBytes(new byte[] { 1, 0 }, EndianBitConverter.BigEndianConverter.GetBytes((ushort)256));
-            this.CheckBytes(new byte[] { 255, 255 }, EndianBitConverter.BigEndianConverter.GetBytes(ushort.MaxValue));
-            this.CheckBytes(new byte[] { 1, 1 }, EndianBitConverter.BigEndianConverter.GetBytes((ushort)257));
+            this.CheckBytes(new byte[] { 0, 0 }, EndianBitConverter.GetConverter(Endianness.BigEndian).GetBytes((ushort)0));
+            this.CheckBytes(new byte[] { 0, 1 }, EndianBitConverter.GetConverter(Endianness.BigEndian).GetBytes((ushort)1));
+            this.CheckBytes(new byte[] { 1, 0 }, EndianBitConverter.GetConverter(Endianness.BigEndian).GetBytes((ushort)256));
+            this.CheckBytes(new byte[] { 255, 255 }, EndianBitConverter.GetConverter(Endianness.BigEndian).GetBytes(ushort.MaxValue));
+            this.CheckBytes(new byte[] { 1, 1 }, EndianBitConverter.GetConverter(Endianness.BigEndian).GetBytes((ushort)257));
         }
 
         /// <summary>
@@ -55,13 +55,13 @@ namespace ImageSharp.Tests.IO
         [Fact]
         public void GetBytesInt()
         {
-            this.CheckBytes(new byte[] { 0, 0, 0, 0 }, EndianBitConverter.BigEndianConverter.GetBytes(0));
-            this.CheckBytes(new byte[] { 0, 0, 0, 1 }, EndianBitConverter.BigEndianConverter.GetBytes(1));
-            this.CheckBytes(new byte[] { 0, 0, 1, 0 }, EndianBitConverter.BigEndianConverter.GetBytes(256));
-            this.CheckBytes(new byte[] { 0, 1, 0, 0 }, EndianBitConverter.BigEndianConverter.GetBytes(65536));
-            this.CheckBytes(new byte[] { 1, 0, 0, 0 }, EndianBitConverter.BigEndianConverter.GetBytes(16777216));
-            this.CheckBytes(new byte[] { 255, 255, 255, 255 }, EndianBitConverter.BigEndianConverter.GetBytes(-1));
-            this.CheckBytes(new byte[] { 0, 0, 1, 1 }, EndianBitConverter.BigEndianConverter.GetBytes(257));
+            this.CheckBytes(new byte[] { 0, 0, 0, 0 }, EndianBitConverter.GetConverter(Endianness.BigEndian).GetBytes(0));
+            this.CheckBytes(new byte[] { 0, 0, 0, 1 }, EndianBitConverter.GetConverter(Endianness.BigEndian).GetBytes(1));
+            this.CheckBytes(new byte[] { 0, 0, 1, 0 }, EndianBitConverter.GetConverter(Endianness.BigEndian).GetBytes(256));
+            this.CheckBytes(new byte[] { 0, 1, 0, 0 }, EndianBitConverter.GetConverter(Endianness.BigEndian).GetBytes(65536));
+            this.CheckBytes(new byte[] { 1, 0, 0, 0 }, EndianBitConverter.GetConverter(Endianness.BigEndian).GetBytes(16777216));
+            this.CheckBytes(new byte[] { 255, 255, 255, 255 }, EndianBitConverter.GetConverter(Endianness.BigEndian).GetBytes(-1));
+            this.CheckBytes(new byte[] { 0, 0, 1, 1 }, EndianBitConverter.GetConverter(Endianness.BigEndian).GetBytes(257));
         }
 
         /// <summary>
@@ -70,13 +70,13 @@ namespace ImageSharp.Tests.IO
         [Fact]
         public void GetBytesUInt()
         {
-            this.CheckBytes(new byte[] { 0, 0, 0, 0 }, EndianBitConverter.BigEndianConverter.GetBytes((uint)0));
-            this.CheckBytes(new byte[] { 0, 0, 0, 1 }, EndianBitConverter.BigEndianConverter.GetBytes((uint)1));
-            this.CheckBytes(new byte[] { 0, 0, 1, 0 }, EndianBitConverter.BigEndianConverter.GetBytes((uint)256));
-            this.CheckBytes(new byte[] { 0, 1, 0, 0 }, EndianBitConverter.BigEndianConverter.GetBytes((uint)65536));
-            this.CheckBytes(new byte[] { 1, 0, 0, 0 }, EndianBitConverter.BigEndianConverter.GetBytes((uint)16777216));
-            this.CheckBytes(new byte[] { 255, 255, 255, 255 }, EndianBitConverter.BigEndianConverter.GetBytes(uint.MaxValue));
-            this.CheckBytes(new byte[] { 0, 0, 1, 1 }, EndianBitConverter.BigEndianConverter.GetBytes((uint)257));
+            this.CheckBytes(new byte[] { 0, 0, 0, 0 }, EndianBitConverter.GetConverter(Endianness.BigEndian).GetBytes((uint)0));
+            this.CheckBytes(new byte[] { 0, 0, 0, 1 }, EndianBitConverter.GetConverter(Endianness.BigEndian).GetBytes((uint)1));
+            this.CheckBytes(new byte[] { 0, 0, 1, 0 }, EndianBitConverter.GetConverter(Endianness.BigEndian).GetBytes((uint)256));
+            this.CheckBytes(new byte[] { 0, 1, 0, 0 }, EndianBitConverter.GetConverter(Endianness.BigEndian).GetBytes((uint)65536));
+            this.CheckBytes(new byte[] { 1, 0, 0, 0 }, EndianBitConverter.GetConverter(Endianness.BigEndian).GetBytes((uint)16777216));
+            this.CheckBytes(new byte[] { 255, 255, 255, 255 }, EndianBitConverter.GetConverter(Endianness.BigEndian).GetBytes(uint.MaxValue));
+            this.CheckBytes(new byte[] { 0, 0, 1, 1 }, EndianBitConverter.GetConverter(Endianness.BigEndian).GetBytes((uint)257));
         }
 
         /// <summary>
@@ -85,17 +85,17 @@ namespace ImageSharp.Tests.IO
         [Fact]
         public void GetBytesLong()
         {
-            this.CheckBytes(new byte[] { 0, 0, 0, 0, 0, 0, 0, 0 }, EndianBitConverter.BigEndianConverter.GetBytes(0L));
-            this.CheckBytes(new byte[] { 0, 0, 0, 0, 0, 0, 0, 1 }, EndianBitConverter.BigEndianConverter.GetBytes(1L));
-            this.CheckBytes(new byte[] { 0, 0, 0, 0, 0, 0, 1, 0 }, EndianBitConverter.BigEndianConverter.GetBytes(256L));
-            this.CheckBytes(new byte[] { 0, 0, 0, 0, 0, 1, 0, 0 }, EndianBitConverter.BigEndianConverter.GetBytes(65536L));
-            this.CheckBytes(new byte[] { 0, 0, 0, 0, 1, 0, 0, 0 }, EndianBitConverter.BigEndianConverter.GetBytes(16777216L));
-            this.CheckBytes(new byte[] { 0, 0, 0, 1, 0, 0, 0, 0 }, EndianBitConverter.BigEndianConverter.GetBytes(4294967296L));
-            this.CheckBytes(new byte[] { 0, 0, 1, 0, 0, 0, 0, 0 }, EndianBitConverter.BigEndianConverter.GetBytes(1099511627776L));
-            this.CheckBytes(new byte[] { 0, 1, 0, 0, 0, 0, 0, 0 }, EndianBitConverter.BigEndianConverter.GetBytes(1099511627776L * 256));
-            this.CheckBytes(new byte[] { 1, 0, 0, 0, 0, 0, 0, 0 }, EndianBitConverter.BigEndianConverter.GetBytes(1099511627776L * 256 * 256));
-            this.CheckBytes(new byte[] { 255, 255, 255, 255, 255, 255, 255, 255 }, EndianBitConverter.BigEndianConverter.GetBytes(-1L));
-            this.CheckBytes(new byte[] { 0, 0, 0, 0, 0, 0, 1, 1 }, EndianBitConverter.BigEndianConverter.GetBytes(257L));
+            this.CheckBytes(new byte[] { 0, 0, 0, 0, 0, 0, 0, 0 }, EndianBitConverter.GetConverter(Endianness.BigEndian).GetBytes(0L));
+            this.CheckBytes(new byte[] { 0, 0, 0, 0, 0, 0, 0, 1 }, EndianBitConverter.GetConverter(Endianness.BigEndian).GetBytes(1L));
+            this.CheckBytes(new byte[] { 0, 0, 0, 0, 0, 0, 1, 0 }, EndianBitConverter.GetConverter(Endianness.BigEndian).GetBytes(256L));
+            this.CheckBytes(new byte[] { 0, 0, 0, 0, 0, 1, 0, 0 }, EndianBitConverter.GetConverter(Endianness.BigEndian).GetBytes(65536L));
+            this.CheckBytes(new byte[] { 0, 0, 0, 0, 1, 0, 0, 0 }, EndianBitConverter.GetConverter(Endianness.BigEndian).GetBytes(16777216L));
+            this.CheckBytes(new byte[] { 0, 0, 0, 1, 0, 0, 0, 0 }, EndianBitConverter.GetConverter(Endianness.BigEndian).GetBytes(4294967296L));
+            this.CheckBytes(new byte[] { 0, 0, 1, 0, 0, 0, 0, 0 }, EndianBitConverter.GetConverter(Endianness.BigEndian).GetBytes(1099511627776L));
+            this.CheckBytes(new byte[] { 0, 1, 0, 0, 0, 0, 0, 0 }, EndianBitConverter.GetConverter(Endianness.BigEndian).GetBytes(1099511627776L * 256));
+            this.CheckBytes(new byte[] { 1, 0, 0, 0, 0, 0, 0, 0 }, EndianBitConverter.GetConverter(Endianness.BigEndian).GetBytes(1099511627776L * 256 * 256));
+            this.CheckBytes(new byte[] { 255, 255, 255, 255, 255, 255, 255, 255 }, EndianBitConverter.GetConverter(Endianness.BigEndian).GetBytes(-1L));
+            this.CheckBytes(new byte[] { 0, 0, 0, 0, 0, 0, 1, 1 }, EndianBitConverter.GetConverter(Endianness.BigEndian).GetBytes(257L));
         }
 
         /// <summary>
@@ -104,17 +104,17 @@ namespace ImageSharp.Tests.IO
         [Fact]
         public void GetBytesULong()
         {
-            this.CheckBytes(new byte[] { 0, 0, 0, 0, 0, 0, 0, 0 }, EndianBitConverter.BigEndianConverter.GetBytes(0UL));
-            this.CheckBytes(new byte[] { 0, 0, 0, 0, 0, 0, 0, 1 }, EndianBitConverter.BigEndianConverter.GetBytes(1UL));
-            this.CheckBytes(new byte[] { 0, 0, 0, 0, 0, 0, 1, 0 }, EndianBitConverter.BigEndianConverter.GetBytes(256UL));
-            this.CheckBytes(new byte[] { 0, 0, 0, 0, 0, 1, 0, 0 }, EndianBitConverter.BigEndianConverter.GetBytes(65536UL));
-            this.CheckBytes(new byte[] { 0, 0, 0, 0, 1, 0, 0, 0 }, EndianBitConverter.BigEndianConverter.GetBytes(16777216UL));
-            this.CheckBytes(new byte[] { 0, 0, 0, 1, 0, 0, 0, 0 }, EndianBitConverter.BigEndianConverter.GetBytes(4294967296UL));
-            this.CheckBytes(new byte[] { 0, 0, 1, 0, 0, 0, 0, 0 }, EndianBitConverter.BigEndianConverter.GetBytes(1099511627776UL));
-            this.CheckBytes(new byte[] { 0, 1, 0, 0, 0, 0, 0, 0 }, EndianBitConverter.BigEndianConverter.GetBytes(1099511627776UL * 256));
-            this.CheckBytes(new byte[] { 1, 0, 0, 0, 0, 0, 0, 0 }, EndianBitConverter.BigEndianConverter.GetBytes(1099511627776UL * 256 * 256));
-            this.CheckBytes(new byte[] { 255, 255, 255, 255, 255, 255, 255, 255 }, EndianBitConverter.BigEndianConverter.GetBytes(ulong.MaxValue));
-            this.CheckBytes(new byte[] { 0, 0, 0, 0, 0, 0, 1, 1 }, EndianBitConverter.BigEndianConverter.GetBytes(257UL));
+            this.CheckBytes(new byte[] { 0, 0, 0, 0, 0, 0, 0, 0 }, EndianBitConverter.GetConverter(Endianness.BigEndian).GetBytes(0UL));
+            this.CheckBytes(new byte[] { 0, 0, 0, 0, 0, 0, 0, 1 }, EndianBitConverter.GetConverter(Endianness.BigEndian).GetBytes(1UL));
+            this.CheckBytes(new byte[] { 0, 0, 0, 0, 0, 0, 1, 0 }, EndianBitConverter.GetConverter(Endianness.BigEndian).GetBytes(256UL));
+            this.CheckBytes(new byte[] { 0, 0, 0, 0, 0, 1, 0, 0 }, EndianBitConverter.GetConverter(Endianness.BigEndian).GetBytes(65536UL));
+            this.CheckBytes(new byte[] { 0, 0, 0, 0, 1, 0, 0, 0 }, EndianBitConverter.GetConverter(Endianness.BigEndian).GetBytes(16777216UL));
+            this.CheckBytes(new byte[] { 0, 0, 0, 1, 0, 0, 0, 0 }, EndianBitConverter.GetConverter(Endianness.BigEndian).GetBytes(4294967296UL));
+            this.CheckBytes(new byte[] { 0, 0, 1, 0, 0, 0, 0, 0 }, EndianBitConverter.GetConverter(Endianness.BigEndian).GetBytes(1099511627776UL));
+            this.CheckBytes(new byte[] { 0, 1, 0, 0, 0, 0, 0, 0 }, EndianBitConverter.GetConverter(Endianness.BigEndian).GetBytes(1099511627776UL * 256));
+            this.CheckBytes(new byte[] { 1, 0, 0, 0, 0, 0, 0, 0 }, EndianBitConverter.GetConverter(Endianness.BigEndian).GetBytes(1099511627776UL * 256 * 256));
+            this.CheckBytes(new byte[] { 255, 255, 255, 255, 255, 255, 255, 255 }, EndianBitConverter.GetConverter(Endianness.BigEndian).GetBytes(ulong.MaxValue));
+            this.CheckBytes(new byte[] { 0, 0, 0, 0, 0, 0, 1, 1 }, EndianBitConverter.GetConverter(Endianness.BigEndian).GetBytes(257UL));
         }
 
         /// <summary>

--- a/tests/ImageSharp.Tests/IO/BigEndianBitConverter.ToTypeTests.cs
+++ b/tests/ImageSharp.Tests/IO/BigEndianBitConverter.ToTypeTests.cs
@@ -17,37 +17,37 @@ namespace ImageSharp.Tests.IO
         [Fact]
         public void CopyToWithNullBufferThrowsException()
         {
-            Assert.Throws<ArgumentNullException>(() => EndianBitConverter.BigEndianConverter.ToBoolean(null, 0));
-            Assert.Throws<ArgumentNullException>(() => EndianBitConverter.BigEndianConverter.ToInt16(null, 0));
-            Assert.Throws<ArgumentNullException>(() => EndianBitConverter.BigEndianConverter.ToUInt16(null, 0));
-            Assert.Throws<ArgumentNullException>(() => EndianBitConverter.BigEndianConverter.ToInt32(null, 0));
-            Assert.Throws<ArgumentNullException>(() => EndianBitConverter.BigEndianConverter.ToUInt32(null, 0));
-            Assert.Throws<ArgumentNullException>(() => EndianBitConverter.BigEndianConverter.ToInt64(null, 0));
-            Assert.Throws<ArgumentNullException>(() => EndianBitConverter.BigEndianConverter.ToUInt64(null, 0));
+            Assert.Throws<ArgumentNullException>(() => EndianBitConverter.GetConverter(Endianness.BigEndian).ToBoolean(null, 0));
+            Assert.Throws<ArgumentNullException>(() => EndianBitConverter.GetConverter(Endianness.BigEndian).ToInt16(null, 0));
+            Assert.Throws<ArgumentNullException>(() => EndianBitConverter.GetConverter(Endianness.BigEndian).ToUInt16(null, 0));
+            Assert.Throws<ArgumentNullException>(() => EndianBitConverter.GetConverter(Endianness.BigEndian).ToInt32(null, 0));
+            Assert.Throws<ArgumentNullException>(() => EndianBitConverter.GetConverter(Endianness.BigEndian).ToUInt32(null, 0));
+            Assert.Throws<ArgumentNullException>(() => EndianBitConverter.GetConverter(Endianness.BigEndian).ToInt64(null, 0));
+            Assert.Throws<ArgumentNullException>(() => EndianBitConverter.GetConverter(Endianness.BigEndian).ToUInt64(null, 0));
         }
 
         [Fact]
         public void CopyToWithIndexTooBigThrowsException()
         {
-            Assert.Throws<ArgumentOutOfRangeException>(() => EndianBitConverter.BigEndianConverter.ToBoolean(new byte[1], 1));
-            Assert.Throws<ArgumentOutOfRangeException>(() => EndianBitConverter.BigEndianConverter.ToInt16(new byte[2], 1));
-            Assert.Throws<ArgumentOutOfRangeException>(() => EndianBitConverter.BigEndianConverter.ToUInt16(new byte[2], 1));
-            Assert.Throws<ArgumentOutOfRangeException>(() => EndianBitConverter.BigEndianConverter.ToInt32(new byte[4], 1));
-            Assert.Throws<ArgumentOutOfRangeException>(() => EndianBitConverter.BigEndianConverter.ToUInt32(new byte[4], 1));
-            Assert.Throws<ArgumentOutOfRangeException>(() => EndianBitConverter.BigEndianConverter.ToInt64(new byte[8], 1));
-            Assert.Throws<ArgumentOutOfRangeException>(() => EndianBitConverter.BigEndianConverter.ToUInt64(new byte[8], 1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => EndianBitConverter.GetConverter(Endianness.BigEndian).ToBoolean(new byte[1], 1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => EndianBitConverter.GetConverter(Endianness.BigEndian).ToInt16(new byte[2], 1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => EndianBitConverter.GetConverter(Endianness.BigEndian).ToUInt16(new byte[2], 1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => EndianBitConverter.GetConverter(Endianness.BigEndian).ToInt32(new byte[4], 1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => EndianBitConverter.GetConverter(Endianness.BigEndian).ToUInt32(new byte[4], 1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => EndianBitConverter.GetConverter(Endianness.BigEndian).ToInt64(new byte[8], 1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => EndianBitConverter.GetConverter(Endianness.BigEndian).ToUInt64(new byte[8], 1));
         }
 
         [Fact]
         public void CopyToWithBufferTooSmallThrowsException()
         {
-            Assert.Throws<ArgumentOutOfRangeException>(() => EndianBitConverter.BigEndianConverter.ToBoolean(new byte[0], 0));
-            Assert.Throws<ArgumentOutOfRangeException>(() => EndianBitConverter.BigEndianConverter.ToInt16(new byte[1], 0));
-            Assert.Throws<ArgumentOutOfRangeException>(() => EndianBitConverter.BigEndianConverter.ToUInt16(new byte[1], 0));
-            Assert.Throws<ArgumentOutOfRangeException>(() => EndianBitConverter.BigEndianConverter.ToInt32(new byte[3], 0));
-            Assert.Throws<ArgumentOutOfRangeException>(() => EndianBitConverter.BigEndianConverter.ToUInt32(new byte[3], 0));
-            Assert.Throws<ArgumentOutOfRangeException>(() => EndianBitConverter.BigEndianConverter.ToInt64(new byte[7], 0));
-            Assert.Throws<ArgumentOutOfRangeException>(() => EndianBitConverter.BigEndianConverter.ToUInt64(new byte[7], 0));
+            Assert.Throws<ArgumentOutOfRangeException>(() => EndianBitConverter.GetConverter(Endianness.BigEndian).ToBoolean(new byte[0], 0));
+            Assert.Throws<ArgumentOutOfRangeException>(() => EndianBitConverter.GetConverter(Endianness.BigEndian).ToInt16(new byte[1], 0));
+            Assert.Throws<ArgumentOutOfRangeException>(() => EndianBitConverter.GetConverter(Endianness.BigEndian).ToUInt16(new byte[1], 0));
+            Assert.Throws<ArgumentOutOfRangeException>(() => EndianBitConverter.GetConverter(Endianness.BigEndian).ToInt32(new byte[3], 0));
+            Assert.Throws<ArgumentOutOfRangeException>(() => EndianBitConverter.GetConverter(Endianness.BigEndian).ToUInt32(new byte[3], 0));
+            Assert.Throws<ArgumentOutOfRangeException>(() => EndianBitConverter.GetConverter(Endianness.BigEndian).ToInt64(new byte[7], 0));
+            Assert.Throws<ArgumentOutOfRangeException>(() => EndianBitConverter.GetConverter(Endianness.BigEndian).ToUInt64(new byte[7], 0));
         }
 
         /// <summary>
@@ -56,13 +56,13 @@ namespace ImageSharp.Tests.IO
         [Fact]
         public void ToBoolean()
         {
-            Assert.Equal(false, EndianBitConverter.BigEndianConverter.ToBoolean(new byte[] { 0 }, 0));
-            Assert.Equal(true, EndianBitConverter.BigEndianConverter.ToBoolean(new byte[] { 1 }, 0));
-            Assert.Equal(true, EndianBitConverter.BigEndianConverter.ToBoolean(new byte[] { 42 }, 0));
+            Assert.Equal(false, EndianBitConverter.GetConverter(Endianness.BigEndian).ToBoolean(new byte[] { 0 }, 0));
+            Assert.Equal(true, EndianBitConverter.GetConverter(Endianness.BigEndian).ToBoolean(new byte[] { 1 }, 0));
+            Assert.Equal(true, EndianBitConverter.GetConverter(Endianness.BigEndian).ToBoolean(new byte[] { 42 }, 0));
 
-            Assert.Equal(false, EndianBitConverter.BigEndianConverter.ToBoolean(new byte[] { 1, 0 }, 1));
-            Assert.Equal(true, EndianBitConverter.BigEndianConverter.ToBoolean(new byte[] { 0, 1 }, 1));
-            Assert.Equal(true, EndianBitConverter.BigEndianConverter.ToBoolean(new byte[] { 0, 42 }, 1));
+            Assert.Equal(false, EndianBitConverter.GetConverter(Endianness.BigEndian).ToBoolean(new byte[] { 1, 0 }, 1));
+            Assert.Equal(true, EndianBitConverter.GetConverter(Endianness.BigEndian).ToBoolean(new byte[] { 0, 1 }, 1));
+            Assert.Equal(true, EndianBitConverter.GetConverter(Endianness.BigEndian).ToBoolean(new byte[] { 0, 42 }, 1));
         }
 
         /// <summary>
@@ -71,17 +71,17 @@ namespace ImageSharp.Tests.IO
         [Fact]
         public void ToInt16()
         {
-            Assert.Equal((short)0, EndianBitConverter.BigEndianConverter.ToInt16(new byte[] { 0, 0 }, 0));
-            Assert.Equal((short)1, EndianBitConverter.BigEndianConverter.ToInt16(new byte[] { 0, 1 }, 0));
-            Assert.Equal((short)256, EndianBitConverter.BigEndianConverter.ToInt16(new byte[] { 1, 0 }, 0));
-            Assert.Equal((short)-1, EndianBitConverter.BigEndianConverter.ToInt16(new byte[] { 255, 255 }, 0));
-            Assert.Equal((short)257, EndianBitConverter.BigEndianConverter.ToInt16(new byte[] { 1, 1 }, 0));
+            Assert.Equal((short)0, EndianBitConverter.GetConverter(Endianness.BigEndian).ToInt16(new byte[] { 0, 0 }, 0));
+            Assert.Equal((short)1, EndianBitConverter.GetConverter(Endianness.BigEndian).ToInt16(new byte[] { 0, 1 }, 0));
+            Assert.Equal((short)256, EndianBitConverter.GetConverter(Endianness.BigEndian).ToInt16(new byte[] { 1, 0 }, 0));
+            Assert.Equal((short)-1, EndianBitConverter.GetConverter(Endianness.BigEndian).ToInt16(new byte[] { 255, 255 }, 0));
+            Assert.Equal((short)257, EndianBitConverter.GetConverter(Endianness.BigEndian).ToInt16(new byte[] { 1, 1 }, 0));
 
-            Assert.Equal((short)0, EndianBitConverter.BigEndianConverter.ToInt16(new byte[] { 1, 0, 0 }, 1));
-            Assert.Equal((short)1, EndianBitConverter.BigEndianConverter.ToInt16(new byte[] { 1, 0, 1 }, 1));
-            Assert.Equal((short)256, EndianBitConverter.BigEndianConverter.ToInt16(new byte[] { 0, 1, 0 }, 1));
-            Assert.Equal((short)-1, EndianBitConverter.BigEndianConverter.ToInt16(new byte[] { 0, 255, 255 }, 1));
-            Assert.Equal((short)257, EndianBitConverter.BigEndianConverter.ToInt16(new byte[] { 0, 1, 1 }, 1));
+            Assert.Equal((short)0, EndianBitConverter.GetConverter(Endianness.BigEndian).ToInt16(new byte[] { 1, 0, 0 }, 1));
+            Assert.Equal((short)1, EndianBitConverter.GetConverter(Endianness.BigEndian).ToInt16(new byte[] { 1, 0, 1 }, 1));
+            Assert.Equal((short)256, EndianBitConverter.GetConverter(Endianness.BigEndian).ToInt16(new byte[] { 0, 1, 0 }, 1));
+            Assert.Equal((short)-1, EndianBitConverter.GetConverter(Endianness.BigEndian).ToInt16(new byte[] { 0, 255, 255 }, 1));
+            Assert.Equal((short)257, EndianBitConverter.GetConverter(Endianness.BigEndian).ToInt16(new byte[] { 0, 1, 1 }, 1));
         }
 
         /// <summary>
@@ -90,17 +90,17 @@ namespace ImageSharp.Tests.IO
         [Fact]
         public void ToUInt16()
         {
-            Assert.Equal((ushort)0, EndianBitConverter.BigEndianConverter.ToUInt16(new byte[] { 0, 0 }, 0));
-            Assert.Equal((ushort)1, EndianBitConverter.BigEndianConverter.ToUInt16(new byte[] { 0, 1 }, 0));
-            Assert.Equal((ushort)256, EndianBitConverter.BigEndianConverter.ToUInt16(new byte[] { 1, 0 }, 0));
-            Assert.Equal(ushort.MaxValue, EndianBitConverter.BigEndianConverter.ToUInt16(new byte[] { 255, 255 }, 0));
-            Assert.Equal((ushort)257, EndianBitConverter.BigEndianConverter.ToUInt16(new byte[] { 1, 1 }, 0));
+            Assert.Equal((ushort)0, EndianBitConverter.GetConverter(Endianness.BigEndian).ToUInt16(new byte[] { 0, 0 }, 0));
+            Assert.Equal((ushort)1, EndianBitConverter.GetConverter(Endianness.BigEndian).ToUInt16(new byte[] { 0, 1 }, 0));
+            Assert.Equal((ushort)256, EndianBitConverter.GetConverter(Endianness.BigEndian).ToUInt16(new byte[] { 1, 0 }, 0));
+            Assert.Equal(ushort.MaxValue, EndianBitConverter.GetConverter(Endianness.BigEndian).ToUInt16(new byte[] { 255, 255 }, 0));
+            Assert.Equal((ushort)257, EndianBitConverter.GetConverter(Endianness.BigEndian).ToUInt16(new byte[] { 1, 1 }, 0));
 
-            Assert.Equal((ushort)0, EndianBitConverter.BigEndianConverter.ToUInt16(new byte[] { 1, 0, 0 }, 1));
-            Assert.Equal((ushort)1, EndianBitConverter.BigEndianConverter.ToUInt16(new byte[] { 1, 0, 1 }, 1));
-            Assert.Equal((ushort)256, EndianBitConverter.BigEndianConverter.ToUInt16(new byte[] { 0, 1, 0 }, 1));
-            Assert.Equal(ushort.MaxValue, EndianBitConverter.BigEndianConverter.ToUInt16(new byte[] { 0, 255, 255 }, 1));
-            Assert.Equal((ushort)257, EndianBitConverter.BigEndianConverter.ToUInt16(new byte[] { 0, 1, 1 }, 1));
+            Assert.Equal((ushort)0, EndianBitConverter.GetConverter(Endianness.BigEndian).ToUInt16(new byte[] { 1, 0, 0 }, 1));
+            Assert.Equal((ushort)1, EndianBitConverter.GetConverter(Endianness.BigEndian).ToUInt16(new byte[] { 1, 0, 1 }, 1));
+            Assert.Equal((ushort)256, EndianBitConverter.GetConverter(Endianness.BigEndian).ToUInt16(new byte[] { 0, 1, 0 }, 1));
+            Assert.Equal(ushort.MaxValue, EndianBitConverter.GetConverter(Endianness.BigEndian).ToUInt16(new byte[] { 0, 255, 255 }, 1));
+            Assert.Equal((ushort)257, EndianBitConverter.GetConverter(Endianness.BigEndian).ToUInt16(new byte[] { 0, 1, 1 }, 1));
         }
 
         /// <summary>
@@ -109,21 +109,21 @@ namespace ImageSharp.Tests.IO
         [Fact]
         public void ToInt32()
         {
-            Assert.Equal(0, EndianBitConverter.BigEndianConverter.ToInt32(new byte[] { 0, 0, 0, 0 }, 0));
-            Assert.Equal(1, EndianBitConverter.BigEndianConverter.ToInt32(new byte[] { 0, 0, 0, 1 }, 0));
-            Assert.Equal(256, EndianBitConverter.BigEndianConverter.ToInt32(new byte[] { 0, 0, 1, 0 }, 0));
-            Assert.Equal(65536, EndianBitConverter.BigEndianConverter.ToInt32(new byte[] { 0, 1, 0, 0 }, 0));
-            Assert.Equal(16777216, EndianBitConverter.BigEndianConverter.ToInt32(new byte[] { 1, 0, 0, 0 }, 0));
-            Assert.Equal(-1, EndianBitConverter.BigEndianConverter.ToInt32(new byte[] { 255, 255, 255, 255 }, 0));
-            Assert.Equal(257, EndianBitConverter.BigEndianConverter.ToInt32(new byte[] { 0, 0, 1, 1 }, 0));
+            Assert.Equal(0, EndianBitConverter.GetConverter(Endianness.BigEndian).ToInt32(new byte[] { 0, 0, 0, 0 }, 0));
+            Assert.Equal(1, EndianBitConverter.GetConverter(Endianness.BigEndian).ToInt32(new byte[] { 0, 0, 0, 1 }, 0));
+            Assert.Equal(256, EndianBitConverter.GetConverter(Endianness.BigEndian).ToInt32(new byte[] { 0, 0, 1, 0 }, 0));
+            Assert.Equal(65536, EndianBitConverter.GetConverter(Endianness.BigEndian).ToInt32(new byte[] { 0, 1, 0, 0 }, 0));
+            Assert.Equal(16777216, EndianBitConverter.GetConverter(Endianness.BigEndian).ToInt32(new byte[] { 1, 0, 0, 0 }, 0));
+            Assert.Equal(-1, EndianBitConverter.GetConverter(Endianness.BigEndian).ToInt32(new byte[] { 255, 255, 255, 255 }, 0));
+            Assert.Equal(257, EndianBitConverter.GetConverter(Endianness.BigEndian).ToInt32(new byte[] { 0, 0, 1, 1 }, 0));
 
-            Assert.Equal(0, EndianBitConverter.BigEndianConverter.ToInt32(new byte[] { 1, 0, 0, 0, 0 }, 1));
-            Assert.Equal(1, EndianBitConverter.BigEndianConverter.ToInt32(new byte[] { 1, 0, 0, 0, 1 }, 1));
-            Assert.Equal(256, EndianBitConverter.BigEndianConverter.ToInt32(new byte[] { 1, 0, 0, 1, 0 }, 1));
-            Assert.Equal(65536, EndianBitConverter.BigEndianConverter.ToInt32(new byte[] { 1, 0, 1, 0, 0 }, 1));
-            Assert.Equal(16777216, EndianBitConverter.BigEndianConverter.ToInt32(new byte[] { 0, 1, 0, 0, 0 }, 1));
-            Assert.Equal(-1, EndianBitConverter.BigEndianConverter.ToInt32(new byte[] { 0, 255, 255, 255, 255 }, 1));
-            Assert.Equal(257, EndianBitConverter.BigEndianConverter.ToInt32(new byte[] { 1, 0, 0, 1, 1 }, 1));
+            Assert.Equal(0, EndianBitConverter.GetConverter(Endianness.BigEndian).ToInt32(new byte[] { 1, 0, 0, 0, 0 }, 1));
+            Assert.Equal(1, EndianBitConverter.GetConverter(Endianness.BigEndian).ToInt32(new byte[] { 1, 0, 0, 0, 1 }, 1));
+            Assert.Equal(256, EndianBitConverter.GetConverter(Endianness.BigEndian).ToInt32(new byte[] { 1, 0, 0, 1, 0 }, 1));
+            Assert.Equal(65536, EndianBitConverter.GetConverter(Endianness.BigEndian).ToInt32(new byte[] { 1, 0, 1, 0, 0 }, 1));
+            Assert.Equal(16777216, EndianBitConverter.GetConverter(Endianness.BigEndian).ToInt32(new byte[] { 0, 1, 0, 0, 0 }, 1));
+            Assert.Equal(-1, EndianBitConverter.GetConverter(Endianness.BigEndian).ToInt32(new byte[] { 0, 255, 255, 255, 255 }, 1));
+            Assert.Equal(257, EndianBitConverter.GetConverter(Endianness.BigEndian).ToInt32(new byte[] { 1, 0, 0, 1, 1 }, 1));
         }
 
         /// <summary>
@@ -132,21 +132,21 @@ namespace ImageSharp.Tests.IO
         [Fact]
         public void ToUInt32()
         {
-            Assert.Equal((uint)0, EndianBitConverter.BigEndianConverter.ToUInt32(new byte[] { 0, 0, 0, 0 }, 0));
-            Assert.Equal((uint)1, EndianBitConverter.BigEndianConverter.ToUInt32(new byte[] { 0, 0, 0, 1 }, 0));
-            Assert.Equal((uint)256, EndianBitConverter.BigEndianConverter.ToUInt32(new byte[] { 0, 0, 1, 0 }, 0));
-            Assert.Equal((uint)65536, EndianBitConverter.BigEndianConverter.ToUInt32(new byte[] { 0, 1, 0, 0 }, 0));
-            Assert.Equal((uint)16777216, EndianBitConverter.BigEndianConverter.ToUInt32(new byte[] { 1, 0, 0, 0 }, 0));
-            Assert.Equal(uint.MaxValue, EndianBitConverter.BigEndianConverter.ToUInt32(new byte[] { 255, 255, 255, 255 }, 0));
-            Assert.Equal((uint)257, EndianBitConverter.BigEndianConverter.ToUInt32(new byte[] { 0, 0, 1, 1 }, 0));
+            Assert.Equal((uint)0, EndianBitConverter.GetConverter(Endianness.BigEndian).ToUInt32(new byte[] { 0, 0, 0, 0 }, 0));
+            Assert.Equal((uint)1, EndianBitConverter.GetConverter(Endianness.BigEndian).ToUInt32(new byte[] { 0, 0, 0, 1 }, 0));
+            Assert.Equal((uint)256, EndianBitConverter.GetConverter(Endianness.BigEndian).ToUInt32(new byte[] { 0, 0, 1, 0 }, 0));
+            Assert.Equal((uint)65536, EndianBitConverter.GetConverter(Endianness.BigEndian).ToUInt32(new byte[] { 0, 1, 0, 0 }, 0));
+            Assert.Equal((uint)16777216, EndianBitConverter.GetConverter(Endianness.BigEndian).ToUInt32(new byte[] { 1, 0, 0, 0 }, 0));
+            Assert.Equal(uint.MaxValue, EndianBitConverter.GetConverter(Endianness.BigEndian).ToUInt32(new byte[] { 255, 255, 255, 255 }, 0));
+            Assert.Equal((uint)257, EndianBitConverter.GetConverter(Endianness.BigEndian).ToUInt32(new byte[] { 0, 0, 1, 1 }, 0));
 
-            Assert.Equal((uint)0, EndianBitConverter.BigEndianConverter.ToUInt32(new byte[] { 1, 0, 0, 0, 0 }, 1));
-            Assert.Equal((uint)1, EndianBitConverter.BigEndianConverter.ToUInt32(new byte[] { 1, 0, 0, 0, 1 }, 1));
-            Assert.Equal((uint)256, EndianBitConverter.BigEndianConverter.ToUInt32(new byte[] { 1, 0, 0, 1, 0 }, 1));
-            Assert.Equal((uint)65536, EndianBitConverter.BigEndianConverter.ToUInt32(new byte[] { 1, 0, 1, 0, 0 }, 1));
-            Assert.Equal((uint)16777216, EndianBitConverter.BigEndianConverter.ToUInt32(new byte[] { 0, 1, 0, 0, 0 }, 1));
-            Assert.Equal(uint.MaxValue, EndianBitConverter.BigEndianConverter.ToUInt32(new byte[] { 0, 255, 255, 255, 255 }, 1));
-            Assert.Equal((uint)257, EndianBitConverter.BigEndianConverter.ToUInt32(new byte[] { 1, 0, 0, 1, 1 }, 1));
+            Assert.Equal((uint)0, EndianBitConverter.GetConverter(Endianness.BigEndian).ToUInt32(new byte[] { 1, 0, 0, 0, 0 }, 1));
+            Assert.Equal((uint)1, EndianBitConverter.GetConverter(Endianness.BigEndian).ToUInt32(new byte[] { 1, 0, 0, 0, 1 }, 1));
+            Assert.Equal((uint)256, EndianBitConverter.GetConverter(Endianness.BigEndian).ToUInt32(new byte[] { 1, 0, 0, 1, 0 }, 1));
+            Assert.Equal((uint)65536, EndianBitConverter.GetConverter(Endianness.BigEndian).ToUInt32(new byte[] { 1, 0, 1, 0, 0 }, 1));
+            Assert.Equal((uint)16777216, EndianBitConverter.GetConverter(Endianness.BigEndian).ToUInt32(new byte[] { 0, 1, 0, 0, 0 }, 1));
+            Assert.Equal(uint.MaxValue, EndianBitConverter.GetConverter(Endianness.BigEndian).ToUInt32(new byte[] { 0, 255, 255, 255, 255 }, 1));
+            Assert.Equal((uint)257, EndianBitConverter.GetConverter(Endianness.BigEndian).ToUInt32(new byte[] { 1, 0, 0, 1, 1 }, 1));
         }
 
         /// <summary>
@@ -155,29 +155,29 @@ namespace ImageSharp.Tests.IO
         [Fact]
         public void ToInt64()
         {
-            Assert.Equal(0L, EndianBitConverter.BigEndianConverter.ToInt64(new byte[] { 0, 0, 0, 0, 0, 0, 0, 0 }, 0));
-            Assert.Equal(1L, EndianBitConverter.BigEndianConverter.ToInt64(new byte[] { 0, 0, 0, 0, 0, 0, 0, 1 }, 0));
-            Assert.Equal(256L, EndianBitConverter.BigEndianConverter.ToInt64(new byte[] { 0, 0, 0, 0, 0, 0, 1, 0 }, 0));
-            Assert.Equal(65536L, EndianBitConverter.BigEndianConverter.ToInt64(new byte[] { 0, 0, 0, 0, 0, 1, 0, 0 }, 0));
-            Assert.Equal(16777216L, EndianBitConverter.BigEndianConverter.ToInt64(new byte[] { 0, 0, 0, 0, 1, 0, 0, 0 }, 0));
-            Assert.Equal(4294967296L, EndianBitConverter.BigEndianConverter.ToInt64(new byte[] { 0, 0, 0, 1, 0, 0, 0, 0 }, 0));
-            Assert.Equal(1099511627776L, EndianBitConverter.BigEndianConverter.ToInt64(new byte[] { 0, 0, 1, 0, 0, 0, 0, 0 }, 0));
-            Assert.Equal(1099511627776L * 256, EndianBitConverter.BigEndianConverter.ToInt64(new byte[] { 0, 1, 0, 0, 0, 0, 0, 0 }, 0));
-            Assert.Equal(1099511627776L * 256 * 256, EndianBitConverter.BigEndianConverter.ToInt64(new byte[] { 1, 0, 0, 0, 0, 0, 0, 0 }, 0));
-            Assert.Equal(-1L, EndianBitConverter.BigEndianConverter.ToInt64(new byte[] { 255, 255, 255, 255, 255, 255, 255, 255 }, 0));
-            Assert.Equal(257L, EndianBitConverter.BigEndianConverter.ToInt64(new byte[] { 0, 0, 0, 0, 0, 0, 1, 1 }, 0));
+            Assert.Equal(0L, EndianBitConverter.GetConverter(Endianness.BigEndian).ToInt64(new byte[] { 0, 0, 0, 0, 0, 0, 0, 0 }, 0));
+            Assert.Equal(1L, EndianBitConverter.GetConverter(Endianness.BigEndian).ToInt64(new byte[] { 0, 0, 0, 0, 0, 0, 0, 1 }, 0));
+            Assert.Equal(256L, EndianBitConverter.GetConverter(Endianness.BigEndian).ToInt64(new byte[] { 0, 0, 0, 0, 0, 0, 1, 0 }, 0));
+            Assert.Equal(65536L, EndianBitConverter.GetConverter(Endianness.BigEndian).ToInt64(new byte[] { 0, 0, 0, 0, 0, 1, 0, 0 }, 0));
+            Assert.Equal(16777216L, EndianBitConverter.GetConverter(Endianness.BigEndian).ToInt64(new byte[] { 0, 0, 0, 0, 1, 0, 0, 0 }, 0));
+            Assert.Equal(4294967296L, EndianBitConverter.GetConverter(Endianness.BigEndian).ToInt64(new byte[] { 0, 0, 0, 1, 0, 0, 0, 0 }, 0));
+            Assert.Equal(1099511627776L, EndianBitConverter.GetConverter(Endianness.BigEndian).ToInt64(new byte[] { 0, 0, 1, 0, 0, 0, 0, 0 }, 0));
+            Assert.Equal(1099511627776L * 256, EndianBitConverter.GetConverter(Endianness.BigEndian).ToInt64(new byte[] { 0, 1, 0, 0, 0, 0, 0, 0 }, 0));
+            Assert.Equal(1099511627776L * 256 * 256, EndianBitConverter.GetConverter(Endianness.BigEndian).ToInt64(new byte[] { 1, 0, 0, 0, 0, 0, 0, 0 }, 0));
+            Assert.Equal(-1L, EndianBitConverter.GetConverter(Endianness.BigEndian).ToInt64(new byte[] { 255, 255, 255, 255, 255, 255, 255, 255 }, 0));
+            Assert.Equal(257L, EndianBitConverter.GetConverter(Endianness.BigEndian).ToInt64(new byte[] { 0, 0, 0, 0, 0, 0, 1, 1 }, 0));
 
-            Assert.Equal(0L, EndianBitConverter.BigEndianConverter.ToInt64(new byte[] { 1, 0, 0, 0, 0, 0, 0, 0, 0 }, 1));
-            Assert.Equal(1L, EndianBitConverter.BigEndianConverter.ToInt64(new byte[] { 1, 0, 0, 0, 0, 0, 0, 0, 1 }, 1));
-            Assert.Equal(256L, EndianBitConverter.BigEndianConverter.ToInt64(new byte[] { 1, 0, 0, 0, 0, 0, 0, 1, 0 }, 1));
-            Assert.Equal(65536L, EndianBitConverter.BigEndianConverter.ToInt64(new byte[] { 1, 0, 0, 0, 0, 0, 1, 0, 0 }, 1));
-            Assert.Equal(16777216L, EndianBitConverter.BigEndianConverter.ToInt64(new byte[] { 1, 0, 0, 0, 0, 1, 0, 0, 0 }, 1));
-            Assert.Equal(4294967296L, EndianBitConverter.BigEndianConverter.ToInt64(new byte[] { 1, 0, 0, 0, 1, 0, 0, 0, 0 }, 1));
-            Assert.Equal(1099511627776L, EndianBitConverter.BigEndianConverter.ToInt64(new byte[] { 1, 0, 0, 1, 0, 0, 0, 0, 0 }, 1));
-            Assert.Equal(1099511627776L * 256, EndianBitConverter.BigEndianConverter.ToInt64(new byte[] { 1, 0, 1, 0, 0, 0, 0, 0, 0 }, 1));
-            Assert.Equal(1099511627776L * 256 * 256, EndianBitConverter.BigEndianConverter.ToInt64(new byte[] { 0, 1, 0, 0, 0, 0, 0, 0, 0 }, 1));
-            Assert.Equal(-1L, EndianBitConverter.BigEndianConverter.ToInt64(new byte[] { 0, 255, 255, 255, 255, 255, 255, 255, 255 }, 1));
-            Assert.Equal(257L, EndianBitConverter.BigEndianConverter.ToInt64(new byte[] { 1, 0, 0, 0, 0, 0, 0, 1, 1 }, 1));
+            Assert.Equal(0L, EndianBitConverter.GetConverter(Endianness.BigEndian).ToInt64(new byte[] { 1, 0, 0, 0, 0, 0, 0, 0, 0 }, 1));
+            Assert.Equal(1L, EndianBitConverter.GetConverter(Endianness.BigEndian).ToInt64(new byte[] { 1, 0, 0, 0, 0, 0, 0, 0, 1 }, 1));
+            Assert.Equal(256L, EndianBitConverter.GetConverter(Endianness.BigEndian).ToInt64(new byte[] { 1, 0, 0, 0, 0, 0, 0, 1, 0 }, 1));
+            Assert.Equal(65536L, EndianBitConverter.GetConverter(Endianness.BigEndian).ToInt64(new byte[] { 1, 0, 0, 0, 0, 0, 1, 0, 0 }, 1));
+            Assert.Equal(16777216L, EndianBitConverter.GetConverter(Endianness.BigEndian).ToInt64(new byte[] { 1, 0, 0, 0, 0, 1, 0, 0, 0 }, 1));
+            Assert.Equal(4294967296L, EndianBitConverter.GetConverter(Endianness.BigEndian).ToInt64(new byte[] { 1, 0, 0, 0, 1, 0, 0, 0, 0 }, 1));
+            Assert.Equal(1099511627776L, EndianBitConverter.GetConverter(Endianness.BigEndian).ToInt64(new byte[] { 1, 0, 0, 1, 0, 0, 0, 0, 0 }, 1));
+            Assert.Equal(1099511627776L * 256, EndianBitConverter.GetConverter(Endianness.BigEndian).ToInt64(new byte[] { 1, 0, 1, 0, 0, 0, 0, 0, 0 }, 1));
+            Assert.Equal(1099511627776L * 256 * 256, EndianBitConverter.GetConverter(Endianness.BigEndian).ToInt64(new byte[] { 0, 1, 0, 0, 0, 0, 0, 0, 0 }, 1));
+            Assert.Equal(-1L, EndianBitConverter.GetConverter(Endianness.BigEndian).ToInt64(new byte[] { 0, 255, 255, 255, 255, 255, 255, 255, 255 }, 1));
+            Assert.Equal(257L, EndianBitConverter.GetConverter(Endianness.BigEndian).ToInt64(new byte[] { 1, 0, 0, 0, 0, 0, 0, 1, 1 }, 1));
         }
 
         /// <summary>
@@ -186,29 +186,29 @@ namespace ImageSharp.Tests.IO
         [Fact]
         public void ToUInt64()
         {
-            Assert.Equal(0UL, EndianBitConverter.BigEndianConverter.ToUInt64(new byte[] { 0, 0, 0, 0, 0, 0, 0, 0 }, 0));
-            Assert.Equal(1UL, EndianBitConverter.BigEndianConverter.ToUInt64(new byte[] { 0, 0, 0, 0, 0, 0, 0, 1 }, 0));
-            Assert.Equal(256UL, EndianBitConverter.BigEndianConverter.ToUInt64(new byte[] { 0, 0, 0, 0, 0, 0, 1, 0 }, 0));
-            Assert.Equal(65536UL, EndianBitConverter.BigEndianConverter.ToUInt64(new byte[] { 0, 0, 0, 0, 0, 1, 0, 0 }, 0));
-            Assert.Equal(16777216UL, EndianBitConverter.BigEndianConverter.ToUInt64(new byte[] { 0, 0, 0, 0, 1, 0, 0, 0 }, 0));
-            Assert.Equal(4294967296UL, EndianBitConverter.BigEndianConverter.ToUInt64(new byte[] { 0, 0, 0, 1, 0, 0, 0, 0 }, 0));
-            Assert.Equal(1099511627776UL, EndianBitConverter.BigEndianConverter.ToUInt64(new byte[] { 0, 0, 1, 0, 0, 0, 0, 0 }, 0));
-            Assert.Equal(1099511627776UL * 256, EndianBitConverter.BigEndianConverter.ToUInt64(new byte[] { 0, 1, 0, 0, 0, 0, 0, 0 }, 0));
-            Assert.Equal(1099511627776UL * 256 * 256, EndianBitConverter.BigEndianConverter.ToUInt64(new byte[] { 1, 0, 0, 0, 0, 0, 0, 0 }, 0));
-            Assert.Equal(ulong.MaxValue, EndianBitConverter.BigEndianConverter.ToUInt64(new byte[] { 255, 255, 255, 255, 255, 255, 255, 255 }, 0));
-            Assert.Equal(257UL, EndianBitConverter.BigEndianConverter.ToUInt64(new byte[] { 0, 0, 0, 0, 0, 0, 1, 1 }, 0));
+            Assert.Equal(0UL, EndianBitConverter.GetConverter(Endianness.BigEndian).ToUInt64(new byte[] { 0, 0, 0, 0, 0, 0, 0, 0 }, 0));
+            Assert.Equal(1UL, EndianBitConverter.GetConverter(Endianness.BigEndian).ToUInt64(new byte[] { 0, 0, 0, 0, 0, 0, 0, 1 }, 0));
+            Assert.Equal(256UL, EndianBitConverter.GetConverter(Endianness.BigEndian).ToUInt64(new byte[] { 0, 0, 0, 0, 0, 0, 1, 0 }, 0));
+            Assert.Equal(65536UL, EndianBitConverter.GetConverter(Endianness.BigEndian).ToUInt64(new byte[] { 0, 0, 0, 0, 0, 1, 0, 0 }, 0));
+            Assert.Equal(16777216UL, EndianBitConverter.GetConverter(Endianness.BigEndian).ToUInt64(new byte[] { 0, 0, 0, 0, 1, 0, 0, 0 }, 0));
+            Assert.Equal(4294967296UL, EndianBitConverter.GetConverter(Endianness.BigEndian).ToUInt64(new byte[] { 0, 0, 0, 1, 0, 0, 0, 0 }, 0));
+            Assert.Equal(1099511627776UL, EndianBitConverter.GetConverter(Endianness.BigEndian).ToUInt64(new byte[] { 0, 0, 1, 0, 0, 0, 0, 0 }, 0));
+            Assert.Equal(1099511627776UL * 256, EndianBitConverter.GetConverter(Endianness.BigEndian).ToUInt64(new byte[] { 0, 1, 0, 0, 0, 0, 0, 0 }, 0));
+            Assert.Equal(1099511627776UL * 256 * 256, EndianBitConverter.GetConverter(Endianness.BigEndian).ToUInt64(new byte[] { 1, 0, 0, 0, 0, 0, 0, 0 }, 0));
+            Assert.Equal(ulong.MaxValue, EndianBitConverter.GetConverter(Endianness.BigEndian).ToUInt64(new byte[] { 255, 255, 255, 255, 255, 255, 255, 255 }, 0));
+            Assert.Equal(257UL, EndianBitConverter.GetConverter(Endianness.BigEndian).ToUInt64(new byte[] { 0, 0, 0, 0, 0, 0, 1, 1 }, 0));
 
-            Assert.Equal(0UL, EndianBitConverter.BigEndianConverter.ToUInt64(new byte[] { 1, 0, 0, 0, 0, 0, 0, 0, 0 }, 1));
-            Assert.Equal(1UL, EndianBitConverter.BigEndianConverter.ToUInt64(new byte[] { 1, 0, 0, 0, 0, 0, 0, 0, 1 }, 1));
-            Assert.Equal(256UL, EndianBitConverter.BigEndianConverter.ToUInt64(new byte[] { 1, 0, 0, 0, 0, 0, 0, 1, 0 }, 1));
-            Assert.Equal(65536UL, EndianBitConverter.BigEndianConverter.ToUInt64(new byte[] { 1, 0, 0, 0, 0, 0, 1, 0, 0 }, 1));
-            Assert.Equal(16777216UL, EndianBitConverter.BigEndianConverter.ToUInt64(new byte[] { 1, 0, 0, 0, 0, 1, 0, 0, 0 }, 1));
-            Assert.Equal(4294967296UL, EndianBitConverter.BigEndianConverter.ToUInt64(new byte[] { 1, 0, 0, 0, 1, 0, 0, 0, 0 }, 1));
-            Assert.Equal(1099511627776UL, EndianBitConverter.BigEndianConverter.ToUInt64(new byte[] { 1, 0, 0, 1, 0, 0, 0, 0, 0 }, 1));
-            Assert.Equal(1099511627776UL * 256, EndianBitConverter.BigEndianConverter.ToUInt64(new byte[] { 1, 0, 1, 0, 0, 0, 0, 0, 0 }, 1));
-            Assert.Equal(1099511627776UL * 256 * 256, EndianBitConverter.BigEndianConverter.ToUInt64(new byte[] { 0, 1, 0, 0, 0, 0, 0, 0, 0 }, 1));
-            Assert.Equal(ulong.MaxValue, EndianBitConverter.BigEndianConverter.ToUInt64(new byte[] { 0, 255, 255, 255, 255, 255, 255, 255, 255 }, 1));
-            Assert.Equal(257UL, EndianBitConverter.BigEndianConverter.ToUInt64(new byte[] { 1, 0, 0, 0, 0, 0, 0, 1, 1 }, 1));
+            Assert.Equal(0UL, EndianBitConverter.GetConverter(Endianness.BigEndian).ToUInt64(new byte[] { 1, 0, 0, 0, 0, 0, 0, 0, 0 }, 1));
+            Assert.Equal(1UL, EndianBitConverter.GetConverter(Endianness.BigEndian).ToUInt64(new byte[] { 1, 0, 0, 0, 0, 0, 0, 0, 1 }, 1));
+            Assert.Equal(256UL, EndianBitConverter.GetConverter(Endianness.BigEndian).ToUInt64(new byte[] { 1, 0, 0, 0, 0, 0, 0, 1, 0 }, 1));
+            Assert.Equal(65536UL, EndianBitConverter.GetConverter(Endianness.BigEndian).ToUInt64(new byte[] { 1, 0, 0, 0, 0, 0, 1, 0, 0 }, 1));
+            Assert.Equal(16777216UL, EndianBitConverter.GetConverter(Endianness.BigEndian).ToUInt64(new byte[] { 1, 0, 0, 0, 0, 1, 0, 0, 0 }, 1));
+            Assert.Equal(4294967296UL, EndianBitConverter.GetConverter(Endianness.BigEndian).ToUInt64(new byte[] { 1, 0, 0, 0, 1, 0, 0, 0, 0 }, 1));
+            Assert.Equal(1099511627776UL, EndianBitConverter.GetConverter(Endianness.BigEndian).ToUInt64(new byte[] { 1, 0, 0, 1, 0, 0, 0, 0, 0 }, 1));
+            Assert.Equal(1099511627776UL * 256, EndianBitConverter.GetConverter(Endianness.BigEndian).ToUInt64(new byte[] { 1, 0, 1, 0, 0, 0, 0, 0, 0 }, 1));
+            Assert.Equal(1099511627776UL * 256 * 256, EndianBitConverter.GetConverter(Endianness.BigEndian).ToUInt64(new byte[] { 0, 1, 0, 0, 0, 0, 0, 0, 0 }, 1));
+            Assert.Equal(ulong.MaxValue, EndianBitConverter.GetConverter(Endianness.BigEndian).ToUInt64(new byte[] { 0, 255, 255, 255, 255, 255, 255, 255, 255 }, 1));
+            Assert.Equal(257UL, EndianBitConverter.GetConverter(Endianness.BigEndian).ToUInt64(new byte[] { 1, 0, 0, 0, 0, 0, 0, 1, 1 }, 1));
         }
     }
 }

--- a/tests/ImageSharp.Tests/IO/LittleEndianBitConverter.CopyBytesTests.cs
+++ b/tests/ImageSharp.Tests/IO/LittleEndianBitConverter.CopyBytesTests.cs
@@ -10,44 +10,44 @@ namespace ImageSharp.Tests.IO
     using Xunit;
 
     /// <summary>
-    /// The <see cref="LittleEndianBitConverter"/> tests.
+    /// The <see cref="NativeBitConverter"/> tests.
     /// </summary>
     public class LittleEndianBitConverterCopyBytesTests
     {
         [Fact]
         public void CopyToWithNullBufferThrowsException()
         {
-            Assert.Throws<ArgumentNullException>(() => EndianBitConverter.LittleEndianConverter.CopyBytes(false, null, 0));
-            Assert.Throws<ArgumentNullException>(() => EndianBitConverter.LittleEndianConverter.CopyBytes((short)42, null, 0));
-            Assert.Throws<ArgumentNullException>(() => EndianBitConverter.LittleEndianConverter.CopyBytes((ushort)42, null, 0));
-            Assert.Throws<ArgumentNullException>(() => EndianBitConverter.LittleEndianConverter.CopyBytes(42, null, 0));
-            Assert.Throws<ArgumentNullException>(() => EndianBitConverter.LittleEndianConverter.CopyBytes(42u, null, 0));
-            Assert.Throws<ArgumentNullException>(() => EndianBitConverter.LittleEndianConverter.CopyBytes(42L, null, 0));
-            Assert.Throws<ArgumentNullException>(() => EndianBitConverter.LittleEndianConverter.CopyBytes((ulong)42L, null, 0));
+            Assert.Throws<ArgumentNullException>(() => EndianBitConverter.GetConverter(Endianness.LittleEndian).CopyBytes(false, null, 0));
+            Assert.Throws<ArgumentNullException>(() => EndianBitConverter.GetConverter(Endianness.LittleEndian).CopyBytes((short)42, null, 0));
+            Assert.Throws<ArgumentNullException>(() => EndianBitConverter.GetConverter(Endianness.LittleEndian).CopyBytes((ushort)42, null, 0));
+            Assert.Throws<ArgumentNullException>(() => EndianBitConverter.GetConverter(Endianness.LittleEndian).CopyBytes(42, null, 0));
+            Assert.Throws<ArgumentNullException>(() => EndianBitConverter.GetConverter(Endianness.LittleEndian).CopyBytes(42u, null, 0));
+            Assert.Throws<ArgumentNullException>(() => EndianBitConverter.GetConverter(Endianness.LittleEndian).CopyBytes(42L, null, 0));
+            Assert.Throws<ArgumentNullException>(() => EndianBitConverter.GetConverter(Endianness.LittleEndian).CopyBytes((ulong)42L, null, 0));
         }
 
         [Fact]
         public void CopyToWithIndexTooBigThrowsException()
         {
-            Assert.Throws<ArgumentOutOfRangeException>(() => EndianBitConverter.LittleEndianConverter.CopyBytes(false, new byte[1], 1));
-            Assert.Throws<ArgumentOutOfRangeException>(() => EndianBitConverter.LittleEndianConverter.CopyBytes((short)42, new byte[2], 1));
-            Assert.Throws<ArgumentOutOfRangeException>(() => EndianBitConverter.LittleEndianConverter.CopyBytes((ushort)42, new byte[2], 1));
-            Assert.Throws<ArgumentOutOfRangeException>(() => EndianBitConverter.LittleEndianConverter.CopyBytes(42, new byte[4], 1));
-            Assert.Throws<ArgumentOutOfRangeException>(() => EndianBitConverter.LittleEndianConverter.CopyBytes(42u, new byte[4], 1));
-            Assert.Throws<ArgumentOutOfRangeException>(() => EndianBitConverter.LittleEndianConverter.CopyBytes(42L, new byte[8], 1));
-            Assert.Throws<ArgumentOutOfRangeException>(() => EndianBitConverter.LittleEndianConverter.CopyBytes((ulong)42L, new byte[8], 1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => EndianBitConverter.GetConverter(Endianness.LittleEndian).CopyBytes(false, new byte[1], 1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => EndianBitConverter.GetConverter(Endianness.LittleEndian).CopyBytes((short)42, new byte[2], 1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => EndianBitConverter.GetConverter(Endianness.LittleEndian).CopyBytes((ushort)42, new byte[2], 1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => EndianBitConverter.GetConverter(Endianness.LittleEndian).CopyBytes(42, new byte[4], 1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => EndianBitConverter.GetConverter(Endianness.LittleEndian).CopyBytes(42u, new byte[4], 1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => EndianBitConverter.GetConverter(Endianness.LittleEndian).CopyBytes(42L, new byte[8], 1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => EndianBitConverter.GetConverter(Endianness.LittleEndian).CopyBytes((ulong)42L, new byte[8], 1));
         }
 
         [Fact]
         public void CopyToWithBufferTooSmallThrowsException()
         {
-            Assert.Throws<ArgumentOutOfRangeException>(() => EndianBitConverter.LittleEndianConverter.CopyBytes(false, new byte[0], 0));
-            Assert.Throws<ArgumentOutOfRangeException>(() => EndianBitConverter.LittleEndianConverter.CopyBytes((short)42, new byte[1], 0));
-            Assert.Throws<ArgumentOutOfRangeException>(() => EndianBitConverter.LittleEndianConverter.CopyBytes((ushort)42, new byte[1], 0));
-            Assert.Throws<ArgumentOutOfRangeException>(() => EndianBitConverter.LittleEndianConverter.CopyBytes(42, new byte[3], 0));
-            Assert.Throws<ArgumentOutOfRangeException>(() => EndianBitConverter.LittleEndianConverter.CopyBytes(42u, new byte[3], 0));
-            Assert.Throws<ArgumentOutOfRangeException>(() => EndianBitConverter.LittleEndianConverter.CopyBytes(42L, new byte[7], 0));
-            Assert.Throws<ArgumentOutOfRangeException>(() => EndianBitConverter.LittleEndianConverter.CopyBytes((ulong)42L, new byte[7], 0));
+            Assert.Throws<ArgumentOutOfRangeException>(() => EndianBitConverter.GetConverter(Endianness.LittleEndian).CopyBytes(false, new byte[0], 0));
+            Assert.Throws<ArgumentOutOfRangeException>(() => EndianBitConverter.GetConverter(Endianness.LittleEndian).CopyBytes((short)42, new byte[1], 0));
+            Assert.Throws<ArgumentOutOfRangeException>(() => EndianBitConverter.GetConverter(Endianness.LittleEndian).CopyBytes((ushort)42, new byte[1], 0));
+            Assert.Throws<ArgumentOutOfRangeException>(() => EndianBitConverter.GetConverter(Endianness.LittleEndian).CopyBytes(42, new byte[3], 0));
+            Assert.Throws<ArgumentOutOfRangeException>(() => EndianBitConverter.GetConverter(Endianness.LittleEndian).CopyBytes(42u, new byte[3], 0));
+            Assert.Throws<ArgumentOutOfRangeException>(() => EndianBitConverter.GetConverter(Endianness.LittleEndian).CopyBytes(42L, new byte[7], 0));
+            Assert.Throws<ArgumentOutOfRangeException>(() => EndianBitConverter.GetConverter(Endianness.LittleEndian).CopyBytes((ulong)42L, new byte[7], 0));
         }
 
         /// <summary>
@@ -58,9 +58,9 @@ namespace ImageSharp.Tests.IO
         {
             byte[] buffer = new byte[1];
 
-            EndianBitConverter.LittleEndianConverter.CopyBytes(false, buffer, 0);
+            EndianBitConverter.GetConverter(Endianness.LittleEndian).CopyBytes(false, buffer, 0);
             this.CheckBytes(new byte[] { 0 }, buffer);
-            EndianBitConverter.LittleEndianConverter.CopyBytes(true, buffer, 0);
+            EndianBitConverter.GetConverter(Endianness.LittleEndian).CopyBytes(true, buffer, 0);
             this.CheckBytes(new byte[] { 1 }, buffer);
         }
 
@@ -72,15 +72,15 @@ namespace ImageSharp.Tests.IO
         {
             byte[] buffer = new byte[2];
 
-            EndianBitConverter.LittleEndianConverter.CopyBytes((short)0, buffer, 0);
+            EndianBitConverter.GetConverter(Endianness.LittleEndian).CopyBytes((short)0, buffer, 0);
             this.CheckBytes(new byte[] { 0, 0 }, buffer);
-            EndianBitConverter.LittleEndianConverter.CopyBytes((short)1, buffer, 0);
+            EndianBitConverter.GetConverter(Endianness.LittleEndian).CopyBytes((short)1, buffer, 0);
             this.CheckBytes(new byte[] { 1, 0 }, buffer);
-            EndianBitConverter.LittleEndianConverter.CopyBytes((short)256, buffer, 0);
+            EndianBitConverter.GetConverter(Endianness.LittleEndian).CopyBytes((short)256, buffer, 0);
             this.CheckBytes(new byte[] { 0, 1 }, buffer);
-            EndianBitConverter.LittleEndianConverter.CopyBytes((short)-1, buffer, 0);
+            EndianBitConverter.GetConverter(Endianness.LittleEndian).CopyBytes((short)-1, buffer, 0);
             this.CheckBytes(new byte[] { 255, 255 }, buffer);
-            EndianBitConverter.LittleEndianConverter.CopyBytes((short)257, buffer, 0);
+            EndianBitConverter.GetConverter(Endianness.LittleEndian).CopyBytes((short)257, buffer, 0);
             this.CheckBytes(new byte[] { 1, 1 }, buffer);
         }
 
@@ -92,15 +92,15 @@ namespace ImageSharp.Tests.IO
         {
             byte[] buffer = new byte[2];
 
-            EndianBitConverter.LittleEndianConverter.CopyBytes((ushort)0, buffer, 0);
+            EndianBitConverter.GetConverter(Endianness.LittleEndian).CopyBytes((ushort)0, buffer, 0);
             this.CheckBytes(new byte[] { 0, 0 }, buffer);
-            EndianBitConverter.LittleEndianConverter.CopyBytes((ushort)1, buffer, 0);
+            EndianBitConverter.GetConverter(Endianness.LittleEndian).CopyBytes((ushort)1, buffer, 0);
             this.CheckBytes(new byte[] { 1, 0 }, buffer);
-            EndianBitConverter.LittleEndianConverter.CopyBytes((ushort)256, buffer, 0);
+            EndianBitConverter.GetConverter(Endianness.LittleEndian).CopyBytes((ushort)256, buffer, 0);
             this.CheckBytes(new byte[] { 0, 1 }, buffer);
-            EndianBitConverter.LittleEndianConverter.CopyBytes(ushort.MaxValue, buffer, 0);
+            EndianBitConverter.GetConverter(Endianness.LittleEndian).CopyBytes(ushort.MaxValue, buffer, 0);
             this.CheckBytes(new byte[] { 255, 255 }, buffer);
-            EndianBitConverter.LittleEndianConverter.CopyBytes((ushort)257, buffer, 0);
+            EndianBitConverter.GetConverter(Endianness.LittleEndian).CopyBytes((ushort)257, buffer, 0);
             this.CheckBytes(new byte[] { 1, 1 }, buffer);
         }
 
@@ -112,19 +112,19 @@ namespace ImageSharp.Tests.IO
         {
             byte[] buffer = new byte[4];
 
-            EndianBitConverter.LittleEndianConverter.CopyBytes(0, buffer, 0);
+            EndianBitConverter.GetConverter(Endianness.LittleEndian).CopyBytes(0, buffer, 0);
             this.CheckBytes(new byte[] { 0, 0, 0, 0 }, buffer);
-            EndianBitConverter.LittleEndianConverter.CopyBytes(1, buffer, 0);
+            EndianBitConverter.GetConverter(Endianness.LittleEndian).CopyBytes(1, buffer, 0);
             this.CheckBytes(new byte[] { 1, 0, 0, 0 }, buffer);
-            EndianBitConverter.LittleEndianConverter.CopyBytes(256, buffer, 0);
+            EndianBitConverter.GetConverter(Endianness.LittleEndian).CopyBytes(256, buffer, 0);
             this.CheckBytes(new byte[] { 0, 1, 0, 0 }, buffer);
-            EndianBitConverter.LittleEndianConverter.CopyBytes(65536, buffer, 0);
+            EndianBitConverter.GetConverter(Endianness.LittleEndian).CopyBytes(65536, buffer, 0);
             this.CheckBytes(new byte[] { 0, 0, 1, 0 }, buffer);
-            EndianBitConverter.LittleEndianConverter.CopyBytes(16777216, buffer, 0);
+            EndianBitConverter.GetConverter(Endianness.LittleEndian).CopyBytes(16777216, buffer, 0);
             this.CheckBytes(new byte[] { 0, 0, 0, 1 }, buffer);
-            EndianBitConverter.LittleEndianConverter.CopyBytes(-1, buffer, 0);
+            EndianBitConverter.GetConverter(Endianness.LittleEndian).CopyBytes(-1, buffer, 0);
             this.CheckBytes(new byte[] { 255, 255, 255, 255 }, buffer);
-            EndianBitConverter.LittleEndianConverter.CopyBytes(257, buffer, 0);
+            EndianBitConverter.GetConverter(Endianness.LittleEndian).CopyBytes(257, buffer, 0);
             this.CheckBytes(new byte[] { 1, 1, 0, 0 }, buffer);
         }
 
@@ -136,19 +136,19 @@ namespace ImageSharp.Tests.IO
         {
             byte[] buffer = new byte[4];
 
-            EndianBitConverter.LittleEndianConverter.CopyBytes((uint)0, buffer, 0);
+            EndianBitConverter.GetConverter(Endianness.LittleEndian).CopyBytes((uint)0, buffer, 0);
             this.CheckBytes(new byte[] { 0, 0, 0, 0 }, buffer);
-            EndianBitConverter.LittleEndianConverter.CopyBytes((uint)1, buffer, 0);
+            EndianBitConverter.GetConverter(Endianness.LittleEndian).CopyBytes((uint)1, buffer, 0);
             this.CheckBytes(new byte[] { 1, 0, 0, 0 }, buffer);
-            EndianBitConverter.LittleEndianConverter.CopyBytes((uint)256, buffer, 0);
+            EndianBitConverter.GetConverter(Endianness.LittleEndian).CopyBytes((uint)256, buffer, 0);
             this.CheckBytes(new byte[] { 0, 1, 0, 0 }, buffer);
-            EndianBitConverter.LittleEndianConverter.CopyBytes((uint)65536, buffer, 0);
+            EndianBitConverter.GetConverter(Endianness.LittleEndian).CopyBytes((uint)65536, buffer, 0);
             this.CheckBytes(new byte[] { 0, 0, 1, 0 }, buffer);
-            EndianBitConverter.LittleEndianConverter.CopyBytes((uint)16777216, buffer, 0);
+            EndianBitConverter.GetConverter(Endianness.LittleEndian).CopyBytes((uint)16777216, buffer, 0);
             this.CheckBytes(new byte[] { 0, 0, 0, 1 }, buffer);
-            EndianBitConverter.LittleEndianConverter.CopyBytes(uint.MaxValue, buffer, 0);
+            EndianBitConverter.GetConverter(Endianness.LittleEndian).CopyBytes(uint.MaxValue, buffer, 0);
             this.CheckBytes(new byte[] { 255, 255, 255, 255 }, buffer);
-            EndianBitConverter.LittleEndianConverter.CopyBytes((uint)257, buffer, 0);
+            EndianBitConverter.GetConverter(Endianness.LittleEndian).CopyBytes((uint)257, buffer, 0);
             this.CheckBytes(new byte[] { 1, 1, 0, 0 }, buffer);
         }
 
@@ -160,27 +160,27 @@ namespace ImageSharp.Tests.IO
         {
             byte[] buffer = new byte[8];
 
-            EndianBitConverter.LittleEndianConverter.CopyBytes(0L, buffer, 0);
+            EndianBitConverter.GetConverter(Endianness.LittleEndian).CopyBytes(0L, buffer, 0);
             this.CheckBytes(new byte[] { 0, 0, 0, 0, 0, 0, 0, 0 }, buffer);
-            EndianBitConverter.LittleEndianConverter.CopyBytes(1L, buffer, 0);
+            EndianBitConverter.GetConverter(Endianness.LittleEndian).CopyBytes(1L, buffer, 0);
             this.CheckBytes(new byte[] { 1, 0, 0, 0, 0, 0, 0, 0 }, buffer);
-            EndianBitConverter.LittleEndianConverter.CopyBytes(256L, buffer, 0);
+            EndianBitConverter.GetConverter(Endianness.LittleEndian).CopyBytes(256L, buffer, 0);
             this.CheckBytes(new byte[] { 0, 1, 0, 0, 0, 0, 0, 0 }, buffer);
-            EndianBitConverter.LittleEndianConverter.CopyBytes(65536L, buffer, 0);
+            EndianBitConverter.GetConverter(Endianness.LittleEndian).CopyBytes(65536L, buffer, 0);
             this.CheckBytes(new byte[] { 0, 0, 1, 0, 0, 0, 0, 0 }, buffer);
-            EndianBitConverter.LittleEndianConverter.CopyBytes(16777216L, buffer, 0);
+            EndianBitConverter.GetConverter(Endianness.LittleEndian).CopyBytes(16777216L, buffer, 0);
             this.CheckBytes(new byte[] { 0, 0, 0, 1, 0, 0, 0, 0 }, buffer);
-            EndianBitConverter.LittleEndianConverter.CopyBytes(4294967296L, buffer, 0);
+            EndianBitConverter.GetConverter(Endianness.LittleEndian).CopyBytes(4294967296L, buffer, 0);
             this.CheckBytes(new byte[] { 0, 0, 0, 0, 1, 0, 0, 0 }, buffer);
-            EndianBitConverter.LittleEndianConverter.CopyBytes(1099511627776L, buffer, 0);
+            EndianBitConverter.GetConverter(Endianness.LittleEndian).CopyBytes(1099511627776L, buffer, 0);
             this.CheckBytes(new byte[] { 0, 0, 0, 0, 0, 1, 0, 0 }, buffer);
-            EndianBitConverter.LittleEndianConverter.CopyBytes(1099511627776L * 256, buffer, 0);
+            EndianBitConverter.GetConverter(Endianness.LittleEndian).CopyBytes(1099511627776L * 256, buffer, 0);
             this.CheckBytes(new byte[] { 0, 0, 0, 0, 0, 0, 1, 0 }, buffer);
-            EndianBitConverter.LittleEndianConverter.CopyBytes(1099511627776L * 256 * 256, buffer, 0);
+            EndianBitConverter.GetConverter(Endianness.LittleEndian).CopyBytes(1099511627776L * 256 * 256, buffer, 0);
             this.CheckBytes(new byte[] { 0, 0, 0, 0, 0, 0, 0, 1 }, buffer);
-            EndianBitConverter.LittleEndianConverter.CopyBytes(-1L, buffer, 0);
+            EndianBitConverter.GetConverter(Endianness.LittleEndian).CopyBytes(-1L, buffer, 0);
             this.CheckBytes(new byte[] { 255, 255, 255, 255, 255, 255, 255, 255 }, buffer);
-            EndianBitConverter.LittleEndianConverter.CopyBytes(257L, buffer, 0);
+            EndianBitConverter.GetConverter(Endianness.LittleEndian).CopyBytes(257L, buffer, 0);
             this.CheckBytes(new byte[] { 1, 1, 0, 0, 0, 0, 0, 0 }, buffer);
         }
 
@@ -192,27 +192,27 @@ namespace ImageSharp.Tests.IO
         {
             byte[] buffer = new byte[8];
 
-            EndianBitConverter.LittleEndianConverter.CopyBytes(0UL, buffer, 0);
+            EndianBitConverter.GetConverter(Endianness.LittleEndian).CopyBytes(0UL, buffer, 0);
             this.CheckBytes(new byte[] { 0, 0, 0, 0, 0, 0, 0, 0 }, buffer);
-            EndianBitConverter.LittleEndianConverter.CopyBytes(1UL, buffer, 0);
+            EndianBitConverter.GetConverter(Endianness.LittleEndian).CopyBytes(1UL, buffer, 0);
             this.CheckBytes(new byte[] { 1, 0, 0, 0, 0, 0, 0, 0 }, buffer);
-            EndianBitConverter.LittleEndianConverter.CopyBytes(256UL, buffer, 0);
+            EndianBitConverter.GetConverter(Endianness.LittleEndian).CopyBytes(256UL, buffer, 0);
             this.CheckBytes(new byte[] { 0, 1, 0, 0, 0, 0, 0, 0 }, buffer);
-            EndianBitConverter.LittleEndianConverter.CopyBytes(65536UL, buffer, 0);
+            EndianBitConverter.GetConverter(Endianness.LittleEndian).CopyBytes(65536UL, buffer, 0);
             this.CheckBytes(new byte[] { 0, 0, 1, 0, 0, 0, 0, 0 }, buffer);
-            EndianBitConverter.LittleEndianConverter.CopyBytes(16777216UL, buffer, 0);
+            EndianBitConverter.GetConverter(Endianness.LittleEndian).CopyBytes(16777216UL, buffer, 0);
             this.CheckBytes(new byte[] { 0, 0, 0, 1, 0, 0, 0, 0 }, buffer);
-            EndianBitConverter.LittleEndianConverter.CopyBytes(4294967296UL, buffer, 0);
+            EndianBitConverter.GetConverter(Endianness.LittleEndian).CopyBytes(4294967296UL, buffer, 0);
             this.CheckBytes(new byte[] { 0, 0, 0, 0, 1, 0, 0, 0 }, buffer);
-            EndianBitConverter.LittleEndianConverter.CopyBytes(1099511627776UL, buffer, 0);
+            EndianBitConverter.GetConverter(Endianness.LittleEndian).CopyBytes(1099511627776UL, buffer, 0);
             this.CheckBytes(new byte[] { 0, 0, 0, 0, 0, 1, 0, 0 }, buffer);
-            EndianBitConverter.LittleEndianConverter.CopyBytes(1099511627776UL * 256, buffer, 0);
+            EndianBitConverter.GetConverter(Endianness.LittleEndian).CopyBytes(1099511627776UL * 256, buffer, 0);
             this.CheckBytes(new byte[] { 0, 0, 0, 0, 0, 0, 1, 0 }, buffer);
-            EndianBitConverter.LittleEndianConverter.CopyBytes(1099511627776UL * 256 * 256, buffer, 0);
+            EndianBitConverter.GetConverter(Endianness.LittleEndian).CopyBytes(1099511627776UL * 256 * 256, buffer, 0);
             this.CheckBytes(new byte[] { 0, 0, 0, 0, 0, 0, 0, 1 }, buffer);
-            EndianBitConverter.LittleEndianConverter.CopyBytes(ulong.MaxValue, buffer, 0);
+            EndianBitConverter.GetConverter(Endianness.LittleEndian).CopyBytes(ulong.MaxValue, buffer, 0);
             this.CheckBytes(new byte[] { 255, 255, 255, 255, 255, 255, 255, 255 }, buffer);
-            EndianBitConverter.LittleEndianConverter.CopyBytes(257UL, buffer, 0);
+            EndianBitConverter.GetConverter(Endianness.LittleEndian).CopyBytes(257UL, buffer, 0);
             this.CheckBytes(new byte[] { 1, 1, 0, 0, 0, 0, 0, 0 }, buffer);
         }
 

--- a/tests/ImageSharp.Tests/IO/LittleEndianBitConverter.GetBytesTests.cs
+++ b/tests/ImageSharp.Tests/IO/LittleEndianBitConverter.GetBytesTests.cs
@@ -9,7 +9,7 @@ namespace ImageSharp.Tests.IO
     using Xunit;
 
     /// <summary>
-    /// The <see cref="LittleEndianBitConverter"/> tests.
+    /// The <see cref="NativeBitConverter"/> tests.
     /// </summary>
     public class LittleEndianBitConverterGetBytesTests
     {
@@ -19,8 +19,8 @@ namespace ImageSharp.Tests.IO
         [Fact]
         public void GetBytesBoolean()
         {
-            this.CheckBytes(new byte[] { 0 }, EndianBitConverter.LittleEndianConverter.GetBytes(false));
-            this.CheckBytes(new byte[] { 1 }, EndianBitConverter.LittleEndianConverter.GetBytes(true));
+            this.CheckBytes(new byte[] { 0 }, EndianBitConverter.GetConverter(Endianness.LittleEndian).GetBytes(false));
+            this.CheckBytes(new byte[] { 1 }, EndianBitConverter.GetConverter(Endianness.LittleEndian).GetBytes(true));
         }
 
         /// <summary>
@@ -29,11 +29,11 @@ namespace ImageSharp.Tests.IO
         [Fact]
         public void GetBytesShort()
         {
-            this.CheckBytes(new byte[] { 0, 0 }, EndianBitConverter.LittleEndianConverter.GetBytes((short)0));
-            this.CheckBytes(new byte[] { 1, 0 }, EndianBitConverter.LittleEndianConverter.GetBytes((short)1));
-            this.CheckBytes(new byte[] { 0, 1 }, EndianBitConverter.LittleEndianConverter.GetBytes((short)256));
-            this.CheckBytes(new byte[] { 255, 255 }, EndianBitConverter.LittleEndianConverter.GetBytes((short)-1));
-            this.CheckBytes(new byte[] { 1, 1 }, EndianBitConverter.LittleEndianConverter.GetBytes((short)257));
+            this.CheckBytes(new byte[] { 0, 0 }, EndianBitConverter.GetConverter(Endianness.LittleEndian).GetBytes((short)0));
+            this.CheckBytes(new byte[] { 1, 0 }, EndianBitConverter.GetConverter(Endianness.LittleEndian).GetBytes((short)1));
+            this.CheckBytes(new byte[] { 0, 1 }, EndianBitConverter.GetConverter(Endianness.LittleEndian).GetBytes((short)256));
+            this.CheckBytes(new byte[] { 255, 255 }, EndianBitConverter.GetConverter(Endianness.LittleEndian).GetBytes((short)-1));
+            this.CheckBytes(new byte[] { 1, 1 }, EndianBitConverter.GetConverter(Endianness.LittleEndian).GetBytes((short)257));
         }
 
         /// <summary>
@@ -42,11 +42,11 @@ namespace ImageSharp.Tests.IO
         [Fact]
         public void GetBytesUShort()
         {
-            this.CheckBytes(new byte[] { 0, 0 }, EndianBitConverter.LittleEndianConverter.GetBytes((ushort)0));
-            this.CheckBytes(new byte[] { 1, 0 }, EndianBitConverter.LittleEndianConverter.GetBytes((ushort)1));
-            this.CheckBytes(new byte[] { 0, 1 }, EndianBitConverter.LittleEndianConverter.GetBytes((ushort)256));
-            this.CheckBytes(new byte[] { 255, 255 }, EndianBitConverter.LittleEndianConverter.GetBytes(ushort.MaxValue));
-            this.CheckBytes(new byte[] { 1, 1 }, EndianBitConverter.LittleEndianConverter.GetBytes((ushort)257));
+            this.CheckBytes(new byte[] { 0, 0 }, EndianBitConverter.GetConverter(Endianness.LittleEndian).GetBytes((ushort)0));
+            this.CheckBytes(new byte[] { 1, 0 }, EndianBitConverter.GetConverter(Endianness.LittleEndian).GetBytes((ushort)1));
+            this.CheckBytes(new byte[] { 0, 1 }, EndianBitConverter.GetConverter(Endianness.LittleEndian).GetBytes((ushort)256));
+            this.CheckBytes(new byte[] { 255, 255 }, EndianBitConverter.GetConverter(Endianness.LittleEndian).GetBytes(ushort.MaxValue));
+            this.CheckBytes(new byte[] { 1, 1 }, EndianBitConverter.GetConverter(Endianness.LittleEndian).GetBytes((ushort)257));
         }
 
         /// <summary>
@@ -55,13 +55,13 @@ namespace ImageSharp.Tests.IO
         [Fact]
         public void GetBytesInt()
         {
-            this.CheckBytes(new byte[] { 0, 0, 0, 0 }, EndianBitConverter.LittleEndianConverter.GetBytes(0));
-            this.CheckBytes(new byte[] { 1, 0, 0, 0 }, EndianBitConverter.LittleEndianConverter.GetBytes(1));
-            this.CheckBytes(new byte[] { 0, 1, 0, 0 }, EndianBitConverter.LittleEndianConverter.GetBytes(256));
-            this.CheckBytes(new byte[] { 0, 0, 1, 0 }, EndianBitConverter.LittleEndianConverter.GetBytes(65536));
-            this.CheckBytes(new byte[] { 0, 0, 0, 1 }, EndianBitConverter.LittleEndianConverter.GetBytes(16777216));
-            this.CheckBytes(new byte[] { 255, 255, 255, 255 }, EndianBitConverter.LittleEndianConverter.GetBytes(-1));
-            this.CheckBytes(new byte[] { 1, 1, 0, 0 }, EndianBitConverter.LittleEndianConverter.GetBytes(257));
+            this.CheckBytes(new byte[] { 0, 0, 0, 0 }, EndianBitConverter.GetConverter(Endianness.LittleEndian).GetBytes(0));
+            this.CheckBytes(new byte[] { 1, 0, 0, 0 }, EndianBitConverter.GetConverter(Endianness.LittleEndian).GetBytes(1));
+            this.CheckBytes(new byte[] { 0, 1, 0, 0 }, EndianBitConverter.GetConverter(Endianness.LittleEndian).GetBytes(256));
+            this.CheckBytes(new byte[] { 0, 0, 1, 0 }, EndianBitConverter.GetConverter(Endianness.LittleEndian).GetBytes(65536));
+            this.CheckBytes(new byte[] { 0, 0, 0, 1 }, EndianBitConverter.GetConverter(Endianness.LittleEndian).GetBytes(16777216));
+            this.CheckBytes(new byte[] { 255, 255, 255, 255 }, EndianBitConverter.GetConverter(Endianness.LittleEndian).GetBytes(-1));
+            this.CheckBytes(new byte[] { 1, 1, 0, 0 }, EndianBitConverter.GetConverter(Endianness.LittleEndian).GetBytes(257));
         }
 
         /// <summary>
@@ -70,13 +70,13 @@ namespace ImageSharp.Tests.IO
         [Fact]
         public void GetBytesUInt()
         {
-            this.CheckBytes(new byte[] { 0, 0, 0, 0 }, EndianBitConverter.LittleEndianConverter.GetBytes((uint)0));
-            this.CheckBytes(new byte[] { 1, 0, 0, 0 }, EndianBitConverter.LittleEndianConverter.GetBytes((uint)1));
-            this.CheckBytes(new byte[] { 0, 1, 0, 0 }, EndianBitConverter.LittleEndianConverter.GetBytes((uint)256));
-            this.CheckBytes(new byte[] { 0, 0, 1, 0 }, EndianBitConverter.LittleEndianConverter.GetBytes((uint)65536));
-            this.CheckBytes(new byte[] { 0, 0, 0, 1 }, EndianBitConverter.LittleEndianConverter.GetBytes((uint)16777216));
-            this.CheckBytes(new byte[] { 255, 255, 255, 255 }, EndianBitConverter.LittleEndianConverter.GetBytes(uint.MaxValue));
-            this.CheckBytes(new byte[] { 1, 1, 0, 0 }, EndianBitConverter.LittleEndianConverter.GetBytes((uint)257));
+            this.CheckBytes(new byte[] { 0, 0, 0, 0 }, EndianBitConverter.GetConverter(Endianness.LittleEndian).GetBytes((uint)0));
+            this.CheckBytes(new byte[] { 1, 0, 0, 0 }, EndianBitConverter.GetConverter(Endianness.LittleEndian).GetBytes((uint)1));
+            this.CheckBytes(new byte[] { 0, 1, 0, 0 }, EndianBitConverter.GetConverter(Endianness.LittleEndian).GetBytes((uint)256));
+            this.CheckBytes(new byte[] { 0, 0, 1, 0 }, EndianBitConverter.GetConverter(Endianness.LittleEndian).GetBytes((uint)65536));
+            this.CheckBytes(new byte[] { 0, 0, 0, 1 }, EndianBitConverter.GetConverter(Endianness.LittleEndian).GetBytes((uint)16777216));
+            this.CheckBytes(new byte[] { 255, 255, 255, 255 }, EndianBitConverter.GetConverter(Endianness.LittleEndian).GetBytes(uint.MaxValue));
+            this.CheckBytes(new byte[] { 1, 1, 0, 0 }, EndianBitConverter.GetConverter(Endianness.LittleEndian).GetBytes((uint)257));
         }
 
         /// <summary>
@@ -85,17 +85,17 @@ namespace ImageSharp.Tests.IO
         [Fact]
         public void GetBytesLong()
         {
-            this.CheckBytes(new byte[] { 0, 0, 0, 0, 0, 0, 0, 0 }, EndianBitConverter.LittleEndianConverter.GetBytes(0L));
-            this.CheckBytes(new byte[] { 1, 0, 0, 0, 0, 0, 0, 0 }, EndianBitConverter.LittleEndianConverter.GetBytes(1L));
-            this.CheckBytes(new byte[] { 0, 1, 0, 0, 0, 0, 0, 0 }, EndianBitConverter.LittleEndianConverter.GetBytes(256L));
-            this.CheckBytes(new byte[] { 0, 0, 1, 0, 0, 0, 0, 0 }, EndianBitConverter.LittleEndianConverter.GetBytes(65536L));
-            this.CheckBytes(new byte[] { 0, 0, 0, 1, 0, 0, 0, 0 }, EndianBitConverter.LittleEndianConverter.GetBytes(16777216L));
-            this.CheckBytes(new byte[] { 0, 0, 0, 0, 1, 0, 0, 0 }, EndianBitConverter.LittleEndianConverter.GetBytes(4294967296L));
-            this.CheckBytes(new byte[] { 0, 0, 0, 0, 0, 1, 0, 0 }, EndianBitConverter.LittleEndianConverter.GetBytes(1099511627776L));
-            this.CheckBytes(new byte[] { 0, 0, 0, 0, 0, 0, 1, 0 }, EndianBitConverter.LittleEndianConverter.GetBytes(1099511627776L * 256));
-            this.CheckBytes(new byte[] { 0, 0, 0, 0, 0, 0, 0, 1 }, EndianBitConverter.LittleEndianConverter.GetBytes(1099511627776L * 256 * 256));
-            this.CheckBytes(new byte[] { 255, 255, 255, 255, 255, 255, 255, 255 }, EndianBitConverter.LittleEndianConverter.GetBytes(-1L));
-            this.CheckBytes(new byte[] { 1, 1, 0, 0, 0, 0, 0, 0 }, EndianBitConverter.LittleEndianConverter.GetBytes(257L));
+            this.CheckBytes(new byte[] { 0, 0, 0, 0, 0, 0, 0, 0 }, EndianBitConverter.GetConverter(Endianness.LittleEndian).GetBytes(0L));
+            this.CheckBytes(new byte[] { 1, 0, 0, 0, 0, 0, 0, 0 }, EndianBitConverter.GetConverter(Endianness.LittleEndian).GetBytes(1L));
+            this.CheckBytes(new byte[] { 0, 1, 0, 0, 0, 0, 0, 0 }, EndianBitConverter.GetConverter(Endianness.LittleEndian).GetBytes(256L));
+            this.CheckBytes(new byte[] { 0, 0, 1, 0, 0, 0, 0, 0 }, EndianBitConverter.GetConverter(Endianness.LittleEndian).GetBytes(65536L));
+            this.CheckBytes(new byte[] { 0, 0, 0, 1, 0, 0, 0, 0 }, EndianBitConverter.GetConverter(Endianness.LittleEndian).GetBytes(16777216L));
+            this.CheckBytes(new byte[] { 0, 0, 0, 0, 1, 0, 0, 0 }, EndianBitConverter.GetConverter(Endianness.LittleEndian).GetBytes(4294967296L));
+            this.CheckBytes(new byte[] { 0, 0, 0, 0, 0, 1, 0, 0 }, EndianBitConverter.GetConverter(Endianness.LittleEndian).GetBytes(1099511627776L));
+            this.CheckBytes(new byte[] { 0, 0, 0, 0, 0, 0, 1, 0 }, EndianBitConverter.GetConverter(Endianness.LittleEndian).GetBytes(1099511627776L * 256));
+            this.CheckBytes(new byte[] { 0, 0, 0, 0, 0, 0, 0, 1 }, EndianBitConverter.GetConverter(Endianness.LittleEndian).GetBytes(1099511627776L * 256 * 256));
+            this.CheckBytes(new byte[] { 255, 255, 255, 255, 255, 255, 255, 255 }, EndianBitConverter.GetConverter(Endianness.LittleEndian).GetBytes(-1L));
+            this.CheckBytes(new byte[] { 1, 1, 0, 0, 0, 0, 0, 0 }, EndianBitConverter.GetConverter(Endianness.LittleEndian).GetBytes(257L));
         }
 
         /// <summary>
@@ -104,17 +104,17 @@ namespace ImageSharp.Tests.IO
         [Fact]
         public void GetBytesULong()
         {
-            this.CheckBytes(new byte[] { 0, 0, 0, 0, 0, 0, 0, 0 }, EndianBitConverter.LittleEndianConverter.GetBytes(0UL));
-            this.CheckBytes(new byte[] { 1, 0, 0, 0, 0, 0, 0, 0 }, EndianBitConverter.LittleEndianConverter.GetBytes(1UL));
-            this.CheckBytes(new byte[] { 0, 1, 0, 0, 0, 0, 0, 0 }, EndianBitConverter.LittleEndianConverter.GetBytes(256UL));
-            this.CheckBytes(new byte[] { 0, 0, 1, 0, 0, 0, 0, 0 }, EndianBitConverter.LittleEndianConverter.GetBytes(65536UL));
-            this.CheckBytes(new byte[] { 0, 0, 0, 1, 0, 0, 0, 0 }, EndianBitConverter.LittleEndianConverter.GetBytes(16777216UL));
-            this.CheckBytes(new byte[] { 0, 0, 0, 0, 1, 0, 0, 0 }, EndianBitConverter.LittleEndianConverter.GetBytes(4294967296UL));
-            this.CheckBytes(new byte[] { 0, 0, 0, 0, 0, 1, 0, 0 }, EndianBitConverter.LittleEndianConverter.GetBytes(1099511627776UL));
-            this.CheckBytes(new byte[] { 0, 0, 0, 0, 0, 0, 1, 0 }, EndianBitConverter.LittleEndianConverter.GetBytes(1099511627776UL * 256));
-            this.CheckBytes(new byte[] { 0, 0, 0, 0, 0, 0, 0, 1 }, EndianBitConverter.LittleEndianConverter.GetBytes(1099511627776UL * 256 * 256));
-            this.CheckBytes(new byte[] { 255, 255, 255, 255, 255, 255, 255, 255 }, EndianBitConverter.LittleEndianConverter.GetBytes(ulong.MaxValue));
-            this.CheckBytes(new byte[] { 1, 1, 0, 0, 0, 0, 0, 0 }, EndianBitConverter.LittleEndianConverter.GetBytes(257UL));
+            this.CheckBytes(new byte[] { 0, 0, 0, 0, 0, 0, 0, 0 }, EndianBitConverter.GetConverter(Endianness.LittleEndian).GetBytes(0UL));
+            this.CheckBytes(new byte[] { 1, 0, 0, 0, 0, 0, 0, 0 }, EndianBitConverter.GetConverter(Endianness.LittleEndian).GetBytes(1UL));
+            this.CheckBytes(new byte[] { 0, 1, 0, 0, 0, 0, 0, 0 }, EndianBitConverter.GetConverter(Endianness.LittleEndian).GetBytes(256UL));
+            this.CheckBytes(new byte[] { 0, 0, 1, 0, 0, 0, 0, 0 }, EndianBitConverter.GetConverter(Endianness.LittleEndian).GetBytes(65536UL));
+            this.CheckBytes(new byte[] { 0, 0, 0, 1, 0, 0, 0, 0 }, EndianBitConverter.GetConverter(Endianness.LittleEndian).GetBytes(16777216UL));
+            this.CheckBytes(new byte[] { 0, 0, 0, 0, 1, 0, 0, 0 }, EndianBitConverter.GetConverter(Endianness.LittleEndian).GetBytes(4294967296UL));
+            this.CheckBytes(new byte[] { 0, 0, 0, 0, 0, 1, 0, 0 }, EndianBitConverter.GetConverter(Endianness.LittleEndian).GetBytes(1099511627776UL));
+            this.CheckBytes(new byte[] { 0, 0, 0, 0, 0, 0, 1, 0 }, EndianBitConverter.GetConverter(Endianness.LittleEndian).GetBytes(1099511627776UL * 256));
+            this.CheckBytes(new byte[] { 0, 0, 0, 0, 0, 0, 0, 1 }, EndianBitConverter.GetConverter(Endianness.LittleEndian).GetBytes(1099511627776UL * 256 * 256));
+            this.CheckBytes(new byte[] { 255, 255, 255, 255, 255, 255, 255, 255 }, EndianBitConverter.GetConverter(Endianness.LittleEndian).GetBytes(ulong.MaxValue));
+            this.CheckBytes(new byte[] { 1, 1, 0, 0, 0, 0, 0, 0 }, EndianBitConverter.GetConverter(Endianness.LittleEndian).GetBytes(257UL));
         }
 
         /// <summary>

--- a/tests/ImageSharp.Tests/IO/LittleEndianBitConverter.ToTypeTests.cs
+++ b/tests/ImageSharp.Tests/IO/LittleEndianBitConverter.ToTypeTests.cs
@@ -10,44 +10,44 @@ namespace ImageSharp.Tests.IO
     using Xunit;
 
     /// <summary>
-    /// The <see cref="LittleEndianBitConverter"/> tests.
+    /// The <see cref="NativeBitConverter"/> tests.
     /// </summary>
     public class LittleEndianBitConverterToTypeTests
     {
         [Fact]
         public void CopyToWithNullBufferThrowsException()
         {
-            Assert.Throws<ArgumentNullException>(() => EndianBitConverter.LittleEndianConverter.ToBoolean(null, 0));
-            Assert.Throws<ArgumentNullException>(() => EndianBitConverter.LittleEndianConverter.ToInt16(null, 0));
-            Assert.Throws<ArgumentNullException>(() => EndianBitConverter.LittleEndianConverter.ToUInt16(null, 0));
-            Assert.Throws<ArgumentNullException>(() => EndianBitConverter.LittleEndianConverter.ToInt32(null, 0));
-            Assert.Throws<ArgumentNullException>(() => EndianBitConverter.LittleEndianConverter.ToUInt32(null, 0));
-            Assert.Throws<ArgumentNullException>(() => EndianBitConverter.LittleEndianConverter.ToInt64(null, 0));
-            Assert.Throws<ArgumentNullException>(() => EndianBitConverter.LittleEndianConverter.ToUInt64(null, 0));
+            Assert.Throws<ArgumentNullException>(() => EndianBitConverter.GetConverter(Endianness.LittleEndian).ToBoolean(null, 0));
+            Assert.Throws<ArgumentNullException>(() => EndianBitConverter.GetConverter(Endianness.LittleEndian).ToInt16(null, 0));
+            Assert.Throws<ArgumentNullException>(() => EndianBitConverter.GetConverter(Endianness.LittleEndian).ToUInt16(null, 0));
+            Assert.Throws<ArgumentNullException>(() => EndianBitConverter.GetConverter(Endianness.LittleEndian).ToInt32(null, 0));
+            Assert.Throws<ArgumentNullException>(() => EndianBitConverter.GetConverter(Endianness.LittleEndian).ToUInt32(null, 0));
+            Assert.Throws<ArgumentNullException>(() => EndianBitConverter.GetConverter(Endianness.LittleEndian).ToInt64(null, 0));
+            Assert.Throws<ArgumentNullException>(() => EndianBitConverter.GetConverter(Endianness.LittleEndian).ToUInt64(null, 0));
         }
 
         [Fact]
         public void CopyToWithIndexTooBigThrowsException()
         {
-            Assert.Throws<ArgumentOutOfRangeException>(() => EndianBitConverter.LittleEndianConverter.ToBoolean(new byte[1], 1));
-            Assert.Throws<ArgumentOutOfRangeException>(() => EndianBitConverter.LittleEndianConverter.ToInt16(new byte[2], 1));
-            Assert.Throws<ArgumentOutOfRangeException>(() => EndianBitConverter.LittleEndianConverter.ToUInt16(new byte[2], 1));
-            Assert.Throws<ArgumentOutOfRangeException>(() => EndianBitConverter.LittleEndianConverter.ToInt32(new byte[4], 1));
-            Assert.Throws<ArgumentOutOfRangeException>(() => EndianBitConverter.LittleEndianConverter.ToUInt32(new byte[4], 1));
-            Assert.Throws<ArgumentOutOfRangeException>(() => EndianBitConverter.LittleEndianConverter.ToInt64(new byte[8], 1));
-            Assert.Throws<ArgumentOutOfRangeException>(() => EndianBitConverter.LittleEndianConverter.ToUInt64(new byte[8], 1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => EndianBitConverter.GetConverter(Endianness.LittleEndian).ToBoolean(new byte[1], 1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => EndianBitConverter.GetConverter(Endianness.LittleEndian).ToInt16(new byte[2], 1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => EndianBitConverter.GetConverter(Endianness.LittleEndian).ToUInt16(new byte[2], 1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => EndianBitConverter.GetConverter(Endianness.LittleEndian).ToInt32(new byte[4], 1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => EndianBitConverter.GetConverter(Endianness.LittleEndian).ToUInt32(new byte[4], 1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => EndianBitConverter.GetConverter(Endianness.LittleEndian).ToInt64(new byte[8], 1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => EndianBitConverter.GetConverter(Endianness.LittleEndian).ToUInt64(new byte[8], 1));
         }
 
         [Fact]
         public void CopyToWithBufferTooSmallThrowsException()
         {
-            Assert.Throws<ArgumentOutOfRangeException>(() => EndianBitConverter.LittleEndianConverter.ToBoolean(new byte[0], 0));
-            Assert.Throws<ArgumentOutOfRangeException>(() => EndianBitConverter.LittleEndianConverter.ToInt16(new byte[1], 0));
-            Assert.Throws<ArgumentOutOfRangeException>(() => EndianBitConverter.LittleEndianConverter.ToUInt16(new byte[1], 0));
-            Assert.Throws<ArgumentOutOfRangeException>(() => EndianBitConverter.LittleEndianConverter.ToInt32(new byte[3], 0));
-            Assert.Throws<ArgumentOutOfRangeException>(() => EndianBitConverter.LittleEndianConverter.ToUInt32(new byte[3], 0));
-            Assert.Throws<ArgumentOutOfRangeException>(() => EndianBitConverter.LittleEndianConverter.ToInt64(new byte[7], 0));
-            Assert.Throws<ArgumentOutOfRangeException>(() => EndianBitConverter.LittleEndianConverter.ToUInt64(new byte[7], 0));
+            Assert.Throws<ArgumentOutOfRangeException>(() => EndianBitConverter.GetConverter(Endianness.LittleEndian).ToBoolean(new byte[0], 0));
+            Assert.Throws<ArgumentOutOfRangeException>(() => EndianBitConverter.GetConverter(Endianness.LittleEndian).ToInt16(new byte[1], 0));
+            Assert.Throws<ArgumentOutOfRangeException>(() => EndianBitConverter.GetConverter(Endianness.LittleEndian).ToUInt16(new byte[1], 0));
+            Assert.Throws<ArgumentOutOfRangeException>(() => EndianBitConverter.GetConverter(Endianness.LittleEndian).ToInt32(new byte[3], 0));
+            Assert.Throws<ArgumentOutOfRangeException>(() => EndianBitConverter.GetConverter(Endianness.LittleEndian).ToUInt32(new byte[3], 0));
+            Assert.Throws<ArgumentOutOfRangeException>(() => EndianBitConverter.GetConverter(Endianness.LittleEndian).ToInt64(new byte[7], 0));
+            Assert.Throws<ArgumentOutOfRangeException>(() => EndianBitConverter.GetConverter(Endianness.LittleEndian).ToUInt64(new byte[7], 0));
         }
 
         /// <summary>
@@ -56,11 +56,11 @@ namespace ImageSharp.Tests.IO
         [Fact]
         public void ToBoolean()
         {
-            Assert.Equal(false, EndianBitConverter.LittleEndianConverter.ToBoolean(new byte[] { 0 }, 0));
-            Assert.Equal(true, EndianBitConverter.LittleEndianConverter.ToBoolean(new byte[] { 1 }, 0));
+            Assert.Equal(false, EndianBitConverter.GetConverter(Endianness.LittleEndian).ToBoolean(new byte[] { 0 }, 0));
+            Assert.Equal(true, EndianBitConverter.GetConverter(Endianness.LittleEndian).ToBoolean(new byte[] { 1 }, 0));
 
-            Assert.Equal(false, EndianBitConverter.LittleEndianConverter.ToBoolean(new byte[] { 1, 0 }, 1));
-            Assert.Equal(true, EndianBitConverter.LittleEndianConverter.ToBoolean(new byte[] { 0, 1 }, 1));
+            Assert.Equal(false, EndianBitConverter.GetConverter(Endianness.LittleEndian).ToBoolean(new byte[] { 1, 0 }, 1));
+            Assert.Equal(true, EndianBitConverter.GetConverter(Endianness.LittleEndian).ToBoolean(new byte[] { 0, 1 }, 1));
         }
 
         /// <summary>
@@ -69,17 +69,17 @@ namespace ImageSharp.Tests.IO
         [Fact]
         public void ToInt16()
         {
-            Assert.Equal((short)0, EndianBitConverter.LittleEndianConverter.ToInt16(new byte[] { 0, 0 }, 0));
-            Assert.Equal((short)1, EndianBitConverter.LittleEndianConverter.ToInt16(new byte[] { 1, 0 }, 0));
-            Assert.Equal((short)256, EndianBitConverter.LittleEndianConverter.ToInt16(new byte[] { 0, 1 }, 0));
-            Assert.Equal((short)-1, EndianBitConverter.LittleEndianConverter.ToInt16(new byte[] { 255, 255 }, 0));
-            Assert.Equal((short)257, EndianBitConverter.LittleEndianConverter.ToInt16(new byte[] { 1, 1 }, 0));
+            Assert.Equal((short)0, EndianBitConverter.GetConverter(Endianness.LittleEndian).ToInt16(new byte[] { 0, 0 }, 0));
+            Assert.Equal((short)1, EndianBitConverter.GetConverter(Endianness.LittleEndian).ToInt16(new byte[] { 1, 0 }, 0));
+            Assert.Equal((short)256, EndianBitConverter.GetConverter(Endianness.LittleEndian).ToInt16(new byte[] { 0, 1 }, 0));
+            Assert.Equal((short)-1, EndianBitConverter.GetConverter(Endianness.LittleEndian).ToInt16(new byte[] { 255, 255 }, 0));
+            Assert.Equal((short)257, EndianBitConverter.GetConverter(Endianness.LittleEndian).ToInt16(new byte[] { 1, 1 }, 0));
 
-            Assert.Equal((short)0, EndianBitConverter.LittleEndianConverter.ToInt16(new byte[] { 1, 0, 0 }, 1));
-            Assert.Equal((short)1, EndianBitConverter.LittleEndianConverter.ToInt16(new byte[] { 0, 1, 0 }, 1));
-            Assert.Equal((short)256, EndianBitConverter.LittleEndianConverter.ToInt16(new byte[] { 1, 0, 1 }, 1));
-            Assert.Equal((short)-1, EndianBitConverter.LittleEndianConverter.ToInt16(new byte[] { 0, 255, 255 }, 1));
-            Assert.Equal((short)257, EndianBitConverter.LittleEndianConverter.ToInt16(new byte[] { 0, 1, 1 }, 1));
+            Assert.Equal((short)0, EndianBitConverter.GetConverter(Endianness.LittleEndian).ToInt16(new byte[] { 1, 0, 0 }, 1));
+            Assert.Equal((short)1, EndianBitConverter.GetConverter(Endianness.LittleEndian).ToInt16(new byte[] { 0, 1, 0 }, 1));
+            Assert.Equal((short)256, EndianBitConverter.GetConverter(Endianness.LittleEndian).ToInt16(new byte[] { 1, 0, 1 }, 1));
+            Assert.Equal((short)-1, EndianBitConverter.GetConverter(Endianness.LittleEndian).ToInt16(new byte[] { 0, 255, 255 }, 1));
+            Assert.Equal((short)257, EndianBitConverter.GetConverter(Endianness.LittleEndian).ToInt16(new byte[] { 0, 1, 1 }, 1));
         }
 
         /// <summary>
@@ -88,17 +88,17 @@ namespace ImageSharp.Tests.IO
         [Fact]
         public void ToUInt16()
         {
-            Assert.Equal((ushort)0, EndianBitConverter.LittleEndianConverter.ToUInt16(new byte[] { 0, 0 }, 0));
-            Assert.Equal((ushort)1, EndianBitConverter.LittleEndianConverter.ToUInt16(new byte[] { 1, 0 }, 0));
-            Assert.Equal((ushort)256, EndianBitConverter.LittleEndianConverter.ToUInt16(new byte[] { 0, 1 }, 0));
-            Assert.Equal(ushort.MaxValue, EndianBitConverter.LittleEndianConverter.ToUInt16(new byte[] { 255, 255 }, 0));
-            Assert.Equal((ushort)257, EndianBitConverter.LittleEndianConverter.ToUInt16(new byte[] { 1, 1 }, 0));
+            Assert.Equal((ushort)0, EndianBitConverter.GetConverter(Endianness.LittleEndian).ToUInt16(new byte[] { 0, 0 }, 0));
+            Assert.Equal((ushort)1, EndianBitConverter.GetConverter(Endianness.LittleEndian).ToUInt16(new byte[] { 1, 0 }, 0));
+            Assert.Equal((ushort)256, EndianBitConverter.GetConverter(Endianness.LittleEndian).ToUInt16(new byte[] { 0, 1 }, 0));
+            Assert.Equal(ushort.MaxValue, EndianBitConverter.GetConverter(Endianness.LittleEndian).ToUInt16(new byte[] { 255, 255 }, 0));
+            Assert.Equal((ushort)257, EndianBitConverter.GetConverter(Endianness.LittleEndian).ToUInt16(new byte[] { 1, 1 }, 0));
 
-            Assert.Equal((ushort)0, EndianBitConverter.LittleEndianConverter.ToUInt16(new byte[] { 1, 0, 0 }, 1));
-            Assert.Equal((ushort)1, EndianBitConverter.LittleEndianConverter.ToUInt16(new byte[] { 0, 1, 0 }, 1));
-            Assert.Equal((ushort)256, EndianBitConverter.LittleEndianConverter.ToUInt16(new byte[] { 1, 0, 1 }, 1));
-            Assert.Equal(ushort.MaxValue, EndianBitConverter.LittleEndianConverter.ToUInt16(new byte[] { 0, 255, 255 }, 1));
-            Assert.Equal((ushort)257, EndianBitConverter.LittleEndianConverter.ToUInt16(new byte[] { 0, 1, 1 }, 1));
+            Assert.Equal((ushort)0, EndianBitConverter.GetConverter(Endianness.LittleEndian).ToUInt16(new byte[] { 1, 0, 0 }, 1));
+            Assert.Equal((ushort)1, EndianBitConverter.GetConverter(Endianness.LittleEndian).ToUInt16(new byte[] { 0, 1, 0 }, 1));
+            Assert.Equal((ushort)256, EndianBitConverter.GetConverter(Endianness.LittleEndian).ToUInt16(new byte[] { 1, 0, 1 }, 1));
+            Assert.Equal(ushort.MaxValue, EndianBitConverter.GetConverter(Endianness.LittleEndian).ToUInt16(new byte[] { 0, 255, 255 }, 1));
+            Assert.Equal((ushort)257, EndianBitConverter.GetConverter(Endianness.LittleEndian).ToUInt16(new byte[] { 0, 1, 1 }, 1));
         }
 
         /// <summary>
@@ -107,21 +107,21 @@ namespace ImageSharp.Tests.IO
         [Fact]
         public void ToInt32()
         {
-            Assert.Equal(0, EndianBitConverter.LittleEndianConverter.ToInt32(new byte[] { 0, 0, 0, 0 }, 0));
-            Assert.Equal(1, EndianBitConverter.LittleEndianConverter.ToInt32(new byte[] { 1, 0, 0, 0 }, 0));
-            Assert.Equal(256, EndianBitConverter.LittleEndianConverter.ToInt32(new byte[] { 0, 1, 0, 0 }, 0));
-            Assert.Equal(65536, EndianBitConverter.LittleEndianConverter.ToInt32(new byte[] { 0, 0, 1, 0 }, 0));
-            Assert.Equal(16777216, EndianBitConverter.LittleEndianConverter.ToInt32(new byte[] { 0, 0, 0, 1 }, 0));
-            Assert.Equal(-1, EndianBitConverter.LittleEndianConverter.ToInt32(new byte[] { 255, 255, 255, 255 }, 0));
-            Assert.Equal(257, EndianBitConverter.LittleEndianConverter.ToInt32(new byte[] { 1, 1, 0, 0 }, 0));
+            Assert.Equal(0, EndianBitConverter.GetConverter(Endianness.LittleEndian).ToInt32(new byte[] { 0, 0, 0, 0 }, 0));
+            Assert.Equal(1, EndianBitConverter.GetConverter(Endianness.LittleEndian).ToInt32(new byte[] { 1, 0, 0, 0 }, 0));
+            Assert.Equal(256, EndianBitConverter.GetConverter(Endianness.LittleEndian).ToInt32(new byte[] { 0, 1, 0, 0 }, 0));
+            Assert.Equal(65536, EndianBitConverter.GetConverter(Endianness.LittleEndian).ToInt32(new byte[] { 0, 0, 1, 0 }, 0));
+            Assert.Equal(16777216, EndianBitConverter.GetConverter(Endianness.LittleEndian).ToInt32(new byte[] { 0, 0, 0, 1 }, 0));
+            Assert.Equal(-1, EndianBitConverter.GetConverter(Endianness.LittleEndian).ToInt32(new byte[] { 255, 255, 255, 255 }, 0));
+            Assert.Equal(257, EndianBitConverter.GetConverter(Endianness.LittleEndian).ToInt32(new byte[] { 1, 1, 0, 0 }, 0));
 
-            Assert.Equal(0, EndianBitConverter.LittleEndianConverter.ToInt32(new byte[] { 1, 0, 0, 0, 0 }, 1));
-            Assert.Equal(1, EndianBitConverter.LittleEndianConverter.ToInt32(new byte[] { 0, 1, 0, 0, 0 }, 1));
-            Assert.Equal(256, EndianBitConverter.LittleEndianConverter.ToInt32(new byte[] { 1, 0, 1, 0, 0 }, 1));
-            Assert.Equal(65536, EndianBitConverter.LittleEndianConverter.ToInt32(new byte[] { 1, 0, 0, 1, 0 }, 1));
-            Assert.Equal(16777216, EndianBitConverter.LittleEndianConverter.ToInt32(new byte[] { 1, 0, 0, 0, 1 }, 1));
-            Assert.Equal(-1, EndianBitConverter.LittleEndianConverter.ToInt32(new byte[] { 0, 255, 255, 255, 255 }, 1));
-            Assert.Equal(257, EndianBitConverter.LittleEndianConverter.ToInt32(new byte[] { 0, 1, 1, 0, 0 }, 1));
+            Assert.Equal(0, EndianBitConverter.GetConverter(Endianness.LittleEndian).ToInt32(new byte[] { 1, 0, 0, 0, 0 }, 1));
+            Assert.Equal(1, EndianBitConverter.GetConverter(Endianness.LittleEndian).ToInt32(new byte[] { 0, 1, 0, 0, 0 }, 1));
+            Assert.Equal(256, EndianBitConverter.GetConverter(Endianness.LittleEndian).ToInt32(new byte[] { 1, 0, 1, 0, 0 }, 1));
+            Assert.Equal(65536, EndianBitConverter.GetConverter(Endianness.LittleEndian).ToInt32(new byte[] { 1, 0, 0, 1, 0 }, 1));
+            Assert.Equal(16777216, EndianBitConverter.GetConverter(Endianness.LittleEndian).ToInt32(new byte[] { 1, 0, 0, 0, 1 }, 1));
+            Assert.Equal(-1, EndianBitConverter.GetConverter(Endianness.LittleEndian).ToInt32(new byte[] { 0, 255, 255, 255, 255 }, 1));
+            Assert.Equal(257, EndianBitConverter.GetConverter(Endianness.LittleEndian).ToInt32(new byte[] { 0, 1, 1, 0, 0 }, 1));
         }
 
         /// <summary>
@@ -130,21 +130,21 @@ namespace ImageSharp.Tests.IO
         [Fact]
         public void ToUInt32()
         {
-            Assert.Equal((uint)0, EndianBitConverter.LittleEndianConverter.ToUInt32(new byte[] { 0, 0, 0, 0 }, 0));
-            Assert.Equal((uint)1, EndianBitConverter.LittleEndianConverter.ToUInt32(new byte[] { 1, 0, 0, 0 }, 0));
-            Assert.Equal((uint)256, EndianBitConverter.LittleEndianConverter.ToUInt32(new byte[] { 0, 1, 0, 0 }, 0));
-            Assert.Equal((uint)65536, EndianBitConverter.LittleEndianConverter.ToUInt32(new byte[] { 0, 0, 1, 0 }, 0));
-            Assert.Equal((uint)16777216, EndianBitConverter.LittleEndianConverter.ToUInt32(new byte[] { 0, 0, 0, 1 }, 0));
-            Assert.Equal(uint.MaxValue, EndianBitConverter.LittleEndianConverter.ToUInt32(new byte[] { 255, 255, 255, 255 }, 0));
-            Assert.Equal((uint)257, EndianBitConverter.LittleEndianConverter.ToUInt32(new byte[] { 1, 1, 0, 0 }, 0));
+            Assert.Equal((uint)0, EndianBitConverter.GetConverter(Endianness.LittleEndian).ToUInt32(new byte[] { 0, 0, 0, 0 }, 0));
+            Assert.Equal((uint)1, EndianBitConverter.GetConverter(Endianness.LittleEndian).ToUInt32(new byte[] { 1, 0, 0, 0 }, 0));
+            Assert.Equal((uint)256, EndianBitConverter.GetConverter(Endianness.LittleEndian).ToUInt32(new byte[] { 0, 1, 0, 0 }, 0));
+            Assert.Equal((uint)65536, EndianBitConverter.GetConverter(Endianness.LittleEndian).ToUInt32(new byte[] { 0, 0, 1, 0 }, 0));
+            Assert.Equal((uint)16777216, EndianBitConverter.GetConverter(Endianness.LittleEndian).ToUInt32(new byte[] { 0, 0, 0, 1 }, 0));
+            Assert.Equal(uint.MaxValue, EndianBitConverter.GetConverter(Endianness.LittleEndian).ToUInt32(new byte[] { 255, 255, 255, 255 }, 0));
+            Assert.Equal((uint)257, EndianBitConverter.GetConverter(Endianness.LittleEndian).ToUInt32(new byte[] { 1, 1, 0, 0 }, 0));
 
-            Assert.Equal((uint)0, EndianBitConverter.LittleEndianConverter.ToUInt32(new byte[] { 1, 0, 0, 0, 0 }, 1));
-            Assert.Equal((uint)1, EndianBitConverter.LittleEndianConverter.ToUInt32(new byte[] { 0, 1, 0, 0, 0 }, 1));
-            Assert.Equal((uint)256, EndianBitConverter.LittleEndianConverter.ToUInt32(new byte[] { 1, 0, 1, 0, 0 }, 1));
-            Assert.Equal((uint)65536, EndianBitConverter.LittleEndianConverter.ToUInt32(new byte[] { 1, 0, 0, 1, 0 }, 1));
-            Assert.Equal((uint)16777216, EndianBitConverter.LittleEndianConverter.ToUInt32(new byte[] { 1, 0, 0, 0, 1 }, 1));
-            Assert.Equal(uint.MaxValue, EndianBitConverter.LittleEndianConverter.ToUInt32(new byte[] { 0, 255, 255, 255, 255 }, 1));
-            Assert.Equal((uint)257, EndianBitConverter.LittleEndianConverter.ToUInt32(new byte[] { 0, 1, 1, 0, 0 }, 1));
+            Assert.Equal((uint)0, EndianBitConverter.GetConverter(Endianness.LittleEndian).ToUInt32(new byte[] { 1, 0, 0, 0, 0 }, 1));
+            Assert.Equal((uint)1, EndianBitConverter.GetConverter(Endianness.LittleEndian).ToUInt32(new byte[] { 0, 1, 0, 0, 0 }, 1));
+            Assert.Equal((uint)256, EndianBitConverter.GetConverter(Endianness.LittleEndian).ToUInt32(new byte[] { 1, 0, 1, 0, 0 }, 1));
+            Assert.Equal((uint)65536, EndianBitConverter.GetConverter(Endianness.LittleEndian).ToUInt32(new byte[] { 1, 0, 0, 1, 0 }, 1));
+            Assert.Equal((uint)16777216, EndianBitConverter.GetConverter(Endianness.LittleEndian).ToUInt32(new byte[] { 1, 0, 0, 0, 1 }, 1));
+            Assert.Equal(uint.MaxValue, EndianBitConverter.GetConverter(Endianness.LittleEndian).ToUInt32(new byte[] { 0, 255, 255, 255, 255 }, 1));
+            Assert.Equal((uint)257, EndianBitConverter.GetConverter(Endianness.LittleEndian).ToUInt32(new byte[] { 0, 1, 1, 0, 0 }, 1));
         }
 
         /// <summary>
@@ -153,29 +153,29 @@ namespace ImageSharp.Tests.IO
         [Fact]
         public void ToInt64()
         {
-            Assert.Equal(0L, EndianBitConverter.LittleEndianConverter.ToInt64(new byte[] { 0, 0, 0, 0, 0, 0, 0, 0 }, 0));
-            Assert.Equal(1L, EndianBitConverter.LittleEndianConverter.ToInt64(new byte[] { 1, 0, 0, 0, 0, 0, 0, 0 }, 0));
-            Assert.Equal(256L, EndianBitConverter.LittleEndianConverter.ToInt64(new byte[] { 0, 1, 0, 0, 0, 0, 0, 0 }, 0));
-            Assert.Equal(65536L, EndianBitConverter.LittleEndianConverter.ToInt64(new byte[] { 0, 0, 1, 0, 0, 0, 0, 0 }, 0));
-            Assert.Equal(16777216L, EndianBitConverter.LittleEndianConverter.ToInt64(new byte[] { 0, 0, 0, 1, 0, 0, 0, 0 }, 0));
-            Assert.Equal(4294967296L, EndianBitConverter.LittleEndianConverter.ToInt64(new byte[] { 0, 0, 0, 0, 1, 0, 0, 0 }, 0));
-            Assert.Equal(1099511627776L, EndianBitConverter.LittleEndianConverter.ToInt64(new byte[] { 0, 0, 0, 0, 0, 1, 0, 0 }, 0));
-            Assert.Equal(1099511627776L * 256, EndianBitConverter.LittleEndianConverter.ToInt64(new byte[] { 0, 0, 0, 0, 0, 0, 1, 0 }, 0));
-            Assert.Equal(1099511627776L * 256 * 256, EndianBitConverter.LittleEndianConverter.ToInt64(new byte[] { 0, 0, 0, 0, 0, 0, 0, 1 }, 0));
-            Assert.Equal(-1L, EndianBitConverter.LittleEndianConverter.ToInt64(new byte[] { 255, 255, 255, 255, 255, 255, 255, 255 }, 0));
-            Assert.Equal(257L, EndianBitConverter.LittleEndianConverter.ToInt64(new byte[] { 1, 1, 0, 0, 0, 0, 0, 0 }, 0));
+            Assert.Equal(0L, EndianBitConverter.GetConverter(Endianness.LittleEndian).ToInt64(new byte[] { 0, 0, 0, 0, 0, 0, 0, 0 }, 0));
+            Assert.Equal(1L, EndianBitConverter.GetConverter(Endianness.LittleEndian).ToInt64(new byte[] { 1, 0, 0, 0, 0, 0, 0, 0 }, 0));
+            Assert.Equal(256L, EndianBitConverter.GetConverter(Endianness.LittleEndian).ToInt64(new byte[] { 0, 1, 0, 0, 0, 0, 0, 0 }, 0));
+            Assert.Equal(65536L, EndianBitConverter.GetConverter(Endianness.LittleEndian).ToInt64(new byte[] { 0, 0, 1, 0, 0, 0, 0, 0 }, 0));
+            Assert.Equal(16777216L, EndianBitConverter.GetConverter(Endianness.LittleEndian).ToInt64(new byte[] { 0, 0, 0, 1, 0, 0, 0, 0 }, 0));
+            Assert.Equal(4294967296L, EndianBitConverter.GetConverter(Endianness.LittleEndian).ToInt64(new byte[] { 0, 0, 0, 0, 1, 0, 0, 0 }, 0));
+            Assert.Equal(1099511627776L, EndianBitConverter.GetConverter(Endianness.LittleEndian).ToInt64(new byte[] { 0, 0, 0, 0, 0, 1, 0, 0 }, 0));
+            Assert.Equal(1099511627776L * 256, EndianBitConverter.GetConverter(Endianness.LittleEndian).ToInt64(new byte[] { 0, 0, 0, 0, 0, 0, 1, 0 }, 0));
+            Assert.Equal(1099511627776L * 256 * 256, EndianBitConverter.GetConverter(Endianness.LittleEndian).ToInt64(new byte[] { 0, 0, 0, 0, 0, 0, 0, 1 }, 0));
+            Assert.Equal(-1L, EndianBitConverter.GetConverter(Endianness.LittleEndian).ToInt64(new byte[] { 255, 255, 255, 255, 255, 255, 255, 255 }, 0));
+            Assert.Equal(257L, EndianBitConverter.GetConverter(Endianness.LittleEndian).ToInt64(new byte[] { 1, 1, 0, 0, 0, 0, 0, 0 }, 0));
 
-            Assert.Equal(0L, EndianBitConverter.LittleEndianConverter.ToInt64(new byte[] { 1, 0, 0, 0, 0, 0, 0, 0, 0 }, 1));
-            Assert.Equal(1L, EndianBitConverter.LittleEndianConverter.ToInt64(new byte[] { 0, 1, 0, 0, 0, 0, 0, 0, 0 }, 1));
-            Assert.Equal(256L, EndianBitConverter.LittleEndianConverter.ToInt64(new byte[] { 1, 0, 1, 0, 0, 0, 0, 0, 0 }, 1));
-            Assert.Equal(65536L, EndianBitConverter.LittleEndianConverter.ToInt64(new byte[] { 1, 0, 0, 1, 0, 0, 0, 0, 0 }, 1));
-            Assert.Equal(16777216L, EndianBitConverter.LittleEndianConverter.ToInt64(new byte[] { 1, 0, 0, 0, 1, 0, 0, 0, 0 }, 1));
-            Assert.Equal(4294967296L, EndianBitConverter.LittleEndianConverter.ToInt64(new byte[] { 1, 0, 0, 0, 0, 1, 0, 0, 0 }, 1));
-            Assert.Equal(1099511627776L, EndianBitConverter.LittleEndianConverter.ToInt64(new byte[] { 1, 0, 0, 0, 0, 0, 1, 0, 0 }, 1));
-            Assert.Equal(1099511627776L * 256, EndianBitConverter.LittleEndianConverter.ToInt64(new byte[] { 1, 0, 0, 0, 0, 0, 0, 1, 0 }, 1));
-            Assert.Equal(1099511627776L * 256 * 256, EndianBitConverter.LittleEndianConverter.ToInt64(new byte[] { 1, 0, 0, 0, 0, 0, 0, 0, 1 }, 1));
-            Assert.Equal(-1L, EndianBitConverter.LittleEndianConverter.ToInt64(new byte[] { 0, 255, 255, 255, 255, 255, 255, 255, 255 }, 1));
-            Assert.Equal(257L, EndianBitConverter.LittleEndianConverter.ToInt64(new byte[] { 0, 1, 1, 0, 0, 0, 0, 0, 0 }, 1));
+            Assert.Equal(0L, EndianBitConverter.GetConverter(Endianness.LittleEndian).ToInt64(new byte[] { 1, 0, 0, 0, 0, 0, 0, 0, 0 }, 1));
+            Assert.Equal(1L, EndianBitConverter.GetConverter(Endianness.LittleEndian).ToInt64(new byte[] { 0, 1, 0, 0, 0, 0, 0, 0, 0 }, 1));
+            Assert.Equal(256L, EndianBitConverter.GetConverter(Endianness.LittleEndian).ToInt64(new byte[] { 1, 0, 1, 0, 0, 0, 0, 0, 0 }, 1));
+            Assert.Equal(65536L, EndianBitConverter.GetConverter(Endianness.LittleEndian).ToInt64(new byte[] { 1, 0, 0, 1, 0, 0, 0, 0, 0 }, 1));
+            Assert.Equal(16777216L, EndianBitConverter.GetConverter(Endianness.LittleEndian).ToInt64(new byte[] { 1, 0, 0, 0, 1, 0, 0, 0, 0 }, 1));
+            Assert.Equal(4294967296L, EndianBitConverter.GetConverter(Endianness.LittleEndian).ToInt64(new byte[] { 1, 0, 0, 0, 0, 1, 0, 0, 0 }, 1));
+            Assert.Equal(1099511627776L, EndianBitConverter.GetConverter(Endianness.LittleEndian).ToInt64(new byte[] { 1, 0, 0, 0, 0, 0, 1, 0, 0 }, 1));
+            Assert.Equal(1099511627776L * 256, EndianBitConverter.GetConverter(Endianness.LittleEndian).ToInt64(new byte[] { 1, 0, 0, 0, 0, 0, 0, 1, 0 }, 1));
+            Assert.Equal(1099511627776L * 256 * 256, EndianBitConverter.GetConverter(Endianness.LittleEndian).ToInt64(new byte[] { 1, 0, 0, 0, 0, 0, 0, 0, 1 }, 1));
+            Assert.Equal(-1L, EndianBitConverter.GetConverter(Endianness.LittleEndian).ToInt64(new byte[] { 0, 255, 255, 255, 255, 255, 255, 255, 255 }, 1));
+            Assert.Equal(257L, EndianBitConverter.GetConverter(Endianness.LittleEndian).ToInt64(new byte[] { 0, 1, 1, 0, 0, 0, 0, 0, 0 }, 1));
         }
 
         /// <summary>
@@ -184,29 +184,29 @@ namespace ImageSharp.Tests.IO
         [Fact]
         public void ToUInt64()
         {
-            Assert.Equal(0UL, EndianBitConverter.LittleEndianConverter.ToUInt64(new byte[] { 0, 0, 0, 0, 0, 0, 0, 0 }, 0));
-            Assert.Equal(1UL, EndianBitConverter.LittleEndianConverter.ToUInt64(new byte[] { 1, 0, 0, 0, 0, 0, 0, 0 }, 0));
-            Assert.Equal(256UL, EndianBitConverter.LittleEndianConverter.ToUInt64(new byte[] { 0, 1, 0, 0, 0, 0, 0, 0 }, 0));
-            Assert.Equal(65536UL, EndianBitConverter.LittleEndianConverter.ToUInt64(new byte[] { 0, 0, 1, 0, 0, 0, 0, 0 }, 0));
-            Assert.Equal(16777216UL, EndianBitConverter.LittleEndianConverter.ToUInt64(new byte[] { 0, 0, 0, 1, 0, 0, 0, 0 }, 0));
-            Assert.Equal(4294967296UL, EndianBitConverter.LittleEndianConverter.ToUInt64(new byte[] { 0, 0, 0, 0, 1, 0, 0, 0 }, 0));
-            Assert.Equal(1099511627776UL, EndianBitConverter.LittleEndianConverter.ToUInt64(new byte[] { 0, 0, 0, 0, 0, 1, 0, 0 }, 0));
-            Assert.Equal(1099511627776UL * 256, EndianBitConverter.LittleEndianConverter.ToUInt64(new byte[] { 0, 0, 0, 0, 0, 0, 1, 0 }, 0));
-            Assert.Equal(1099511627776UL * 256 * 256, EndianBitConverter.LittleEndianConverter.ToUInt64(new byte[] { 0, 0, 0, 0, 0, 0, 0, 1 }, 0));
-            Assert.Equal(ulong.MaxValue, EndianBitConverter.LittleEndianConverter.ToUInt64(new byte[] { 255, 255, 255, 255, 255, 255, 255, 255 }, 0));
-            Assert.Equal(257UL, EndianBitConverter.LittleEndianConverter.ToUInt64(new byte[] { 1, 1, 0, 0, 0, 0, 0, 0 }, 0));
+            Assert.Equal(0UL, EndianBitConverter.GetConverter(Endianness.LittleEndian).ToUInt64(new byte[] { 0, 0, 0, 0, 0, 0, 0, 0 }, 0));
+            Assert.Equal(1UL, EndianBitConverter.GetConverter(Endianness.LittleEndian).ToUInt64(new byte[] { 1, 0, 0, 0, 0, 0, 0, 0 }, 0));
+            Assert.Equal(256UL, EndianBitConverter.GetConverter(Endianness.LittleEndian).ToUInt64(new byte[] { 0, 1, 0, 0, 0, 0, 0, 0 }, 0));
+            Assert.Equal(65536UL, EndianBitConverter.GetConverter(Endianness.LittleEndian).ToUInt64(new byte[] { 0, 0, 1, 0, 0, 0, 0, 0 }, 0));
+            Assert.Equal(16777216UL, EndianBitConverter.GetConverter(Endianness.LittleEndian).ToUInt64(new byte[] { 0, 0, 0, 1, 0, 0, 0, 0 }, 0));
+            Assert.Equal(4294967296UL, EndianBitConverter.GetConverter(Endianness.LittleEndian).ToUInt64(new byte[] { 0, 0, 0, 0, 1, 0, 0, 0 }, 0));
+            Assert.Equal(1099511627776UL, EndianBitConverter.GetConverter(Endianness.LittleEndian).ToUInt64(new byte[] { 0, 0, 0, 0, 0, 1, 0, 0 }, 0));
+            Assert.Equal(1099511627776UL * 256, EndianBitConverter.GetConverter(Endianness.LittleEndian).ToUInt64(new byte[] { 0, 0, 0, 0, 0, 0, 1, 0 }, 0));
+            Assert.Equal(1099511627776UL * 256 * 256, EndianBitConverter.GetConverter(Endianness.LittleEndian).ToUInt64(new byte[] { 0, 0, 0, 0, 0, 0, 0, 1 }, 0));
+            Assert.Equal(ulong.MaxValue, EndianBitConverter.GetConverter(Endianness.LittleEndian).ToUInt64(new byte[] { 255, 255, 255, 255, 255, 255, 255, 255 }, 0));
+            Assert.Equal(257UL, EndianBitConverter.GetConverter(Endianness.LittleEndian).ToUInt64(new byte[] { 1, 1, 0, 0, 0, 0, 0, 0 }, 0));
 
-            Assert.Equal(0UL, EndianBitConverter.LittleEndianConverter.ToUInt64(new byte[] { 1, 0, 0, 0, 0, 0, 0, 0, 0 }, 1));
-            Assert.Equal(1UL, EndianBitConverter.LittleEndianConverter.ToUInt64(new byte[] { 0, 1, 0, 0, 0, 0, 0, 0, 0 }, 1));
-            Assert.Equal(256UL, EndianBitConverter.LittleEndianConverter.ToUInt64(new byte[] { 1, 0, 1, 0, 0, 0, 0, 0, 0 }, 1));
-            Assert.Equal(65536UL, EndianBitConverter.LittleEndianConverter.ToUInt64(new byte[] { 1, 0, 0, 1, 0, 0, 0, 0, 0 }, 1));
-            Assert.Equal(16777216UL, EndianBitConverter.LittleEndianConverter.ToUInt64(new byte[] { 1, 0, 0, 0, 1, 0, 0, 0, 0 }, 1));
-            Assert.Equal(4294967296UL, EndianBitConverter.LittleEndianConverter.ToUInt64(new byte[] { 1, 0, 0, 0, 0, 1, 0, 0, 0 }, 1));
-            Assert.Equal(1099511627776UL, EndianBitConverter.LittleEndianConverter.ToUInt64(new byte[] { 1, 0, 0, 0, 0, 0, 1, 0, 0 }, 1));
-            Assert.Equal(1099511627776UL * 256, EndianBitConverter.LittleEndianConverter.ToUInt64(new byte[] { 1, 0, 0, 0, 0, 0, 0, 1, 0 }, 1));
-            Assert.Equal(1099511627776UL * 256 * 256, EndianBitConverter.LittleEndianConverter.ToUInt64(new byte[] { 1, 0, 0, 0, 0, 0, 0, 0, 1 }, 1));
-            Assert.Equal(ulong.MaxValue, EndianBitConverter.LittleEndianConverter.ToUInt64(new byte[] { 0, 255, 255, 255, 255, 255, 255, 255, 255 }, 1));
-            Assert.Equal(257UL, EndianBitConverter.LittleEndianConverter.ToUInt64(new byte[] { 0, 1, 1, 0, 0, 0, 0, 0, 0 }, 1));
+            Assert.Equal(0UL, EndianBitConverter.GetConverter(Endianness.LittleEndian).ToUInt64(new byte[] { 1, 0, 0, 0, 0, 0, 0, 0, 0 }, 1));
+            Assert.Equal(1UL, EndianBitConverter.GetConverter(Endianness.LittleEndian).ToUInt64(new byte[] { 0, 1, 0, 0, 0, 0, 0, 0, 0 }, 1));
+            Assert.Equal(256UL, EndianBitConverter.GetConverter(Endianness.LittleEndian).ToUInt64(new byte[] { 1, 0, 1, 0, 0, 0, 0, 0, 0 }, 1));
+            Assert.Equal(65536UL, EndianBitConverter.GetConverter(Endianness.LittleEndian).ToUInt64(new byte[] { 1, 0, 0, 1, 0, 0, 0, 0, 0 }, 1));
+            Assert.Equal(16777216UL, EndianBitConverter.GetConverter(Endianness.LittleEndian).ToUInt64(new byte[] { 1, 0, 0, 0, 1, 0, 0, 0, 0 }, 1));
+            Assert.Equal(4294967296UL, EndianBitConverter.GetConverter(Endianness.LittleEndian).ToUInt64(new byte[] { 1, 0, 0, 0, 0, 1, 0, 0, 0 }, 1));
+            Assert.Equal(1099511627776UL, EndianBitConverter.GetConverter(Endianness.LittleEndian).ToUInt64(new byte[] { 1, 0, 0, 0, 0, 0, 1, 0, 0 }, 1));
+            Assert.Equal(1099511627776UL * 256, EndianBitConverter.GetConverter(Endianness.LittleEndian).ToUInt64(new byte[] { 1, 0, 0, 0, 0, 0, 0, 1, 0 }, 1));
+            Assert.Equal(1099511627776UL * 256 * 256, EndianBitConverter.GetConverter(Endianness.LittleEndian).ToUInt64(new byte[] { 1, 0, 0, 0, 0, 0, 0, 0, 1 }, 1));
+            Assert.Equal(ulong.MaxValue, EndianBitConverter.GetConverter(Endianness.LittleEndian).ToUInt64(new byte[] { 0, 255, 255, 255, 255, 255, 255, 255, 255 }, 1));
+            Assert.Equal(257UL, EndianBitConverter.GetConverter(Endianness.LittleEndian).ToUInt64(new byte[] { 0, 1, 1, 0, 0, 0, 0, 0, 0 }, 1));
         }
     }
 }


### PR DESCRIPTION
### Prerequisites

### Description
Currently if the library was run on an BigEndian Processor it will not work, instead I have changed the Endianness Converters to Reverse and Native. This is then selected based on the 

BitConverter.IsLittleEndian flag.