### PR TITLE
Use Bufferspan + Unsafe.Add for png filters

### DIFF
--- a/src/ImageSharp/Common/Helpers/DebugGuard.cs
+++ b/src/ImageSharp/Common/Helpers/DebugGuard.cs
@@ -159,5 +159,43 @@ namespace ImageSharp
                 throw new ArgumentException(message, parameterName);
             }
         }
+
+        /// <summary>
+        /// Verifies, that the target span is of same size than the 'other' span.
+        /// </summary>
+        /// <typeparam name="T">The element type of the spans</typeparam>
+        /// <param name="target">The target span.</param>
+        /// <param name="other">The 'other' span to compare 'target' to.</param>
+        /// <param name="parameterName">The name of the parameter that is to be checked.</param>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="target"/> is true
+        /// </exception>
+        public static void MustBeSameSized<T>(BufferSpan<T> target, BufferSpan<T> other, string parameterName)
+            where T : struct
+        {
+            if (target.Length != other.Length)
+            {
+                throw new ArgumentException("Span-s must be the same size!", parameterName);
+            }
+        }
+
+        /// <summary>
+        /// Verifies, that the `target` span has the length of 'minSpan', or longer.
+        /// </summary>
+        /// <typeparam name="T">The element type of the spans</typeparam>
+        /// <param name="target">The target span.</param>
+        /// <param name="minSpan">The 'minSpan' span to compare 'target' to.</param>
+        /// <param name="parameterName">The name of the parameter that is to be checked.</param>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="target"/> is true
+        /// </exception>
+        public static void MustBeSizedAtLeast<T>(BufferSpan<T> target, BufferSpan<T> minSpan, string parameterName)
+            where T : struct
+        {
+            if (target.Length < minSpan.Length)
+            {
+                throw new ArgumentException($"Span-s must be at least of length {minSpan.Length}!", parameterName);
+            }
+        }
     }
 }

--- a/src/ImageSharp/Common/Helpers/Guard.cs
+++ b/src/ImageSharp/Common/Helpers/Guard.cs
@@ -230,5 +230,43 @@ namespace ImageSharp
                 throw new ArgumentException(message, parameterName);
             }
         }
+
+        /// <summary>
+        /// Verifies, that the target span is of same size than the 'other' span.
+        /// </summary>
+        /// <typeparam name="T">The element type of the spans</typeparam>
+        /// <param name="target">The target span.</param>
+        /// <param name="other">The 'other' span to compare 'target' to.</param>
+        /// <param name="parameterName">The name of the parameter that is to be checked.</param>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="target"/> is true
+        /// </exception>
+        public static void MustBeSameSized<T>(BufferSpan<T> target, BufferSpan<T> other, string parameterName)
+            where T : struct
+        {
+            if (target.Length != other.Length)
+            {
+                throw new ArgumentException("Span-s must be the same size!", parameterName);
+            }
+        }
+
+        /// <summary>
+        /// Verifies, that the `target` span has the length of 'minSpan', or longer.
+        /// </summary>
+        /// <typeparam name="T">The element type of the spans</typeparam>
+        /// <param name="target">The target span.</param>
+        /// <param name="minSpan">The 'minSpan' span to compare 'target' to.</param>
+        /// <param name="parameterName">The name of the parameter that is to be checked.</param>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="target"/> is true
+        /// </exception>
+        public static void MustBeSizedAtLeast<T>(BufferSpan<T> target, BufferSpan<T> minSpan, string parameterName)
+            where T : struct
+        {
+            if (target.Length < minSpan.Length)
+            {
+                throw new ArgumentException($"Span-s must be at least of length {minSpan.Length}!", parameterName);
+            }
+        }
     }
 }

--- a/src/ImageSharp/Common/Helpers/Guard.cs
+++ b/src/ImageSharp/Common/Helpers/Guard.cs
@@ -230,43 +230,5 @@ namespace ImageSharp
                 throw new ArgumentException(message, parameterName);
             }
         }
-
-        /// <summary>
-        /// Verifies, that the target span is of same size than the 'other' span.
-        /// </summary>
-        /// <typeparam name="T">The element type of the spans</typeparam>
-        /// <param name="target">The target span.</param>
-        /// <param name="other">The 'other' span to compare 'target' to.</param>
-        /// <param name="parameterName">The name of the parameter that is to be checked.</param>
-        /// <exception cref="ArgumentException">
-        /// <paramref name="target"/> is true
-        /// </exception>
-        public static void MustBeSameSized<T>(BufferSpan<T> target, BufferSpan<T> other, string parameterName)
-            where T : struct
-        {
-            if (target.Length != other.Length)
-            {
-                throw new ArgumentException("Span-s must be the same size!", parameterName);
-            }
-        }
-
-        /// <summary>
-        /// Verifies, that the `target` span has the length of 'minSpan', or longer.
-        /// </summary>
-        /// <typeparam name="T">The element type of the spans</typeparam>
-        /// <param name="target">The target span.</param>
-        /// <param name="minSpan">The 'minSpan' span to compare 'target' to.</param>
-        /// <param name="parameterName">The name of the parameter that is to be checked.</param>
-        /// <exception cref="ArgumentException">
-        /// <paramref name="target"/> is true
-        /// </exception>
-        public static void MustBeSizedAtLeast<T>(BufferSpan<T> target, BufferSpan<T> minSpan, string parameterName)
-            where T : struct
-        {
-            if (target.Length < minSpan.Length)
-            {
-                throw new ArgumentException($"Span-s must be at least of length {minSpan.Length}!", parameterName);
-            }
-        }
     }
 }

--- a/src/ImageSharp/Formats/Png/Filters/AverageFilter.cs
+++ b/src/ImageSharp/Formats/Png/Filters/AverageFilter.cs
@@ -24,23 +24,23 @@ namespace ImageSharp.Formats
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void Decode(BufferSpan<byte> scanline, BufferSpan<byte> previousScanline, int bytesPerScanline, int bytesPerPixel)
         {
-            ref byte scanPointer = ref scanline.DangerousGetPinnableReference();
-            ref byte prevPointer = ref previousScanline.DangerousGetPinnableReference();
+            ref byte scanBaseRef = ref scanline.DangerousGetPinnableReference();
+            ref byte prevBaseRef = ref previousScanline.DangerousGetPinnableReference();
 
             // Average(x) + floor((Raw(x-bpp)+Prior(x))/2)
             for (int x = 1; x < bytesPerScanline; x++)
             {
                 if (x - bytesPerPixel < 1)
                 {
-                    ref byte scan = ref Unsafe.Add(ref scanPointer, x);
-                    byte above = Unsafe.Add(ref prevPointer, x);
+                    ref byte scan = ref Unsafe.Add(ref scanBaseRef, x);
+                    byte above = Unsafe.Add(ref prevBaseRef, x);
                     scan = (byte)((scan + (above >> 1)) % 256);
                 }
                 else
                 {
-                    ref byte scan = ref Unsafe.Add(ref scanPointer, x);
-                    byte left = Unsafe.Add(ref scanPointer, x - bytesPerPixel);
-                    byte above = Unsafe.Add(ref prevPointer, x);
+                    ref byte scan = ref Unsafe.Add(ref scanBaseRef, x);
+                    byte left = Unsafe.Add(ref scanBaseRef, x - bytesPerPixel);
+                    byte above = Unsafe.Add(ref prevBaseRef, x);
                     scan = (byte)((scan + Average(left, above)) % 256);
                 }
             }
@@ -57,28 +57,28 @@ namespace ImageSharp.Formats
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void Encode(BufferSpan<byte> scanline, BufferSpan<byte> previousScanline, BufferSpan<byte> result, int bytesPerScanline, int bytesPerPixel)
         {
-            ref byte scanPointer = ref scanline.DangerousGetPinnableReference();
-            ref byte prevPointer = ref previousScanline.DangerousGetPinnableReference();
-            ref byte resultPointer = ref result.DangerousGetPinnableReference();
+            ref byte scanBaseRef = ref scanline.DangerousGetPinnableReference();
+            ref byte prevBaseRef = ref previousScanline.DangerousGetPinnableReference();
+            ref byte resultBaseRef = ref result.DangerousGetPinnableReference();
 
             // Average(x) = Raw(x) - floor((Raw(x-bpp)+Prior(x))/2)
-            resultPointer = 3;
+            resultBaseRef = 3;
 
             for (int x = 0; x < bytesPerScanline; x++)
             {
                 if (x - bytesPerPixel < 0)
                 {
-                    byte scan = Unsafe.Add(ref scanPointer, x);
-                    byte above = Unsafe.Add(ref prevPointer, x);
-                    ref byte res = ref Unsafe.Add(ref resultPointer, x + 1);
+                    byte scan = Unsafe.Add(ref scanBaseRef, x);
+                    byte above = Unsafe.Add(ref prevBaseRef, x);
+                    ref byte res = ref Unsafe.Add(ref resultBaseRef, x + 1);
                     res = (byte)((scan - (above >> 1)) % 256);
                 }
                 else
                 {
-                    byte scan = Unsafe.Add(ref scanPointer, x);
-                    byte left = Unsafe.Add(ref scanPointer, x - bytesPerPixel);
-                    byte above = Unsafe.Add(ref prevPointer, x);
-                    ref byte res = ref Unsafe.Add(ref resultPointer, x + 1);
+                    byte scan = Unsafe.Add(ref scanBaseRef, x);
+                    byte left = Unsafe.Add(ref scanBaseRef, x - bytesPerPixel);
+                    byte above = Unsafe.Add(ref prevBaseRef, x);
+                    ref byte res = ref Unsafe.Add(ref resultBaseRef, x + 1);
                     res = (byte)((scan - Average(left, above)) % 256);
                 }
             }

--- a/src/ImageSharp/Formats/Png/Filters/AverageFilter.cs
+++ b/src/ImageSharp/Formats/Png/Filters/AverageFilter.cs
@@ -23,7 +23,7 @@ namespace ImageSharp.Formats
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void Decode(BufferSpan<byte> scanline, BufferSpan<byte> previousScanline, int bytesPerPixel)
         {
-            Guard.MustBeSameSized(scanline, previousScanline, nameof(scanline));
+            DebugGuard.MustBeSameSized(scanline, previousScanline, nameof(scanline));
 
             ref byte scanBaseRef = ref scanline.DangerousGetPinnableReference();
             ref byte prevBaseRef = ref previousScanline.DangerousGetPinnableReference();
@@ -57,8 +57,8 @@ namespace ImageSharp.Formats
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void Encode(BufferSpan<byte> scanline, BufferSpan<byte> previousScanline, BufferSpan<byte> result, int bytesPerPixel)
         {
-            Guard.MustBeSameSized(scanline, previousScanline, nameof(scanline));
-            Guard.MustBeSizedAtLeast(result, scanline, nameof(result));
+            DebugGuard.MustBeSameSized(scanline, previousScanline, nameof(scanline));
+            DebugGuard.MustBeSizedAtLeast(result, scanline, nameof(result));
 
             ref byte scanBaseRef = ref scanline.DangerousGetPinnableReference();
             ref byte prevBaseRef = ref previousScanline.DangerousGetPinnableReference();

--- a/src/ImageSharp/Formats/Png/Filters/AverageFilter.cs
+++ b/src/ImageSharp/Formats/Png/Filters/AverageFilter.cs
@@ -49,23 +49,30 @@ namespace ImageSharp.Formats
         /// <param name="scanline">The scanline to encode</param>
         /// <param name="previousScanline">The previous scanline.</param>
         /// <param name="result">The filtered scanline result.</param>
+        /// <param name="bytesPerScanline">The number of bytes per scanline</param>
         /// <param name="bytesPerPixel">The bytes per pixel.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Encode(byte[] scanline, byte[] previousScanline, byte[] result, int bytesPerPixel)
+        public static void Encode(ref byte scanline, ref byte previousScanline, ref byte result, int bytesPerScanline, int bytesPerPixel)
         {
             // Average(x) = Raw(x) - floor((Raw(x-bpp)+Prior(x))/2)
-            fixed (byte* scan = scanline)
-            fixed (byte* prev = previousScanline)
-            fixed (byte* res = result)
+            result = 3;
+
+            for (int x = 0; x < bytesPerScanline; x++)
             {
-                res[0] = 3;
-
-                for (int x = 0; x < scanline.Length; x++)
+                if (x - bytesPerPixel < 0)
                 {
-                    byte left = (x - bytesPerPixel < 0) ? (byte)0 : scan[x - bytesPerPixel];
-                    byte above = prev[x];
-
-                    res[x + 1] = (byte)((scan[x] - Average(left, above)) % 256);
+                    ref byte scan = ref Unsafe.Add(ref scanline, x);
+                    ref byte above = ref Unsafe.Add(ref previousScanline, x);
+                    ref byte res = ref Unsafe.Add(ref result, x + 1);
+                    res = (byte)((scan - (above >> 1)) % 256);
+                }
+                else
+                {
+                    ref byte scan = ref Unsafe.Add(ref scanline, x);
+                    ref byte left = ref Unsafe.Add(ref scanline, x - bytesPerPixel);
+                    ref byte above = ref Unsafe.Add(ref previousScanline, x);
+                    ref byte res = ref Unsafe.Add(ref result, x + 1);
+                    res = (byte)((scan - Average(left, above)) % 256);
                 }
             }
         }

--- a/src/ImageSharp/Formats/Png/Filters/AverageFilter.cs
+++ b/src/ImageSharp/Formats/Png/Filters/AverageFilter.cs
@@ -12,23 +12,24 @@ namespace ImageSharp.Formats
     /// the value of a pixel.
     /// <see href="https://www.w3.org/TR/PNG-Filters.html"/>
     /// </summary>
-    internal static unsafe class AverageFilter
+    internal static class AverageFilter
     {
         /// <summary>
         /// Decodes the scanline
         /// </summary>
         /// <param name="scanline">The scanline to decode</param>
         /// <param name="previousScanline">The previous scanline.</param>
-        /// <param name="bytesPerScanline">The number of bytes per scanline</param>
         /// <param name="bytesPerPixel">The bytes per pixel.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Decode(BufferSpan<byte> scanline, BufferSpan<byte> previousScanline, int bytesPerScanline, int bytesPerPixel)
+        public static void Decode(BufferSpan<byte> scanline, BufferSpan<byte> previousScanline, int bytesPerPixel)
         {
+            Guard.MustBeSameSized(scanline, previousScanline, nameof(scanline));
+
             ref byte scanBaseRef = ref scanline.DangerousGetPinnableReference();
             ref byte prevBaseRef = ref previousScanline.DangerousGetPinnableReference();
 
             // Average(x) + floor((Raw(x-bpp)+Prior(x))/2)
-            for (int x = 1; x < bytesPerScanline; x++)
+            for (int x = 1; x < scanline.Length; x++)
             {
                 if (x - bytesPerPixel < 1)
                 {
@@ -52,11 +53,13 @@ namespace ImageSharp.Formats
         /// <param name="scanline">The scanline to encode</param>
         /// <param name="previousScanline">The previous scanline.</param>
         /// <param name="result">The filtered scanline result.</param>
-        /// <param name="bytesPerScanline">The number of bytes per scanline</param>
         /// <param name="bytesPerPixel">The bytes per pixel.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Encode(BufferSpan<byte> scanline, BufferSpan<byte> previousScanline, BufferSpan<byte> result, int bytesPerScanline, int bytesPerPixel)
+        public static void Encode(BufferSpan<byte> scanline, BufferSpan<byte> previousScanline, BufferSpan<byte> result, int bytesPerPixel)
         {
+            Guard.MustBeSameSized(scanline, previousScanline, nameof(scanline));
+            Guard.MustBeSizedAtLeast(result, scanline, nameof(result));
+
             ref byte scanBaseRef = ref scanline.DangerousGetPinnableReference();
             ref byte prevBaseRef = ref previousScanline.DangerousGetPinnableReference();
             ref byte resultBaseRef = ref result.DangerousGetPinnableReference();
@@ -64,7 +67,7 @@ namespace ImageSharp.Formats
             // Average(x) = Raw(x) - floor((Raw(x-bpp)+Prior(x))/2)
             resultBaseRef = 3;
 
-            for (int x = 0; x < bytesPerScanline; x++)
+            for (int x = 0; x < scanline.Length; x++)
             {
                 if (x - bytesPerPixel < 0)
                 {

--- a/src/ImageSharp/Formats/Png/Filters/NoneFilter.cs
+++ b/src/ImageSharp/Formats/Png/Filters/NoneFilter.cs
@@ -21,11 +21,12 @@ namespace ImageSharp.Formats
         /// <param name="scanline">The scanline to encode</param>
         /// <param name="result">The filtered scanline result.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Encode(byte[] scanline, byte[] result)
+        public static void Encode(BufferSpan<byte> scanline, BufferSpan<byte> result)
         {
             // Insert a byte before the data.
             result[0] = 0;
-            Buffer.BlockCopy(scanline, 0, result, 1, scanline.Length);
+            result = result.Slice(1);
+            BufferSpan.Copy(scanline, result);
         }
     }
 }

--- a/src/ImageSharp/Formats/Png/Filters/NoneFilter.cs
+++ b/src/ImageSharp/Formats/Png/Filters/NoneFilter.cs
@@ -16,18 +16,6 @@ namespace ImageSharp.Formats
     internal static class NoneFilter
     {
         /// <summary>
-        /// Decodes the scanline
-        /// </summary>
-        /// <param name="scanline">The scanline to decode</param>
-        /// <returns>The <see cref="T:byte[]"/></returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static byte[] Decode(byte[] scanline)
-        {
-            // No change required.
-            return scanline;
-        }
-
-        /// <summary>
         /// Encodes the scanline
         /// </summary>
         /// <param name="scanline">The scanline to encode</param>

--- a/src/ImageSharp/Formats/Png/Filters/PaethFilter.cs
+++ b/src/ImageSharp/Formats/Png/Filters/PaethFilter.cs
@@ -20,16 +20,17 @@ namespace ImageSharp.Formats
         /// </summary>
         /// <param name="scanline">The scanline to decode</param>
         /// <param name="previousScanline">The previous scanline.</param>
-        /// <param name="bytesPerScanline">The number of bytes per scanline</param>
         /// <param name="bytesPerPixel">The bytes per pixel.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Decode(BufferSpan<byte> scanline, BufferSpan<byte> previousScanline, int bytesPerScanline, int bytesPerPixel)
+        public static void Decode(BufferSpan<byte> scanline, BufferSpan<byte> previousScanline, int bytesPerPixel)
         {
+            Guard.MustBeSameSized(scanline, previousScanline, nameof(scanline));
+
             ref byte scanBaseRef = ref scanline.DangerousGetPinnableReference();
             ref byte prevBaseRef = ref previousScanline.DangerousGetPinnableReference();
 
             // Paeth(x) + PaethPredictor(Raw(x-bpp), Prior(x), Prior(x-bpp))
-            for (int x = 1; x < bytesPerScanline; x++)
+            for (int x = 1; x < scanline.Length; x++)
             {
                 if (x - bytesPerPixel < 1)
                 {
@@ -54,11 +55,13 @@ namespace ImageSharp.Formats
         /// <param name="scanline">The scanline to encode</param>
         /// <param name="previousScanline">The previous scanline.</param>
         /// <param name="result">The filtered scanline result.</param>
-        /// <param name="bytesPerScanline">The number of bytes per scanline</param>
         /// <param name="bytesPerPixel">The bytes per pixel.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Encode(BufferSpan<byte> scanline, BufferSpan<byte> previousScanline, BufferSpan<byte> result, int bytesPerScanline, int bytesPerPixel)
+        public static void Encode(BufferSpan<byte> scanline, BufferSpan<byte> previousScanline, BufferSpan<byte> result, int bytesPerPixel)
         {
+            Guard.MustBeSameSized(scanline, previousScanline, nameof(scanline));
+            Guard.MustBeSizedAtLeast(result, scanline, nameof(result));
+
             ref byte scanBaseRef = ref scanline.DangerousGetPinnableReference();
             ref byte prevBaseRef = ref previousScanline.DangerousGetPinnableReference();
             ref byte resultBaseRef = ref result.DangerousGetPinnableReference();
@@ -66,7 +69,7 @@ namespace ImageSharp.Formats
             // Paeth(x) = Raw(x) - PaethPredictor(Raw(x-bpp), Prior(x), Prior(x - bpp))
             resultBaseRef = 4;
 
-            for (int x = 0; x < bytesPerScanline; x++)
+            for (int x = 0; x < scanline.Length; x++)
             {
                 if (x - bytesPerPixel < 0)
                 {

--- a/src/ImageSharp/Formats/Png/Filters/PaethFilter.cs
+++ b/src/ImageSharp/Formats/Png/Filters/PaethFilter.cs
@@ -25,24 +25,24 @@ namespace ImageSharp.Formats
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void Decode(BufferSpan<byte> scanline, BufferSpan<byte> previousScanline, int bytesPerScanline, int bytesPerPixel)
         {
-            ref byte scanPointer = ref scanline.DangerousGetPinnableReference();
-            ref byte prevPointer = ref previousScanline.DangerousGetPinnableReference();
+            ref byte scanBaseRef = ref scanline.DangerousGetPinnableReference();
+            ref byte prevBaseRef = ref previousScanline.DangerousGetPinnableReference();
 
             // Paeth(x) + PaethPredictor(Raw(x-bpp), Prior(x), Prior(x-bpp))
             for (int x = 1; x < bytesPerScanline; x++)
             {
                 if (x - bytesPerPixel < 1)
                 {
-                    ref byte scan = ref Unsafe.Add(ref scanPointer, x);
-                    byte above = Unsafe.Add(ref prevPointer, x);
+                    ref byte scan = ref Unsafe.Add(ref scanBaseRef, x);
+                    byte above = Unsafe.Add(ref prevBaseRef, x);
                     scan = (byte)((scan + PaethPredicator(0, above, 0)) % 256);
                 }
                 else
                 {
-                    ref byte scan = ref Unsafe.Add(ref scanPointer, x);
-                    byte left = Unsafe.Add(ref scanPointer, x - bytesPerPixel);
-                    byte above = Unsafe.Add(ref prevPointer, x);
-                    byte upperLeft = Unsafe.Add(ref prevPointer, x - bytesPerPixel);
+                    ref byte scan = ref Unsafe.Add(ref scanBaseRef, x);
+                    byte left = Unsafe.Add(ref scanBaseRef, x - bytesPerPixel);
+                    byte above = Unsafe.Add(ref prevBaseRef, x);
+                    byte upperLeft = Unsafe.Add(ref prevBaseRef, x - bytesPerPixel);
                     scan = (byte)((scan + PaethPredicator(left, above, upperLeft)) % 256);
                 }
             }
@@ -59,29 +59,29 @@ namespace ImageSharp.Formats
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void Encode(BufferSpan<byte> scanline, BufferSpan<byte> previousScanline, BufferSpan<byte> result, int bytesPerScanline, int bytesPerPixel)
         {
-            ref byte scanPointer = ref scanline.DangerousGetPinnableReference();
-            ref byte prevPointer = ref previousScanline.DangerousGetPinnableReference();
-            ref byte resultPointer = ref result.DangerousGetPinnableReference();
+            ref byte scanBaseRef = ref scanline.DangerousGetPinnableReference();
+            ref byte prevBaseRef = ref previousScanline.DangerousGetPinnableReference();
+            ref byte resultBaseRef = ref result.DangerousGetPinnableReference();
 
             // Paeth(x) = Raw(x) - PaethPredictor(Raw(x-bpp), Prior(x), Prior(x - bpp))
-            resultPointer = 4;
+            resultBaseRef = 4;
 
             for (int x = 0; x < bytesPerScanline; x++)
             {
                 if (x - bytesPerPixel < 0)
                 {
-                    byte scan = Unsafe.Add(ref scanPointer, x);
-                    byte above = Unsafe.Add(ref prevPointer, x);
-                    ref byte res = ref Unsafe.Add(ref resultPointer, x + 1);
+                    byte scan = Unsafe.Add(ref scanBaseRef, x);
+                    byte above = Unsafe.Add(ref prevBaseRef, x);
+                    ref byte res = ref Unsafe.Add(ref resultBaseRef, x + 1);
                     res = (byte)((scan - PaethPredicator(0, above, 0)) % 256);
                 }
                 else
                 {
-                    byte scan = Unsafe.Add(ref scanPointer, x);
-                    byte left = Unsafe.Add(ref scanPointer, x - bytesPerPixel);
-                    byte above = Unsafe.Add(ref prevPointer, x);
-                    byte upperLeft = Unsafe.Add(ref prevPointer, x - bytesPerPixel);
-                    ref byte res = ref Unsafe.Add(ref resultPointer, x + 1);
+                    byte scan = Unsafe.Add(ref scanBaseRef, x);
+                    byte left = Unsafe.Add(ref scanBaseRef, x - bytesPerPixel);
+                    byte above = Unsafe.Add(ref prevBaseRef, x);
+                    byte upperLeft = Unsafe.Add(ref prevBaseRef, x - bytesPerPixel);
+                    ref byte res = ref Unsafe.Add(ref resultBaseRef, x + 1);
                     res = (byte)((scan - PaethPredicator(left, above, upperLeft)) % 256);
                 }
             }

--- a/src/ImageSharp/Formats/Png/Filters/PaethFilter.cs
+++ b/src/ImageSharp/Formats/Png/Filters/PaethFilter.cs
@@ -24,7 +24,7 @@ namespace ImageSharp.Formats
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void Decode(BufferSpan<byte> scanline, BufferSpan<byte> previousScanline, int bytesPerPixel)
         {
-            Guard.MustBeSameSized(scanline, previousScanline, nameof(scanline));
+            DebugGuard.MustBeSameSized(scanline, previousScanline, nameof(scanline));
 
             ref byte scanBaseRef = ref scanline.DangerousGetPinnableReference();
             ref byte prevBaseRef = ref previousScanline.DangerousGetPinnableReference();
@@ -59,8 +59,8 @@ namespace ImageSharp.Formats
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void Encode(BufferSpan<byte> scanline, BufferSpan<byte> previousScanline, BufferSpan<byte> result, int bytesPerPixel)
         {
-            Guard.MustBeSameSized(scanline, previousScanline, nameof(scanline));
-            Guard.MustBeSizedAtLeast(result, scanline, nameof(result));
+            DebugGuard.MustBeSameSized(scanline, previousScanline, nameof(scanline));
+            DebugGuard.MustBeSizedAtLeast(result, scanline, nameof(result));
 
             ref byte scanBaseRef = ref scanline.DangerousGetPinnableReference();
             ref byte prevBaseRef = ref previousScanline.DangerousGetPinnableReference();

--- a/src/ImageSharp/Formats/Png/Filters/PaethFilter.cs
+++ b/src/ImageSharp/Formats/Png/Filters/PaethFilter.cs
@@ -5,7 +5,6 @@
 
 namespace ImageSharp.Formats
 {
-    using System;
     using System.Runtime.CompilerServices;
 
     /// <summary>
@@ -24,19 +23,24 @@ namespace ImageSharp.Formats
         /// <param name="bytesPerScanline">The number of bytes per scanline</param>
         /// <param name="bytesPerPixel">The bytes per pixel.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Decode(byte[] scanline, byte[] previousScanline, int bytesPerScanline, int bytesPerPixel)
+        public static void Decode(ref byte scanline, ref byte previousScanline, int bytesPerScanline, int bytesPerPixel)
         {
             // Paeth(x) + PaethPredictor(Raw(x-bpp), Prior(x), Prior(x-bpp))
-            fixed (byte* scan = scanline)
-            fixed (byte* prev = previousScanline)
+            for (int x = 1; x < bytesPerScanline; x++)
             {
-                for (int x = 1; x < bytesPerScanline; x++)
+                if (x - bytesPerPixel < 1)
                 {
-                    byte left = (x - bytesPerPixel < 1) ? (byte)0 : scan[x - bytesPerPixel];
-                    byte above = prev[x];
-                    byte upperLeft = (x - bytesPerPixel < 1) ? (byte)0 : prev[x - bytesPerPixel];
-
-                    scan[x] = (byte)((scan[x] + PaethPredicator(left, above, upperLeft)) % 256);
+                    ref byte scan = ref Unsafe.Add(ref scanline, x);
+                    ref byte above = ref Unsafe.Add(ref previousScanline, x);
+                    scan = (byte)((scan + PaethPredicator(0, above, 0)) % 256);
+                }
+                else
+                {
+                    ref byte scan = ref Unsafe.Add(ref scanline, x);
+                    ref byte left = ref Unsafe.Add(ref scanline, x - bytesPerPixel);
+                    ref byte above = ref Unsafe.Add(ref previousScanline, x);
+                    ref byte upperLeft = ref Unsafe.Add(ref previousScanline, x - bytesPerPixel);
+                    scan = (byte)((scan + PaethPredicator(left, above, upperLeft)) % 256);
                 }
             }
         }

--- a/src/ImageSharp/Formats/Png/Filters/SubFilter.cs
+++ b/src/ImageSharp/Formats/Png/Filters/SubFilter.cs
@@ -50,7 +50,7 @@ namespace ImageSharp.Formats
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void Encode(BufferSpan<byte> scanline, BufferSpan<byte> result, int bytesPerPixel)
         {
-            Guard.MustBeSizedAtLeast(result, scanline, nameof(result));
+            DebugGuard.MustBeSizedAtLeast(result, scanline, nameof(result));
 
             ref byte scanBaseRef = ref scanline.DangerousGetPinnableReference();
             ref byte resultBaseRef = ref result.DangerousGetPinnableReference();

--- a/src/ImageSharp/Formats/Png/Filters/SubFilter.cs
+++ b/src/ImageSharp/Formats/Png/Filters/SubFilter.cs
@@ -21,15 +21,21 @@ namespace ImageSharp.Formats
         /// <param name="bytesPerScanline">The number of bytes per scanline</param>
         /// <param name="bytesPerPixel">The bytes per pixel.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Decode(byte[] scanline, int bytesPerScanline, int bytesPerPixel)
+        public static void Decode(ref byte scanline, int bytesPerScanline, int bytesPerPixel)
         {
             // Sub(x) + Raw(x-bpp)
-            fixed (byte* scan = scanline)
+            for (int x = 1; x < bytesPerScanline; x++)
             {
-                for (int x = 1; x < bytesPerScanline; x++)
+                if (x - bytesPerPixel < 1)
                 {
-                    byte priorRawByte = (x - bytesPerPixel < 1) ? (byte)0 : scan[x - bytesPerPixel];
-                    scan[x] = (byte)((scan[x] + priorRawByte) % 256);
+                    ref byte scan = ref Unsafe.Add(ref scanline, x);
+                    scan = (byte)(scan % 256);
+                }
+                else
+                {
+                    ref byte scan = ref Unsafe.Add(ref scanline, x);
+                    ref byte prev = ref Unsafe.Add(ref scanline, x - bytesPerPixel);
+                    scan = (byte)((scan + prev) % 256);
                 }
             }
         }

--- a/src/ImageSharp/Formats/Png/Filters/SubFilter.cs
+++ b/src/ImageSharp/Formats/Png/Filters/SubFilter.cs
@@ -23,20 +23,20 @@ namespace ImageSharp.Formats
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void Decode(BufferSpan<byte> scanline, int bytesPerScanline, int bytesPerPixel)
         {
-            ref byte scanPointer = ref scanline.DangerousGetPinnableReference();
+            ref byte scanBaseRef = ref scanline.DangerousGetPinnableReference();
 
             // Sub(x) + Raw(x-bpp)
             for (int x = 1; x < bytesPerScanline; x++)
             {
                 if (x - bytesPerPixel < 1)
                 {
-                    ref byte scan = ref Unsafe.Add(ref scanPointer, x);
+                    ref byte scan = ref Unsafe.Add(ref scanBaseRef, x);
                     scan = (byte)(scan % 256);
                 }
                 else
                 {
-                    ref byte scan = ref Unsafe.Add(ref scanPointer, x);
-                    byte prev = Unsafe.Add(ref scanPointer, x - bytesPerPixel);
+                    ref byte scan = ref Unsafe.Add(ref scanBaseRef, x);
+                    byte prev = Unsafe.Add(ref scanBaseRef, x - bytesPerPixel);
                     scan = (byte)((scan + prev) % 256);
                 }
             }
@@ -52,25 +52,25 @@ namespace ImageSharp.Formats
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void Encode(BufferSpan<byte> scanline, BufferSpan<byte> result, int bytesPerScanline, int bytesPerPixel)
         {
-            ref byte scanPointer = ref scanline.DangerousGetPinnableReference();
-            ref byte resultPointer = ref result.DangerousGetPinnableReference();
+            ref byte scanBaseRef = ref scanline.DangerousGetPinnableReference();
+            ref byte resultBaseRef = ref result.DangerousGetPinnableReference();
 
             // Sub(x) = Raw(x) - Raw(x-bpp)
-            resultPointer = 1;
+            resultBaseRef = 1;
 
             for (int x = 0; x < bytesPerScanline; x++)
             {
                 if (x - bytesPerPixel < 0)
                 {
-                    byte scan = Unsafe.Add(ref scanPointer, x);
-                    ref byte res = ref Unsafe.Add(ref resultPointer, x + 1);
+                    byte scan = Unsafe.Add(ref scanBaseRef, x);
+                    ref byte res = ref Unsafe.Add(ref resultBaseRef, x + 1);
                     res = (byte)(scan % 256);
                 }
                 else
                 {
-                    byte scan = Unsafe.Add(ref scanPointer, x);
-                    byte prev = Unsafe.Add(ref scanPointer, x - bytesPerPixel);
-                    ref byte res = ref Unsafe.Add(ref resultPointer, x + 1);
+                    byte scan = Unsafe.Add(ref scanBaseRef, x);
+                    byte prev = Unsafe.Add(ref scanBaseRef, x - bytesPerPixel);
+                    ref byte res = ref Unsafe.Add(ref resultBaseRef, x + 1);
                     res = (byte)((scan - prev) % 256);
                 }
             }

--- a/src/ImageSharp/Formats/Png/Filters/SubFilter.cs
+++ b/src/ImageSharp/Formats/Png/Filters/SubFilter.cs
@@ -18,15 +18,14 @@ namespace ImageSharp.Formats
         /// Decodes the scanline
         /// </summary>
         /// <param name="scanline">The scanline to decode</param>
-        /// <param name="bytesPerScanline">The number of bytes per scanline</param>
         /// <param name="bytesPerPixel">The bytes per pixel.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Decode(BufferSpan<byte> scanline, int bytesPerScanline, int bytesPerPixel)
+        public static void Decode(BufferSpan<byte> scanline, int bytesPerPixel)
         {
             ref byte scanBaseRef = ref scanline.DangerousGetPinnableReference();
 
             // Sub(x) + Raw(x-bpp)
-            for (int x = 1; x < bytesPerScanline; x++)
+            for (int x = 1; x < scanline.Length; x++)
             {
                 if (x - bytesPerPixel < 1)
                 {
@@ -47,18 +46,19 @@ namespace ImageSharp.Formats
         /// </summary>
         /// <param name="scanline">The scanline to encode</param>
         /// <param name="result">The filtered scanline result.</param>
-        /// <param name="bytesPerScanline">The number of bytes per scanline</param>
         /// <param name="bytesPerPixel">The bytes per pixel.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Encode(BufferSpan<byte> scanline, BufferSpan<byte> result, int bytesPerScanline, int bytesPerPixel)
+        public static void Encode(BufferSpan<byte> scanline, BufferSpan<byte> result, int bytesPerPixel)
         {
+            Guard.MustBeSizedAtLeast(result, scanline, nameof(result));
+
             ref byte scanBaseRef = ref scanline.DangerousGetPinnableReference();
             ref byte resultBaseRef = ref result.DangerousGetPinnableReference();
 
             // Sub(x) = Raw(x) - Raw(x-bpp)
             resultBaseRef = 1;
 
-            for (int x = 0; x < bytesPerScanline; x++)
+            for (int x = 0; x < scanline.Length; x++)
             {
                 if (x - bytesPerPixel < 0)
                 {

--- a/src/ImageSharp/Formats/Png/Filters/UpFilter.cs
+++ b/src/ImageSharp/Formats/Png/Filters/UpFilter.cs
@@ -21,18 +21,14 @@ namespace ImageSharp.Formats
         /// <param name="previousScanline">The previous scanline.</param>
         /// <param name="bytesPerScanline">The number of bytes per scanline</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Decode(byte[] scanline, byte[] previousScanline, int bytesPerScanline)
+        public static void Decode(ref byte scanline, ref byte previousScanline, int bytesPerScanline)
         {
             // Up(x) + Prior(x)
-            fixed (byte* scan = scanline)
-            fixed (byte* prev = previousScanline)
+            for (int x = 1; x < bytesPerScanline; x++)
             {
-                for (int x = 1; x < bytesPerScanline; x++)
-                {
-                    byte above = prev[x];
-
-                    scan[x] = (byte)((scan[x] + above) % 256);
-                }
+                ref byte scan = ref Unsafe.Add(ref scanline, x);
+                ref byte above = ref Unsafe.Add(ref previousScanline, x);
+                scan = (byte)((scan + above) % 256);
             }
         }
 

--- a/src/ImageSharp/Formats/Png/Filters/UpFilter.cs
+++ b/src/ImageSharp/Formats/Png/Filters/UpFilter.cs
@@ -19,15 +19,16 @@ namespace ImageSharp.Formats
         /// </summary>
         /// <param name="scanline">The scanline to decode</param>
         /// <param name="previousScanline">The previous scanline.</param>
-        /// <param name="bytesPerScanline">The number of bytes per scanline</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Decode(BufferSpan<byte> scanline, BufferSpan<byte> previousScanline, int bytesPerScanline)
+        public static void Decode(BufferSpan<byte> scanline, BufferSpan<byte> previousScanline)
         {
+            Guard.MustBeSameSized(scanline, previousScanline, nameof(scanline));
+
             ref byte scanBaseRef = ref scanline.DangerousGetPinnableReference();
             ref byte prevBaseRef = ref previousScanline.DangerousGetPinnableReference();
 
             // Up(x) + Prior(x)
-            for (int x = 1; x < bytesPerScanline; x++)
+            for (int x = 1; x < scanline.Length; x++)
             {
                 ref byte scan = ref Unsafe.Add(ref scanBaseRef, x);
                 byte above = Unsafe.Add(ref prevBaseRef, x);
@@ -41,10 +42,12 @@ namespace ImageSharp.Formats
         /// <param name="scanline">The scanline to encode</param>
         /// <param name="previousScanline">The previous scanline.</param>
         /// <param name="result">The filtered scanline result.</param>
-        /// <param name="bytesPerScanline">The number of bytes per scanline</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Encode(BufferSpan<byte> scanline, BufferSpan<byte> previousScanline, BufferSpan<byte> result, int bytesPerScanline)
+        public static void Encode(BufferSpan<byte> scanline, BufferSpan<byte> previousScanline, BufferSpan<byte> result)
         {
+            Guard.MustBeSameSized(scanline, previousScanline, nameof(scanline));
+            Guard.MustBeSizedAtLeast(result, scanline, nameof(result));
+
             ref byte scanBaseRef = ref scanline.DangerousGetPinnableReference();
             ref byte prevBaseRef = ref previousScanline.DangerousGetPinnableReference();
             ref byte resultBaseRef = ref result.DangerousGetPinnableReference();
@@ -52,7 +55,7 @@ namespace ImageSharp.Formats
             // Up(x) = Raw(x) - Prior(x)
             resultBaseRef = 2;
 
-            for (int x = 0; x < bytesPerScanline; x++)
+            for (int x = 0; x < scanline.Length; x++)
             {
                 byte scan = Unsafe.Add(ref scanBaseRef, x);
                 byte above = Unsafe.Add(ref prevBaseRef, x);

--- a/src/ImageSharp/Formats/Png/Filters/UpFilter.cs
+++ b/src/ImageSharp/Formats/Png/Filters/UpFilter.cs
@@ -38,22 +38,19 @@ namespace ImageSharp.Formats
         /// <param name="scanline">The scanline to encode</param>
         /// <param name="previousScanline">The previous scanline.</param>
         /// <param name="result">The filtered scanline result.</param>
+        /// <param name="bytesPerScanline">The number of bytes per scanline</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Encode(byte[] scanline, byte[] previousScanline, byte[] result)
+        public static void Encode(ref byte scanline, ref byte previousScanline, ref byte result, int bytesPerScanline)
         {
             // Up(x) = Raw(x) - Prior(x)
-            fixed (byte* scan = scanline)
-            fixed (byte* prev = previousScanline)
-            fixed (byte* res = result)
+            result = 2;
+
+            for (int x = 0; x < bytesPerScanline; x++)
             {
-                res[0] = 2;
-
-                for (int x = 0; x < scanline.Length; x++)
-                {
-                    byte above = prev[x];
-
-                    res[x + 1] = (byte)((scan[x] - above) % 256);
-                }
+                ref byte scan = ref Unsafe.Add(ref scanline, x);
+                ref byte above = ref Unsafe.Add(ref previousScanline, x);
+                ref byte res = ref Unsafe.Add(ref result, x + 1);
+                res = (byte)((scan - above) % 256);
             }
         }
     }

--- a/src/ImageSharp/Formats/Png/Filters/UpFilter.cs
+++ b/src/ImageSharp/Formats/Png/Filters/UpFilter.cs
@@ -23,14 +23,14 @@ namespace ImageSharp.Formats
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void Decode(BufferSpan<byte> scanline, BufferSpan<byte> previousScanline, int bytesPerScanline)
         {
-            ref byte scanPointer = ref scanline.DangerousGetPinnableReference();
-            ref byte prevPointer = ref previousScanline.DangerousGetPinnableReference();
+            ref byte scanBaseRef = ref scanline.DangerousGetPinnableReference();
+            ref byte prevBaseRef = ref previousScanline.DangerousGetPinnableReference();
 
             // Up(x) + Prior(x)
             for (int x = 1; x < bytesPerScanline; x++)
             {
-                ref byte scan = ref Unsafe.Add(ref scanPointer, x);
-                byte above = Unsafe.Add(ref prevPointer, x);
+                ref byte scan = ref Unsafe.Add(ref scanBaseRef, x);
+                byte above = Unsafe.Add(ref prevBaseRef, x);
                 scan = (byte)((scan + above) % 256);
             }
         }
@@ -45,18 +45,18 @@ namespace ImageSharp.Formats
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void Encode(BufferSpan<byte> scanline, BufferSpan<byte> previousScanline, BufferSpan<byte> result, int bytesPerScanline)
         {
-            ref byte scanPointer = ref scanline.DangerousGetPinnableReference();
-            ref byte prevPointer = ref previousScanline.DangerousGetPinnableReference();
-            ref byte resultPointer = ref result.DangerousGetPinnableReference();
+            ref byte scanBaseRef = ref scanline.DangerousGetPinnableReference();
+            ref byte prevBaseRef = ref previousScanline.DangerousGetPinnableReference();
+            ref byte resultBaseRef = ref result.DangerousGetPinnableReference();
 
             // Up(x) = Raw(x) - Prior(x)
-            resultPointer = 2;
+            resultBaseRef = 2;
 
             for (int x = 0; x < bytesPerScanline; x++)
             {
-                byte scan = Unsafe.Add(ref scanPointer, x);
-                byte above = Unsafe.Add(ref prevPointer, x);
-                ref byte res = ref Unsafe.Add(ref resultPointer, x + 1);
+                byte scan = Unsafe.Add(ref scanBaseRef, x);
+                byte above = Unsafe.Add(ref prevBaseRef, x);
+                ref byte res = ref Unsafe.Add(ref resultBaseRef, x + 1);
                 res = (byte)((scan - above) % 256);
             }
         }

--- a/src/ImageSharp/Formats/Png/Filters/UpFilter.cs
+++ b/src/ImageSharp/Formats/Png/Filters/UpFilter.cs
@@ -22,7 +22,7 @@ namespace ImageSharp.Formats
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void Decode(BufferSpan<byte> scanline, BufferSpan<byte> previousScanline)
         {
-            Guard.MustBeSameSized(scanline, previousScanline, nameof(scanline));
+            DebugGuard.MustBeSameSized(scanline, previousScanline, nameof(scanline));
 
             ref byte scanBaseRef = ref scanline.DangerousGetPinnableReference();
             ref byte prevBaseRef = ref previousScanline.DangerousGetPinnableReference();
@@ -45,8 +45,8 @@ namespace ImageSharp.Formats
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void Encode(BufferSpan<byte> scanline, BufferSpan<byte> previousScanline, BufferSpan<byte> result)
         {
-            Guard.MustBeSameSized(scanline, previousScanline, nameof(scanline));
-            Guard.MustBeSizedAtLeast(result, scanline, nameof(result));
+            DebugGuard.MustBeSameSized(scanline, previousScanline, nameof(scanline));
+            DebugGuard.MustBeSizedAtLeast(result, scanline, nameof(result));
 
             ref byte scanBaseRef = ref scanline.DangerousGetPinnableReference();
             ref byte prevBaseRef = ref previousScanline.DangerousGetPinnableReference();

--- a/src/ImageSharp/Formats/Png/PngDecoderCore.cs
+++ b/src/ImageSharp/Formats/Png/PngDecoderCore.cs
@@ -438,11 +438,11 @@ namespace ImageSharp.Formats
 
                 this.currentRowBytesRead = 0;
 
-                var filterType = (FilterType)this.scanline[0];
-                var scanBuffer = new BufferSpan<byte>(this.scanline);
-                ref byte scanPoint = ref scanBuffer.DangerousGetPinnableReference();
-                var prevBuffer = new BufferSpan<byte>(this.previousScanline);
-                ref byte prevPoint = ref prevBuffer.DangerousGetPinnableReference();
+                var scanSpan = new BufferSpan<byte>(this.scanline);
+                var prevSpan = new BufferSpan<byte>(this.previousScanline);
+                ref byte scanPointer = ref scanSpan.DangerousGetPinnableReference();
+                ref byte prevPointer = ref prevSpan.DangerousGetPinnableReference();
+                var filterType = (FilterType)scanPointer;
 
                 switch (filterType)
                 {
@@ -451,22 +451,22 @@ namespace ImageSharp.Formats
 
                     case FilterType.Sub:
 
-                        SubFilter.Decode(ref scanPoint, this.bytesPerScanline, this.bytesPerPixel);
+                        SubFilter.Decode(ref scanPointer, this.bytesPerScanline, this.bytesPerPixel);
                         break;
 
                     case FilterType.Up:
 
-                        UpFilter.Decode(ref scanPoint, ref prevPoint, this.bytesPerScanline);
+                        UpFilter.Decode(ref scanPointer, ref prevPointer, this.bytesPerScanline);
                         break;
 
                     case FilterType.Average:
 
-                        AverageFilter.Decode(ref scanPoint, ref prevPoint, this.bytesPerScanline, this.bytesPerPixel);
+                        AverageFilter.Decode(ref scanPointer, ref prevPointer, this.bytesPerScanline, this.bytesPerPixel);
                         break;
 
                     case FilterType.Paeth:
 
-                        PaethFilter.Decode(ref scanPoint, ref prevPoint, this.bytesPerScanline, this.bytesPerPixel);
+                        PaethFilter.Decode(ref scanPointer, ref prevPointer, this.bytesPerScanline, this.bytesPerPixel);
                         break;
 
                     default:
@@ -515,11 +515,11 @@ namespace ImageSharp.Formats
 
                     this.currentRowBytesRead = 0;
 
-                    var filterType = (FilterType)this.scanline[0];
-                    var scanBuffer = new BufferSpan<byte>(this.scanline);
-                    ref byte scanPointer = ref scanBuffer.DangerousGetPinnableReference();
-                    var prevBuffer = new BufferSpan<byte>(this.previousScanline);
-                    ref byte prevPointer = ref prevBuffer.DangerousGetPinnableReference();
+                    var scanSpan = new BufferSpan<byte>(this.scanline);
+                    var prevSpan = new BufferSpan<byte>(this.previousScanline);
+                    ref byte scanPointer = ref scanSpan.DangerousGetPinnableReference();
+                    ref byte prevPointer = ref prevSpan.DangerousGetPinnableReference();
+                    var filterType = (FilterType)scanPointer;
 
                     switch (filterType)
                     {

--- a/src/ImageSharp/Formats/Png/PngDecoderCore.cs
+++ b/src/ImageSharp/Formats/Png/PngDecoderCore.cs
@@ -430,10 +430,7 @@ namespace ImageSharp.Formats
                 }
 
                 this.currentRowBytesRead = 0;
-
-                BufferSpan<byte> scanSpan = this.scanline.Span;
-                BufferSpan<byte> prevSpan = this.previousScanline.Span;
-                var filterType = (FilterType)scanSpan[0];
+                var filterType = (FilterType)this.scanline[0];
 
                 switch (filterType)
                 {
@@ -442,22 +439,22 @@ namespace ImageSharp.Formats
 
                     case FilterType.Sub:
 
-                        SubFilter.Decode(scanSpan, this.bytesPerScanline, this.bytesPerPixel);
+                        SubFilter.Decode(this.scanline, this.bytesPerPixel);
                         break;
 
                     case FilterType.Up:
 
-                        UpFilter.Decode(scanSpan, prevSpan, this.bytesPerScanline);
+                        UpFilter.Decode(this.scanline, this.previousScanline);
                         break;
 
                     case FilterType.Average:
 
-                        AverageFilter.Decode(scanSpan, prevSpan, this.bytesPerScanline, this.bytesPerPixel);
+                        AverageFilter.Decode(this.scanline, this.previousScanline, this.bytesPerPixel);
                         break;
 
                     case FilterType.Paeth:
 
-                        PaethFilter.Decode(scanSpan, prevSpan, this.bytesPerScanline, this.bytesPerPixel);
+                        PaethFilter.Decode(this.scanline, this.previousScanline, this.bytesPerPixel);
                         break;
 
                     default:
@@ -506,8 +503,8 @@ namespace ImageSharp.Formats
 
                     this.currentRowBytesRead = 0;
 
-                    BufferSpan<byte> scanSpan = this.scanline.Span;
-                    BufferSpan<byte> prevSpan = this.previousScanline.Span;
+                    BufferSpan<byte> scanSpan = this.scanline.Slice(0, bytesPerInterlaceScanline);
+                    BufferSpan<byte> prevSpan = this.previousScanline.Span.Slice(0, bytesPerInterlaceScanline);
                     var filterType = (FilterType)scanSpan[0];
 
                     switch (filterType)
@@ -517,22 +514,22 @@ namespace ImageSharp.Formats
 
                         case FilterType.Sub:
 
-                            SubFilter.Decode(scanSpan, bytesPerInterlaceScanline, this.bytesPerPixel);
+                            SubFilter.Decode(scanSpan, this.bytesPerPixel);
                             break;
 
                         case FilterType.Up:
 
-                            UpFilter.Decode(scanSpan, prevSpan, bytesPerInterlaceScanline);
+                            UpFilter.Decode(scanSpan, prevSpan);
                             break;
 
                         case FilterType.Average:
 
-                            AverageFilter.Decode(scanSpan, prevSpan, bytesPerInterlaceScanline, this.bytesPerPixel);
+                            AverageFilter.Decode(scanSpan, prevSpan, this.bytesPerPixel);
                             break;
 
                         case FilterType.Paeth:
 
-                            PaethFilter.Decode(scanSpan, prevSpan, bytesPerInterlaceScanline, this.bytesPerPixel);
+                            PaethFilter.Decode(scanSpan, prevSpan, this.bytesPerPixel);
                             break;
 
                         default:

--- a/src/ImageSharp/Formats/Png/PngDecoderCore.cs
+++ b/src/ImageSharp/Formats/Png/PngDecoderCore.cs
@@ -440,9 +440,7 @@ namespace ImageSharp.Formats
 
                 var scanSpan = new BufferSpan<byte>(this.scanline);
                 var prevSpan = new BufferSpan<byte>(this.previousScanline);
-                ref byte scanPointer = ref scanSpan.DangerousGetPinnableReference();
-                ref byte prevPointer = ref prevSpan.DangerousGetPinnableReference();
-                var filterType = (FilterType)scanPointer;
+                var filterType = (FilterType)scanSpan[0];
 
                 switch (filterType)
                 {
@@ -451,22 +449,22 @@ namespace ImageSharp.Formats
 
                     case FilterType.Sub:
 
-                        SubFilter.Decode(ref scanPointer, this.bytesPerScanline, this.bytesPerPixel);
+                        SubFilter.Decode(scanSpan, this.bytesPerScanline, this.bytesPerPixel);
                         break;
 
                     case FilterType.Up:
 
-                        UpFilter.Decode(ref scanPointer, ref prevPointer, this.bytesPerScanline);
+                        UpFilter.Decode(scanSpan, prevSpan, this.bytesPerScanline);
                         break;
 
                     case FilterType.Average:
 
-                        AverageFilter.Decode(ref scanPointer, ref prevPointer, this.bytesPerScanline, this.bytesPerPixel);
+                        AverageFilter.Decode(scanSpan, prevSpan, this.bytesPerScanline, this.bytesPerPixel);
                         break;
 
                     case FilterType.Paeth:
 
-                        PaethFilter.Decode(ref scanPointer, ref prevPointer, this.bytesPerScanline, this.bytesPerPixel);
+                        PaethFilter.Decode(scanSpan, prevSpan, this.bytesPerScanline, this.bytesPerPixel);
                         break;
 
                     default:
@@ -517,9 +515,7 @@ namespace ImageSharp.Formats
 
                     var scanSpan = new BufferSpan<byte>(this.scanline);
                     var prevSpan = new BufferSpan<byte>(this.previousScanline);
-                    ref byte scanPointer = ref scanSpan.DangerousGetPinnableReference();
-                    ref byte prevPointer = ref prevSpan.DangerousGetPinnableReference();
-                    var filterType = (FilterType)scanPointer;
+                    var filterType = (FilterType)scanSpan[0];
 
                     switch (filterType)
                     {
@@ -528,22 +524,22 @@ namespace ImageSharp.Formats
 
                         case FilterType.Sub:
 
-                            SubFilter.Decode(ref scanPointer, bytesPerInterlaceScanline, this.bytesPerPixel);
+                            SubFilter.Decode(scanSpan, bytesPerInterlaceScanline, this.bytesPerPixel);
                             break;
 
                         case FilterType.Up:
 
-                            UpFilter.Decode(ref scanPointer, ref prevPointer, bytesPerInterlaceScanline);
+                            UpFilter.Decode(scanSpan, prevSpan, bytesPerInterlaceScanline);
                             break;
 
                         case FilterType.Average:
 
-                            AverageFilter.Decode(ref scanPointer, ref prevPointer, bytesPerInterlaceScanline, this.bytesPerPixel);
+                            AverageFilter.Decode(scanSpan, prevSpan, bytesPerInterlaceScanline, this.bytesPerPixel);
                             break;
 
                         case FilterType.Paeth:
 
-                            PaethFilter.Decode(ref scanPointer, ref prevPointer, bytesPerInterlaceScanline, this.bytesPerPixel);
+                            PaethFilter.Decode(scanSpan, prevSpan, bytesPerInterlaceScanline, this.bytesPerPixel);
                             break;
 
                         default:

--- a/src/ImageSharp/Formats/Png/PngEncoder.cs
+++ b/src/ImageSharp/Formats/Png/PngEncoder.cs
@@ -33,8 +33,10 @@ namespace ImageSharp.Formats
         public void Encode<TPixel>(Image<TPixel> image, Stream stream, IPngEncoderOptions options)
             where TPixel : struct, IPixel<TPixel>
         {
-            PngEncoderCore encode = new PngEncoderCore(options);
-            encode.Encode(image, stream);
+            using (var encode = new PngEncoderCore(options))
+            {
+                encode.Encode(image, stream);
+            }
         }
     }
 }

--- a/src/ImageSharp/Formats/Png/PngEncoderCore.cs
+++ b/src/ImageSharp/Formats/Png/PngEncoderCore.cs
@@ -399,16 +399,14 @@ namespace ImageSharp.Formats
 
             // This order, while different to the enumerated order is more likely to produce a smaller sum
             // early on which shaves a couple of milliseconds off the processing time.
-            BufferSpan<byte> upSpan = this.up.Span;
-            UpFilter.Encode(scanSpan, prevSpan, upSpan, this.bytesPerScanline);
+            UpFilter.Encode(scanSpan, prevSpan, this.up);
 
-            int currentSum = this.CalculateTotalVariation(upSpan, int.MaxValue);
+            int currentSum = this.CalculateTotalVariation(this.up, int.MaxValue);
             int lowestSum = currentSum;
             Buffer<byte> actualResult = this.up;
 
-            BufferSpan<byte> paethSpan = this.paeth.Span;
-            PaethFilter.Encode(scanSpan, prevSpan, paethSpan, this.bytesPerScanline, this.bytesPerPixel);
-            currentSum = this.CalculateTotalVariation(paethSpan, currentSum);
+            PaethFilter.Encode(scanSpan, prevSpan, this.paeth, this.bytesPerPixel);
+            currentSum = this.CalculateTotalVariation(this.paeth, currentSum);
 
             if (currentSum < lowestSum)
             {
@@ -416,9 +414,8 @@ namespace ImageSharp.Formats
                 actualResult = this.paeth;
             }
 
-            BufferSpan<byte> subSpan = this.sub.Span;
-            SubFilter.Encode(scanSpan, subSpan, this.bytesPerScanline, this.bytesPerPixel);
-            currentSum = this.CalculateTotalVariation(subSpan, int.MaxValue);
+            SubFilter.Encode(scanSpan, this.sub, this.bytesPerPixel);
+            currentSum = this.CalculateTotalVariation(this.sub, int.MaxValue);
 
             if (currentSum < lowestSum)
             {
@@ -426,9 +423,8 @@ namespace ImageSharp.Formats
                 actualResult = this.sub;
             }
 
-            BufferSpan<byte> averageSpan = this.average.Span;
-            AverageFilter.Encode(scanSpan, prevSpan, averageSpan, this.bytesPerScanline, this.bytesPerPixel);
-            currentSum = this.CalculateTotalVariation(averageSpan, currentSum);
+            AverageFilter.Encode(scanSpan, prevSpan, this.average, this.bytesPerPixel);
+            currentSum = this.CalculateTotalVariation(this.average, currentSum);
 
             if (currentSum < lowestSum)
             {

--- a/src/ImageSharp/Formats/Png/PngEncoderCore.cs
+++ b/src/ImageSharp/Formats/Png/PngEncoderCore.cs
@@ -420,12 +420,12 @@ namespace ImageSharp.Formats
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private int CalculateTotalVariation(BufferSpan<byte> scanline, int lastSum)
         {
-            ref byte scanPointer = ref scanline.DangerousGetPinnableReference();
+            ref byte scanBaseRef = ref scanline.DangerousGetPinnableReference();
             int sum = 0;
 
             for (int i = 1; i < this.bytesPerScanline; i++)
             {
-                byte v = Unsafe.Add(ref scanPointer, i);
+                byte v = Unsafe.Add(ref scanBaseRef, i);
                 sum += v < 128 ? v : 256 - v;
 
                 // No point continuing if we are larger.


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/JimBobSquarePants/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practise as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
This PR replaces the old `fixed` png filters with methods utilizing `BufferSpan<byte>` + `Unsafe.Add` to bring the format codebase more inline with the newer memory access struct approach.

<!-- Thanks for contributing to ImageSharp! -->
