### PR TITLE
Load from pixel data methods

### DIFF
--- a/src/ImageSharp/Image/Image.LoadPixelData.cs
+++ b/src/ImageSharp/Image/Image.LoadPixelData.cs
@@ -14,49 +14,36 @@ namespace ImageSharp
     using ImageSharp.PixelFormats;
 
     /// <content>
-    /// Adds static methods allowing the creation of new image from a byte array.
+    /// Adds static methods allowing the creation of new image from raw pixel data.
     /// </content>
     public static partial class Image
     {
         /// <summary>
-        /// Create a new instance of the <see cref="Image{TPixel}"/> class from the given pixel data.
+        /// Create a new instance of the <see cref="Image{TPixel}"/> class from the raw <typeparamref name="TPixel"/> data.
         /// </summary>
         /// <param name="data">The byte array containing image data.</param>
         /// <param name="width">The width of the final image.</param>
         /// <param name="height">The height of the final image.</param>
         /// <typeparam name="TPixel">The pixel format.</typeparam>
         /// <returns>A new <see cref="Image{TPixel}"/>.</returns>
-        public static Image<TPixel> LoadPixelData<TPixel>(TPixel[] data, int width, int height)
+        public static Image<TPixel> LoadPixelData<TPixel>(Span<TPixel> data, int width, int height)
             where TPixel : struct, IPixel<TPixel>
             => LoadPixelData(Configuration.Default, data, width, height);
 
         /// <summary>
-        /// Create a new instance of the <see cref="Image{TPixel}"/> class from the given pixel data.
-        /// </summary>
-        /// <param name="config">The config for the decoder.</param>
-        /// <param name="data">The byte array containing image data.</param>
-        /// <param name="width">The width of the final image.</param>
-        /// <param name="height">The height of the final image.</param>
-        /// <typeparam name="TPixel">The pixel format.</typeparam>
-        /// <returns>A new <see cref="Image{TPixel}"/>.</returns>
-        public static Image<TPixel> LoadPixelData<TPixel>(Configuration config, TPixel[] data, int width, int height)
-            where TPixel : struct, IPixel<TPixel>
-            => LoadPixelData(config, new Span<TPixel>(data), width, height);
-
-        /// <summary>
-        /// Create a new instance of the <see cref="Image{TPixel}"/> class from the given byte array as raw pixel data.
+        /// Create a new instance of the <see cref="Image{TPixel}"/> class from the given byte array in <typeparamref name="TPixel"/> format.
         /// </summary>
         /// <param name="data">The byte array containing image data.</param>
         /// <param name="width">The width of the final image.</param>
         /// <param name="height">The height of the final image.</param>
         /// <typeparam name="TPixel">The pixel format.</typeparam>
         /// <returns>A new <see cref="Image{TPixel}"/>.</returns>
-        public static Image<TPixel> LoadPixelData<TPixel>(byte[] data, int width, int height)
+        public static Image<TPixel> LoadPixelData<TPixel>(Span<byte> data, int width, int height)
             where TPixel : struct, IPixel<TPixel>
             => LoadPixelData<TPixel>(Configuration.Default, data, width, height);
 
         /// <summary>
-        /// Create a new instance of the <see cref="Image{TPixel}"/> class from the given byte array as raw pixel data.
+        /// Create a new instance of the <see cref="Image{TPixel}"/> class from the given byte array in <typeparamref name="TPixel"/> format.
         /// </summary>
         /// <param name="config">The config for the decoder.</param>
         /// <param name="data">The byte array containing image data.</param>
@@ -64,19 +51,12 @@ namespace ImageSharp
         /// <param name="height">The height of the final image.</param>
         /// <typeparam name="TPixel">The pixel format.</typeparam>
         /// <returns>A new <see cref="Image{TPixel}"/>.</returns>
-        public static Image<TPixel> LoadPixelData<TPixel>(Configuration config, byte[] data, int width, int height)
+        public static Image<TPixel> LoadPixelData<TPixel>(Configuration config, Span<byte> data, int width, int height)
             where TPixel : struct, IPixel<TPixel>
-        {
-            int size = width * height;
-            using (var sourceBuffer = new Buffer<TPixel>(size))
-            {
-                PixelOperations<TPixel>.Instance.PackFromRawBytes(new Span<byte>(data), sourceBuffer.Span, size);
-                return LoadPixelData(config, sourceBuffer.Span, width, height);
-            }
-        }
+            => LoadPixelData(config, data.NonPortableCast<byte, TPixel>(), width, height);
 
         /// <summary>
-        /// Create a new instance of the <see cref="Image{TPixel}"/> class from the given byte array as raw pixel data.
+        /// Create a new instance of the <see cref="Image{TPixel}"/> class from the raw <typeparamref name="TPixel"/> data.
         /// </summary>
         /// <param name="config">The config for the decoder.</param>
         /// <param name="data">The Span containing the image Pixel data.</param>
@@ -84,7 +64,7 @@ namespace ImageSharp
         /// <param name="height">The height of the final image.</param>
         /// <typeparam name="TPixel">The pixel format.</typeparam>
         /// <returns>A new <see cref="Image{TPixel}"/>.</returns>
-        private static Image<TPixel> LoadPixelData<TPixel>(Configuration config, Span<TPixel> data, int width, int height)
+        public static Image<TPixel> LoadPixelData<TPixel>(Configuration config, Span<TPixel> data, int width, int height)
             where TPixel : struct, IPixel<TPixel>
         {
             int count = width * height;

--- a/src/ImageSharp/Image/Image.LoadPixelData.cs
+++ b/src/ImageSharp/Image/Image.LoadPixelData.cs
@@ -1,0 +1,100 @@
+﻿// <copyright file="Image.LoadPixelData.cs" company="James Jackson-South">
+// Copyright (c) James Jackson-South and contributors.
+// Licensed under the Apache License, Version 2.0.
+// </copyright>
+
+namespace ImageSharp
+{
+    using System;
+    using System.IO;
+    using System.Runtime.CompilerServices;
+    using System.Threading.Tasks;
+    using Formats;
+    using ImageSharp.Memory;
+    using ImageSharp.PixelFormats;
+
+    /// <content>
+    /// Adds static methods allowing the creation of new image from a byte array.
+    /// </content>
+    public static partial class Image
+    {
+        /// <summary>
+        /// Create a new instance of the <see cref="Image{TPixel}"/> class from the given pixel data.
+        /// </summary>
+        /// <param name="data">The byte array containing image data.</param>
+        /// <param name="width">The width of the final image.</param>
+        /// <param name="height">The height of the final image.</param>
+        /// <typeparam name="TPixel">The pixel format.</typeparam>
+        /// <returns>A new <see cref="Image{TPixel}"/>.</returns>
+        public static Image<TPixel> LoadPixelData<TPixel>(TPixel[] data, int width, int height)
+            where TPixel : struct, IPixel<TPixel>
+            => LoadPixelData(Configuration.Default, data, width, height);
+
+        /// <summary>
+        /// Create a new instance of the <see cref="Image{TPixel}"/> class from the given pixel data.
+        /// </summary>
+        /// <param name="config">The config for the decoder.</param>
+        /// <param name="data">The byte array containing image data.</param>
+        /// <param name="width">The width of the final image.</param>
+        /// <param name="height">The height of the final image.</param>
+        /// <typeparam name="TPixel">The pixel format.</typeparam>
+        /// <returns>A new <see cref="Image{TPixel}"/>.</returns>
+        public static Image<TPixel> LoadPixelData<TPixel>(Configuration config, TPixel[] data, int width, int height)
+            where TPixel : struct, IPixel<TPixel>
+            => LoadPixelData(config, new Span<TPixel>(data), width, height);
+
+        /// <summary>
+        /// Create a new instance of the <see cref="Image{TPixel}"/> class from the given byte array as raw pixel data.
+        /// </summary>
+        /// <param name="data">The byte array containing image data.</param>
+        /// <param name="width">The width of the final image.</param>
+        /// <param name="height">The height of the final image.</param>
+        /// <typeparam name="TPixel">The pixel format.</typeparam>
+        /// <returns>A new <see cref="Image{TPixel}"/>.</returns>
+        public static Image<TPixel> LoadPixelData<TPixel>(byte[] data, int width, int height)
+            where TPixel : struct, IPixel<TPixel>
+            => LoadPixelData<TPixel>(Configuration.Default, data, width, height);
+
+        /// <summary>
+        /// Create a new instance of the <see cref="Image{TPixel}"/> class from the given byte array as raw pixel data.
+        /// </summary>
+        /// <param name="config">The config for the decoder.</param>
+        /// <param name="data">The byte array containing image data.</param>
+        /// <param name="width">The width of the final image.</param>
+        /// <param name="height">The height of the final image.</param>
+        /// <typeparam name="TPixel">The pixel format.</typeparam>
+        /// <returns>A new <see cref="Image{TPixel}"/>.</returns>
+        public static Image<TPixel> LoadPixelData<TPixel>(Configuration config, byte[] data, int width, int height)
+            where TPixel : struct, IPixel<TPixel>
+        {
+            int size = width * height;
+            using (var sourceBuffer = new Buffer<TPixel>(size))
+            {
+                PixelOperations<TPixel>.Instance.PackFromRawBytes(new Span<byte>(data), sourceBuffer.Span, size);
+                return LoadPixelData(config, sourceBuffer.Span, width, height);
+            }
+        }
+
+        /// <summary>
+        /// Create a new instance of the <see cref="Image{TPixel}"/> class from the given byte array as raw pixel data.
+        /// </summary>
+        /// <param name="config">The config for the decoder.</param>
+        /// <param name="data">The Span containing the image Pixel data.</param>
+        /// <param name="width">The width of the final image.</param>
+        /// <param name="height">The height of the final image.</param>
+        /// <typeparam name="TPixel">The pixel format.</typeparam>
+        /// <returns>A new <see cref="Image{TPixel}"/>.</returns>
+        private static Image<TPixel> LoadPixelData<TPixel>(Configuration config, Span<TPixel> data, int width, int height)
+            where TPixel : struct, IPixel<TPixel>
+        {
+            int count = width * height;
+            Guard.MustBeGreaterThanOrEqualTo(data.Length, width * height, nameof(data));
+            var image = new Image<TPixel>(config, width, height);
+            var dest = new Span<TPixel>(image.Pixels, 0, count);
+
+            SpanHelper.Copy(data, dest, count);
+
+            return image;
+        }
+    }
+}

--- a/src/ImageSharp/PixelFormats/PixelOperations{TPixel}.cs
+++ b/src/ImageSharp/PixelFormats/PixelOperations{TPixel}.cs
@@ -249,27 +249,5 @@ namespace ImageSharp.PixelFormats
                 sp.ToZyxwBytes(destBytes, i * 4);
             }
         }
-
-        /// <summary>
-        /// Bulk conversion of data from series bytes to a series of Pixels.
-        /// </summary>
-        /// <param name="sourceBytes">The <see cref="Span{T}"/> to the source bytes.</param>
-        /// <param name="destColors">The <see cref="Span{T}"/> to the destination colors.</param>
-        /// <param name="count">The number of pixels to convert.</param>
-        internal virtual void PackFromRawBytes(Span<byte> sourceBytes, Span<TPixel> destColors, int count)
-        {
-            Guard.MustBeSizedAtLeast(sourceBytes, count * Unsafe.SizeOf<TPixel>(), nameof(sourceBytes));
-            Guard.MustBeSizedAtLeast(destColors, count, nameof(destColors));
-
-            ref TPixel sourceRef = ref Unsafe.As<byte, TPixel>(ref sourceBytes.DangerousGetPinnableReference());
-            ref TPixel destRef = ref destColors.DangerousGetPinnableReference();
-
-            for (int i = 0; i < count; i++)
-            {
-                ref TPixel sp = ref Unsafe.Add(ref sourceRef, i);
-                ref TPixel dp = ref Unsafe.Add(ref destRef, i);
-                dp = sp;
-            }
-        }
     }
 }

--- a/src/ImageSharp/PixelFormats/PixelOperations{TPixel}.cs
+++ b/src/ImageSharp/PixelFormats/PixelOperations{TPixel}.cs
@@ -249,5 +249,27 @@ namespace ImageSharp.PixelFormats
                 sp.ToZyxwBytes(destBytes, i * 4);
             }
         }
+
+        /// <summary>
+        /// Bulk conversion of data from series bytes to a series of Pixels.
+        /// </summary>
+        /// <param name="sourceBytes">The <see cref="Span{T}"/> to the source bytes.</param>
+        /// <param name="destColors">The <see cref="Span{T}"/> to the destination colors.</param>
+        /// <param name="count">The number of pixels to convert.</param>
+        internal virtual void PackFromRawBytes(Span<byte> sourceBytes, Span<TPixel> destColors, int count)
+        {
+            Guard.MustBeSizedAtLeast(sourceBytes, count * Unsafe.SizeOf<TPixel>(), nameof(sourceBytes));
+            Guard.MustBeSizedAtLeast(destColors, count, nameof(destColors));
+
+            ref TPixel sourceRef = ref Unsafe.As<byte, TPixel>(ref sourceBytes.DangerousGetPinnableReference());
+            ref TPixel destRef = ref destColors.DangerousGetPinnableReference();
+
+            for (int i = 0; i < count; i++)
+            {
+                ref TPixel sp = ref Unsafe.Add(ref sourceRef, i);
+                ref TPixel dp = ref Unsafe.Add(ref destRef, i);
+                dp = sp;
+            }
+        }
     }
 }

--- a/tests/ImageSharp.Tests/Image/ImageLoadTests.cs
+++ b/tests/ImageSharp.Tests/Image/ImageLoadTests.cs
@@ -526,6 +526,48 @@ namespace ImageSharp.Tests
             this.localDecoder.Verify(x => x.Decode<Rgba32>(Configuration.Default, this.DataStream, this.decoderOptions));
         }
 
+        [Fact]
+        public void LoadFromPixelData_Pixels()
+        {
+            var img = Image.LoadPixelData<Rgba32>(new Rgba32[] {
+                Rgba32.Black, Rgba32.White,
+                Rgba32.White, Rgba32.Black,
+            }, 2, 2);
+
+            Assert.NotNull(img);
+            using (var px = img.Lock())
+            {
+                Assert.Equal(Rgba32.Black, px[0, 0]);
+                Assert.Equal(Rgba32.White, px[0, 1]);
+
+                Assert.Equal(Rgba32.White, px[1, 0]);
+                Assert.Equal(Rgba32.Black, px[1, 1]);
+
+            }
+        }
+
+        [Fact]
+        public void LoadFromPixelData_Bytes()
+        {
+            var img = Image.LoadPixelData<Rgba32>(new byte[] {
+                0,0,0,255, // 0,0
+                255,255,255,255, // 0,1
+                255,255,255,255, // 1,0
+                0,0,0,255, // 1,1
+            }, 2, 2);
+
+            Assert.NotNull(img);
+            using (var px = img.Lock())
+            {
+                Assert.Equal(Rgba32.Black, px[0, 0]);
+                Assert.Equal(Rgba32.White, px[0, 1]);
+
+                Assert.Equal(Rgba32.White, px[1, 0]);
+                Assert.Equal(Rgba32.Black, px[1, 1]);
+
+            }
+        }
+
         public void Dispose()
         {
             // clean up the global object;


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/JimBobSquarePants/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practise as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->

We've have multiple people recently asking how to push the raw pixel data into imagesharp.

So I've added a couple of new methods (with multiple overloads) of `Image.LoadPixelData(...)`

There are 2 variants one that takes `TPixel[]` and another taking `byte[]`. The version taking `byte[]` processes the bytes as raw memory holding pixel data based on which ever `TPixel` is being used, thus if you have a `byte[]` holding data in argb32 you would have to load that using `Image.LoadPixelData<Argb32>(...)` etc.


<!-- Thanks for contributing to ImageSharp! -->
