### PR TITLE
Internalize PixelAccessor<T>

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,17 +106,22 @@ using (Image<Rgba32> image = Image.Load<Rgba32>(stream))
 }
 ```
 
-Setting individual pixel values is perfomed as follows:
+Setting individual pixel values can perfomed as follows:
 
 ```csharp
+// Individual pixels
 using (Image<Rgba32> image = new Image<Rgba32>(400, 400)
-using (PixelAccessor<Rgba32> pixels = image.Lock())
 {
-    pixels[200, 200] = Rgba32.White;
+    image[200, 200] = Rgba32.White;
 }
 ```
 
-For advanced usage there are multiple [PixelFormat implementations](https://github.com/JimBobSquarePants/ImageSharp/tree/master/src/ImageSharp/PixelFormats) available allowing developers to implement their own color models in the same manner as Microsoft XNA Game Studio and MonoGame. 
+For optimized access within a loop it is recommended that the following methods are used.
+
+1. `image.GetRowSpan(y)`
+2. `image.GetRowSPan(x, y)`
+
+For advanced pixel format usage there are multiple [PixelFormat implementations](https://github.com/JimBobSquarePants/ImageSharp/tree/master/src/ImageSharp/PixelFormats) available allowing developers to implement their own color models in the same manner as Microsoft XNA Game Studio and MonoGame. 
 
 All in all this should allow image processing to be much more accessible to developers which has always been my goal from the start.
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ using (Image<Rgba32> image = Image.Load<Rgba32>(stream))
 }
 ```
 
-Setting individual pixel values can perfomed as follows:
+Setting individual pixel values can be perfomed as follows:
 
 ```csharp
 // Individual pixels

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ using (Image<Rgba32> image = new Image<Rgba32>(400, 400)
 For optimized access within a loop it is recommended that the following methods are used.
 
 1. `image.GetRowSpan(y)`
-2. `image.GetRowSPan(x, y)`
+2. `image.GetRowSpan(x, y)`
 
 For advanced pixel format usage there are multiple [PixelFormat implementations](https://github.com/JimBobSquarePants/ImageSharp/tree/master/src/ImageSharp/PixelFormats) available allowing developers to implement their own color models in the same manner as Microsoft XNA Game Studio and MonoGame. 
 

--- a/src/ImageSharp.Drawing/Brushes/IBrush.cs
+++ b/src/ImageSharp.Drawing/Brushes/IBrush.cs
@@ -22,7 +22,7 @@ namespace ImageSharp.Drawing
         /// <summary>
         /// Creates the applicator for this brush.
         /// </summary>
-        /// <param name="pixelSource">The pixel source.</param>
+        /// <param name="source">The source image.</param>
         /// <param name="region">The region the brush will be applied to.</param>
         /// <param name="options">The graphic options</param>
         /// <returns>
@@ -32,6 +32,6 @@ namespace ImageSharp.Drawing
         /// The <paramref name="region" /> when being applied to things like shapes would usually be the
         /// bounding box of the shape not necessarily the bounds of the whole image
         /// </remarks>
-        BrushApplicator<TPixel> CreateApplicator(PixelAccessor<TPixel> pixelSource, RectangleF region, GraphicsOptions options);
+        BrushApplicator<TPixel> CreateApplicator(ImageBase<TPixel> source, RectangleF region, GraphicsOptions options);
     }
 }

--- a/src/ImageSharp.Drawing/Brushes/PatternBrush{TPixel}.cs
+++ b/src/ImageSharp.Drawing/Brushes/PatternBrush{TPixel}.cs
@@ -62,8 +62,8 @@ namespace ImageSharp.Drawing.Brushes
         /// <param name="pattern">The pattern.</param>
         internal PatternBrush(TPixel foreColor, TPixel backColor, Fast2DArray<bool> pattern)
         {
-            Vector4 foreColorVector = foreColor.ToVector4();
-            Vector4 backColorVector = backColor.ToVector4();
+            var foreColorVector = foreColor.ToVector4();
+            var backColorVector = backColor.ToVector4();
             this.pattern = new Fast2DArray<TPixel>(pattern.Width, pattern.Height);
             this.patternVector = new Fast2DArray<Vector4>(pattern.Width, pattern.Height);
             for (int i = 0; i < pattern.Data.Length; i++)
@@ -92,9 +92,9 @@ namespace ImageSharp.Drawing.Brushes
         }
 
         /// <inheritdoc />
-        public BrushApplicator<TPixel> CreateApplicator(PixelAccessor<TPixel> sourcePixels, RectangleF region, GraphicsOptions options)
+        public BrushApplicator<TPixel> CreateApplicator(ImageBase<TPixel> source, RectangleF region, GraphicsOptions options)
         {
-            return new PatternBrushApplicator(sourcePixels, this.pattern, this.patternVector, options);
+            return new PatternBrushApplicator(source, this.pattern, this.patternVector, options);
         }
 
         /// <summary>
@@ -111,12 +111,12 @@ namespace ImageSharp.Drawing.Brushes
             /// <summary>
             /// Initializes a new instance of the <see cref="PatternBrushApplicator" /> class.
             /// </summary>
-            /// <param name="sourcePixels">The sourcePixels.</param>
+            /// <param name="source">The source image.</param>
             /// <param name="pattern">The pattern.</param>
             /// <param name="patternVector">The patternVector.</param>
             /// <param name="options">The options</param>
-            public PatternBrushApplicator(PixelAccessor<TPixel> sourcePixels, Fast2DArray<TPixel> pattern, Fast2DArray<Vector4> patternVector, GraphicsOptions options)
-                : base(sourcePixels, options)
+            public PatternBrushApplicator(ImageBase<TPixel> source, Fast2DArray<TPixel> pattern, Fast2DArray<Vector4> patternVector, GraphicsOptions options)
+                : base(source, options)
             {
                 this.pattern = pattern;
                 this.patternVector = patternVector;
@@ -152,8 +152,8 @@ namespace ImageSharp.Drawing.Brushes
             internal override void Apply(Span<float> scanline, int x, int y)
             {
                 int patternY = y % this.pattern.Height;
-                using (Buffer<float> amountBuffer = new Buffer<float>(scanline.Length))
-                using (Buffer<TPixel> overlay = new Buffer<TPixel>(scanline.Length))
+                using (var amountBuffer = new Buffer<float>(scanline.Length))
+                using (var overlay = new Buffer<TPixel>(scanline.Length))
                 {
                     for (int i = 0; i < scanline.Length; i++)
                     {

--- a/src/ImageSharp.Drawing/Brushes/Processors/BrushApplicator.cs
+++ b/src/ImageSharp.Drawing/Brushes/Processors/BrushApplicator.cs
@@ -6,7 +6,6 @@
 namespace ImageSharp.Drawing.Processors
 {
     using System;
-    using System.Numerics;
 
     using ImageSharp.Memory;
     using ImageSharp.PixelFormats;
@@ -24,7 +23,7 @@ namespace ImageSharp.Drawing.Processors
         /// </summary>
         /// <param name="target">The target.</param>
         /// <param name="options">The options.</param>
-        internal BrushApplicator(PixelAccessor<TPixel> target, GraphicsOptions options)
+        internal BrushApplicator(ImageBase<TPixel> target, GraphicsOptions options)
         {
             this.Target = target;
 
@@ -41,7 +40,7 @@ namespace ImageSharp.Drawing.Processors
         /// <summary>
         /// Gets the destinaion
         /// </summary>
-        protected PixelAccessor<TPixel> Target { get; }
+        protected ImageBase<TPixel> Target { get; }
 
         /// <summary>
         /// Gets the blend percentage
@@ -68,8 +67,8 @@ namespace ImageSharp.Drawing.Processors
         /// <remarks>scanlineBuffer will be > scanlineWidth but provide and offset in case we want to share a larger buffer across runs.</remarks>
         internal virtual void Apply(Span<float> scanline, int x, int y)
         {
-            using (Buffer<float> amountBuffer = new Buffer<float>(scanline.Length))
-            using (Buffer<TPixel> overlay = new Buffer<TPixel>(scanline.Length))
+            using (var amountBuffer = new Buffer<float>(scanline.Length))
+            using (var overlay = new Buffer<TPixel>(scanline.Length))
             {
                 for (int i = 0; i < scanline.Length; i++)
                 {

--- a/src/ImageSharp.Drawing/Brushes/RecolorBrush{TPixel}.cs
+++ b/src/ImageSharp.Drawing/Brushes/RecolorBrush{TPixel}.cs
@@ -57,9 +57,9 @@ namespace ImageSharp.Drawing.Brushes
         public TPixel TargeTPixel { get; }
 
         /// <inheritdoc />
-        public BrushApplicator<TPixel> CreateApplicator(PixelAccessor<TPixel> sourcePixels, RectangleF region, GraphicsOptions options)
+        public BrushApplicator<TPixel> CreateApplicator(ImageBase<TPixel> source, RectangleF region, GraphicsOptions options)
         {
-            return new RecolorBrushApplicator(sourcePixels, this.SourceColor, this.TargeTPixel, this.Threshold, options);
+            return new RecolorBrushApplicator(source, this.SourceColor, this.TargeTPixel, this.Threshold, options);
         }
 
         /// <summary>
@@ -87,22 +87,22 @@ namespace ImageSharp.Drawing.Brushes
             /// <summary>
             /// Initializes a new instance of the <see cref="RecolorBrushApplicator" /> class.
             /// </summary>
-            /// <param name="sourcePixels">The source pixels.</param>
+            /// <param name="source">The source image.</param>
             /// <param name="sourceColor">Color of the source.</param>
             /// <param name="targetColor">Color of the target.</param>
             /// <param name="threshold">The threshold .</param>
             /// <param name="options">The options</param>
-            public RecolorBrushApplicator(PixelAccessor<TPixel> sourcePixels, TPixel sourceColor, TPixel targetColor, float threshold, GraphicsOptions options)
-                : base(sourcePixels, options)
+            public RecolorBrushApplicator(ImageBase<TPixel> source, TPixel sourceColor, TPixel targetColor, float threshold, GraphicsOptions options)
+                : base(source, options)
             {
                 this.sourceColor = sourceColor.ToVector4();
                 this.targetColor = targetColor.ToVector4();
                 this.targetColorPixel = targetColor;
 
-                // Lets hack a min max extreams for a color space by letteing the IPackedPixel clamp our values to something in the correct spaces :)
-                TPixel maxColor = default(TPixel);
+                // Lets hack a min max extreams for a color space by letting the IPackedPixel clamp our values to something in the correct spaces :)
+                var maxColor = default(TPixel);
                 maxColor.PackFromVector4(new Vector4(float.MaxValue));
-                TPixel minColor = default(TPixel);
+                var minColor = default(TPixel);
                 minColor.PackFromVector4(new Vector4(float.MinValue));
                 this.threshold = Vector4.DistanceSquared(maxColor.ToVector4(), minColor.ToVector4()) * threshold;
             }
@@ -121,7 +121,7 @@ namespace ImageSharp.Drawing.Brushes
                 {
                     // Offset the requested pixel by the value in the rectangle (the shapes position)
                     TPixel result = this.Target[x, y];
-                    Vector4 background = result.ToVector4();
+                    var background = result.ToVector4();
                     float distance = Vector4.DistanceSquared(background, this.sourceColor);
                     if (distance <= this.threshold)
                     {
@@ -144,8 +144,8 @@ namespace ImageSharp.Drawing.Brushes
             /// <inheritdoc />
             internal override void Apply(Span<float> scanline, int x, int y)
             {
-                using (Buffer<float> amountBuffer = new Buffer<float>(scanline.Length))
-                using (Buffer<TPixel> overlay = new Buffer<TPixel>(scanline.Length))
+                using (var amountBuffer = new Buffer<float>(scanline.Length))
+                using (var overlay = new Buffer<TPixel>(scanline.Length))
                 {
                     for (int i = 0; i < scanline.Length; i++)
                     {

--- a/src/ImageSharp.Drawing/Brushes/SolidBrush{TPixel}.cs
+++ b/src/ImageSharp.Drawing/Brushes/SolidBrush{TPixel}.cs
@@ -42,9 +42,9 @@ namespace ImageSharp.Drawing.Brushes
         public TPixel Color => this.color;
 
         /// <inheritdoc />
-        public BrushApplicator<TPixel> CreateApplicator(PixelAccessor<TPixel> sourcePixels, RectangleF region, GraphicsOptions options)
+        public BrushApplicator<TPixel> CreateApplicator(ImageBase<TPixel> source, RectangleF region, GraphicsOptions options)
         {
-            return new SolidBrushApplicator(sourcePixels, this.color, options);
+            return new SolidBrushApplicator(source, this.color, options);
         }
 
         /// <summary>
@@ -55,13 +55,13 @@ namespace ImageSharp.Drawing.Brushes
             /// <summary>
             /// Initializes a new instance of the <see cref="SolidBrushApplicator"/> class.
             /// </summary>
+            /// <param name="source">The source image.</param>
             /// <param name="color">The color.</param>
             /// <param name="options">The options</param>
-            /// <param name="sourcePixels">The sourcePixels.</param>
-            public SolidBrushApplicator(PixelAccessor<TPixel> sourcePixels, TPixel color, GraphicsOptions options)
-                : base(sourcePixels, options)
+            public SolidBrushApplicator(ImageBase<TPixel> source, TPixel color, GraphicsOptions options)
+                : base(source, options)
             {
-                this.Colors = new Buffer<TPixel>(sourcePixels.Width);
+                this.Colors = new Buffer<TPixel>(source.Width);
                 for (int i = 0; i < this.Colors.Length; i++)
                 {
                     this.Colors[i] = color;
@@ -94,7 +94,7 @@ namespace ImageSharp.Drawing.Brushes
             {
                 Span<TPixel> destinationRow = this.Target.GetRowSpan(x, y).Slice(0, scanline.Length);
 
-                using (Buffer<float> amountBuffer = new Buffer<float>(scanline.Length))
+                using (var amountBuffer = new Buffer<float>(scanline.Length))
                 {
                     for (int i = 0; i < scanline.Length; i++)
                     {

--- a/src/ImageSharp.Drawing/Pens/IPen.cs
+++ b/src/ImageSharp.Drawing/Pens/IPen.cs
@@ -18,7 +18,7 @@ namespace ImageSharp.Drawing.Pens
         /// <summary>
         /// Creates the applicator for applying this pen to an Image
         /// </summary>
-        /// <param name="pixelSource">The pixel source.</param>
+        /// <param name="source">The source image.</param>
         /// <param name="region">The region the pen will be applied to.</param>
         /// <param name="options">The currently active graphic options.</param>
         /// <returns>
@@ -27,6 +27,6 @@ namespace ImageSharp.Drawing.Pens
         /// <remarks>
         /// The <paramref name="region" /> when being applied to things like shapes would usually be the bounding box of the shape not necessarily the shape of the whole image.
         /// </remarks>
-        PenApplicator<TPixel> CreateApplicator(PixelAccessor<TPixel> pixelSource, RectangleF region, GraphicsOptions options);
+        PenApplicator<TPixel> CreateApplicator(ImageBase<TPixel> source, RectangleF region, GraphicsOptions options);
     }
 }

--- a/src/ImageSharp.Drawing/Pens/Pen{TPixel}.cs
+++ b/src/ImageSharp.Drawing/Pens/Pen{TPixel}.cs
@@ -101,7 +101,7 @@ namespace ImageSharp.Drawing.Pens
         /// <summary>
         /// Creates the applicator for applying this pen to an Image
         /// </summary>
-        /// <param name="sourcePixels">The source pixels.</param>
+        /// <param name="source">The source image.</param>
         /// <param name="region">The region the pen will be applied to.</param>
         /// <param name="options">The Graphics options</param>
         /// <returns>
@@ -111,16 +111,16 @@ namespace ImageSharp.Drawing.Pens
         /// The <paramref name="region" /> when being applied to things like shapes would ussually be the
         /// bounding box of the shape not necorserrally the shape of the whole image
         /// </remarks>
-        public PenApplicator<TPixel> CreateApplicator(PixelAccessor<TPixel> sourcePixels, RectangleF region, GraphicsOptions options)
+        public PenApplicator<TPixel> CreateApplicator(ImageBase<TPixel> source, RectangleF region, GraphicsOptions options)
         {
             if (this.pattern == null || this.pattern.Length < 2)
             {
                 // if there is only one item in the pattern then 100% of it will
                 // be solid so use the quicker applicator
-                return new SolidPenApplicator(sourcePixels, this.Brush, region, this.Width, options);
+                return new SolidPenApplicator(source, this.Brush, region, this.Width, options);
             }
 
-            return new PatternPenApplicator(sourcePixels, this.Brush, region, this.Width, this.pattern, options);
+            return new PatternPenApplicator(source, this.Brush, region, this.Width, this.pattern, options);
         }
 
         private class SolidPenApplicator : PenApplicator<TPixel>
@@ -128,7 +128,7 @@ namespace ImageSharp.Drawing.Pens
             private readonly BrushApplicator<TPixel> brush;
             private readonly float halfWidth;
 
-            public SolidPenApplicator(PixelAccessor<TPixel> sourcePixels, IBrush<TPixel> brush, RectangleF region, float width, GraphicsOptions options)
+            public SolidPenApplicator(ImageBase<TPixel> sourcePixels, IBrush<TPixel> brush, RectangleF region, float width, GraphicsOptions options)
             {
                 this.brush = brush.CreateApplicator(sourcePixels, region, options);
                 this.halfWidth = width / 2;
@@ -147,7 +147,7 @@ namespace ImageSharp.Drawing.Pens
 
             public override ColoredPointInfo<TPixel> GetColor(int x, int y, PointInfo info)
             {
-                ColoredPointInfo<TPixel> result = default(ColoredPointInfo<TPixel>);
+                var result = default(ColoredPointInfo<TPixel>);
                 result.Color = this.brush[x, y];
 
                 if (info.DistanceFromPath < this.halfWidth)
@@ -171,9 +171,9 @@ namespace ImageSharp.Drawing.Pens
             private readonly float[] pattern;
             private readonly float totalLength;
 
-            public PatternPenApplicator(PixelAccessor<TPixel> sourcePixels, IBrush<TPixel> brush, RectangleF region, float width, float[] pattern, GraphicsOptions options)
+            public PatternPenApplicator(ImageBase<TPixel> source, IBrush<TPixel> brush, RectangleF region, float width, float[] pattern, GraphicsOptions options)
             {
-                this.brush = brush.CreateApplicator(sourcePixels, region, options);
+                this.brush = brush.CreateApplicator(source, region, options);
                 this.halfWidth = width / 2;
                 this.totalLength = 0;
 
@@ -200,7 +200,7 @@ namespace ImageSharp.Drawing.Pens
 
             public override ColoredPointInfo<TPixel> GetColor(int x, int y, PointInfo info)
             {
-                ColoredPointInfo<TPixel> infoResult = default(ColoredPointInfo<TPixel>);
+                var infoResult = default(ColoredPointInfo<TPixel>);
                 infoResult.DistanceFromElement = float.MaxValue; // is really outside the element
 
                 float length = info.DistanceAlongPath % this.totalLength;

--- a/src/ImageSharp.Drawing/Processors/DrawPathProcessor.cs
+++ b/src/ImageSharp.Drawing/Processors/DrawPathProcessor.cs
@@ -56,8 +56,7 @@ namespace ImageSharp.Drawing.Processors
         /// <inheritdoc/>
         protected override void OnApply(ImageBase<TPixel> source, Rectangle sourceRectangle)
         {
-            using (PixelAccessor<TPixel> sourcePixels = source.Lock())
-            using (PenApplicator<TPixel> applicator = this.Pen.CreateApplicator(sourcePixels, this.Path.Bounds, this.Options))
+            using (PenApplicator<TPixel> applicator = this.Pen.CreateApplicator(source, this.Path.Bounds, this.Options))
             {
                 Rectangle rect = RectangleF.Ceiling(applicator.RequiredRegion);
 
@@ -99,8 +98,8 @@ namespace ImageSharp.Drawing.Processors
                 {
                     int offsetY = y - polyStartY;
 
-                    using (Buffer<float> amount = new Buffer<float>(width))
-                    using (Buffer<TPixel> colors = new Buffer<TPixel>(width))
+                    using (var amount = new Buffer<float>(width))
+                    using (var colors = new Buffer<TPixel>(width))
                     {
                         for (int i = 0; i < width; i++)
                         {
@@ -112,7 +111,7 @@ namespace ImageSharp.Drawing.Processors
                             colors[i] = color.Color;
                         }
 
-                        Span<TPixel> destination = sourcePixels.GetRowSpan(offsetY).Slice(minX - startX, width);
+                        Span<TPixel> destination = source.GetRowSpan(offsetY).Slice(minX - startX, width);
                         blender.Blend(destination, destination, colors, amount);
                     }
                 });

--- a/src/ImageSharp.Drawing/Processors/FillProcessor.cs
+++ b/src/ImageSharp.Drawing/Processors/FillProcessor.cs
@@ -66,12 +66,11 @@ namespace ImageSharp.Drawing.Processors
 
             int width = maxX - minX;
 
-            // we could possibly do some optermising by having knowledge about the individual brushes operate
+            // We could possibly do some optimization by having knowledge about the individual brushes operate
             // for example If brush is SolidBrush<TPixel> then we could just get the color upfront
             // and skip using the IBrushApplicator<TPixel>?.
-            using (PixelAccessor<TPixel> sourcePixels = source.Lock())
-            using (Buffer<float> amount = new Buffer<float>(width))
-            using (BrushApplicator<TPixel> applicator = this.brush.CreateApplicator(sourcePixels, sourceRectangle, this.options))
+            using (var amount = new Buffer<float>(width))
+            using (BrushApplicator<TPixel> applicator = this.brush.CreateApplicator(source, sourceRectangle, this.options))
             {
                     for (int i = 0; i < width; i++)
                     {

--- a/src/ImageSharp.Drawing/Processors/FillRegionProcessor.cs
+++ b/src/ImageSharp.Drawing/Processors/FillRegionProcessor.cs
@@ -7,6 +7,7 @@ namespace ImageSharp.Drawing.Processors
 {
     using System;
     using System.Buffers;
+    using System.Runtime.CompilerServices;
     using Drawing;
 
     using ImageSharp.Memory;
@@ -89,12 +90,11 @@ namespace ImageSharp.Drawing.Processors
                 }
             }
 
-            using (PixelAccessor<TPixel> sourcePixels = source.Lock())
-            using (BrushApplicator<TPixel> applicator = this.Brush.CreateApplicator(sourcePixels, rect, this.Options))
+            using (BrushApplicator<TPixel> applicator = this.Brush.CreateApplicator(source, rect, this.Options))
             {
                 float[] buffer = arrayPool.Rent(maxIntersections);
                 int scanlineWidth = maxX - minX;
-                using (Buffer<float> scanline = new Buffer<float>(scanlineWidth))
+                using (var scanline = new Buffer<float>(scanlineWidth))
                 {
                     try
                     {
@@ -193,6 +193,7 @@ namespace ImageSharp.Drawing.Processors
             }
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static void Swap(float[] data, int left, int right)
         {
             float tmp = data[left];

--- a/src/ImageSharp/Common/Helpers/ImageMaths.cs
+++ b/src/ImageSharp/Common/Helpers/ImageMaths.cs
@@ -157,10 +157,10 @@ namespace ImageSharp
         {
             int width = bitmap.Width;
             int height = bitmap.Height;
-            Point topLeft = default(Point);
-            Point bottomRight = default(Point);
+            var topLeft = default(Point);
+            var bottomRight = default(Point);
 
-            Func<PixelAccessor<TPixel>, int, int, float, bool> delegateFunc;
+            Func<ImageBase<TPixel>, int, int, float, bool> delegateFunc;
 
             // Determine which channel to check against
             switch (channel)
@@ -182,7 +182,7 @@ namespace ImageSharp
                     break;
             }
 
-            int GetMinY(PixelAccessor<TPixel> pixels)
+            int GetMinY(ImageBase<TPixel> pixels)
             {
                 for (int y = 0; y < height; y++)
                 {
@@ -198,7 +198,7 @@ namespace ImageSharp
                 return 0;
             }
 
-            int GetMaxY(PixelAccessor<TPixel> pixels)
+            int GetMaxY(ImageBase<TPixel> pixels)
             {
                 for (int y = height - 1; y > -1; y--)
                 {
@@ -214,7 +214,7 @@ namespace ImageSharp
                 return height;
             }
 
-            int GetMinX(PixelAccessor<TPixel> pixels)
+            int GetMinX(ImageBase<TPixel> pixels)
             {
                 for (int x = 0; x < width; x++)
                 {
@@ -230,7 +230,7 @@ namespace ImageSharp
                 return 0;
             }
 
-            int GetMaxX(PixelAccessor<TPixel> pixels)
+            int GetMaxX(ImageBase<TPixel> pixels)
             {
                 for (int x = width - 1; x > -1; x--)
                 {
@@ -246,13 +246,10 @@ namespace ImageSharp
                 return height;
             }
 
-            using (PixelAccessor<TPixel> bitmapPixels = bitmap.Lock())
-            {
-                topLeft.Y = GetMinY(bitmapPixels);
-                topLeft.X = GetMinX(bitmapPixels);
-                bottomRight.Y = (GetMaxY(bitmapPixels) + 1).Clamp(0, height);
-                bottomRight.X = (GetMaxX(bitmapPixels) + 1).Clamp(0, width);
-            }
+            topLeft.Y = GetMinY(bitmap);
+            topLeft.X = GetMinX(bitmap);
+            bottomRight.Y = (GetMaxY(bitmap) + 1).Clamp(0, height);
+            bottomRight.X = (GetMaxX(bitmap) + 1).Clamp(0, width);
 
             return GetBoundingRectangle(topLeft, bottomRight);
         }

--- a/src/ImageSharp/Dithering/ErrorDiffusion/ErrorDiffuser.cs
+++ b/src/ImageSharp/Dithering/ErrorDiffusion/ErrorDiffuser.cs
@@ -71,7 +71,7 @@ namespace ImageSharp.Dithering
 
         /// <inheritdoc />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void Dither<TPixel>(PixelAccessor<TPixel> pixels, TPixel source, TPixel transformed, int x, int y, int width, int height)
+        public void Dither<TPixel>(ImageBase<TPixel> pixels, TPixel source, TPixel transformed, int x, int y, int width, int height)
             where TPixel : struct, IPixel<TPixel>
         {
             this.Dither(pixels, source, transformed, x, y, width, height, true);
@@ -79,13 +79,13 @@ namespace ImageSharp.Dithering
 
         /// <inheritdoc />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void Dither<TPixel>(PixelAccessor<TPixel> pixels, TPixel source, TPixel transformed, int x, int y, int width, int height, bool replacePixel)
+        public void Dither<TPixel>(ImageBase<TPixel> image, TPixel source, TPixel transformed, int x, int y, int width, int height, bool replacePixel)
             where TPixel : struct, IPixel<TPixel>
         {
             if (replacePixel)
             {
                 // Assign the transformed pixel to the array.
-                pixels[x, y] = transformed;
+                image[x, y] = transformed;
             }
 
             // Calculate the error
@@ -111,14 +111,14 @@ namespace ImageSharp.Dithering
                             continue;
                         }
 
-                        Vector4 coefficientVector = new Vector4(coefficient);
-                        Vector4 offsetColor = pixels[matrixX, matrixY].ToVector4();
+                        var coefficientVector = new Vector4(coefficient);
+                        var offsetColor = image[matrixX, matrixY].ToVector4();
                         Vector4 result = ((error * coefficientVector) / this.divisorVector) + offsetColor;
                         result.W = offsetColor.W;
 
-                        TPixel packed = default(TPixel);
+                        var packed = default(TPixel);
                         packed.PackFromVector4(result);
-                        pixels[matrixX, matrixY] = packed;
+                        image[matrixX, matrixY] = packed;
                     }
                 }
             }

--- a/src/ImageSharp/Dithering/ErrorDiffusion/IErrorDiffuser.cs
+++ b/src/ImageSharp/Dithering/ErrorDiffusion/IErrorDiffuser.cs
@@ -15,7 +15,7 @@ namespace ImageSharp.Dithering
         /// <summary>
         /// Transforms the image applying the dither matrix. This method alters the input pixels array
         /// </summary>
-        /// <param name="pixels">The pixel accessor </param>
+        /// <param name="image">The image</param>
         /// <param name="source">The source pixel</param>
         /// <param name="transformed">The transformed pixel</param>
         /// <param name="x">The column index.</param>
@@ -23,13 +23,13 @@ namespace ImageSharp.Dithering
         /// <param name="width">The image width.</param>
         /// <param name="height">The image height.</param>
         /// <typeparam name="TPixel">The pixel format.</typeparam>
-        void Dither<TPixel>(PixelAccessor<TPixel> pixels, TPixel source, TPixel transformed, int x, int y, int width, int height)
+        void Dither<TPixel>(ImageBase<TPixel> image, TPixel source, TPixel transformed, int x, int y, int width, int height)
             where TPixel : struct, IPixel<TPixel>;
 
         /// <summary>
         /// Transforms the image applying the dither matrix. This method alters the input pixels array
         /// </summary>
-        /// <param name="pixels">The pixel accessor </param>
+        /// <param name="image">The image</param>
         /// <param name="source">The source pixel</param>
         /// <param name="transformed">The transformed pixel</param>
         /// <param name="x">The column index.</param>
@@ -41,7 +41,7 @@ namespace ImageSharp.Dithering
         /// Generally this would be true for standard two-color dithering but when used in conjunction with color quantization this should be false.
         /// </param>
         /// <typeparam name="TPixel">The pixel format.</typeparam>
-        void Dither<TPixel>(PixelAccessor<TPixel> pixels, TPixel source, TPixel transformed, int x, int y, int width, int height, bool replacePixel)
+        void Dither<TPixel>(ImageBase<TPixel> image, TPixel source, TPixel transformed, int x, int y, int width, int height, bool replacePixel)
             where TPixel : struct, IPixel<TPixel>;
     }
 }

--- a/src/ImageSharp/Dithering/Ordered/IOrderedDither.cs
+++ b/src/ImageSharp/Dithering/Ordered/IOrderedDither.cs
@@ -15,7 +15,7 @@ namespace ImageSharp.Dithering
         /// <summary>
         /// Transforms the image applying the dither matrix. This method alters the input pixels array
         /// </summary>
-        /// <param name="pixels">The pixel accessor </param>
+        /// <param name="image">The image</param>
         /// <param name="source">The source pixel</param>
         /// <param name="upper">The color to apply to the pixels above the threshold.</param>
         /// <param name="lower">The color to apply to the pixels below the threshold.</param>
@@ -26,7 +26,7 @@ namespace ImageSharp.Dithering
         /// <param name="width">The image width.</param>
         /// <param name="height">The image height.</param>
         /// <typeparam name="TPixel">The pixel format.</typeparam>
-        void Dither<TPixel>(PixelAccessor<TPixel> pixels, TPixel source, TPixel upper, TPixel lower, byte[] bytes, int index, int x, int y, int width, int height)
+        void Dither<TPixel>(ImageBase<TPixel> image, TPixel source, TPixel upper, TPixel lower, byte[] bytes, int index, int x, int y, int width, int height)
             where TPixel : struct, IPixel<TPixel>;
     }
 }

--- a/src/ImageSharp/Dithering/Ordered/OrderedDither4x4.cs
+++ b/src/ImageSharp/Dithering/Ordered/OrderedDither4x4.cs
@@ -28,14 +28,14 @@ namespace ImageSharp.Dithering.Ordered
         }
 
         /// <inheritdoc />
-        public void Dither<TPixel>(PixelAccessor<TPixel> pixels, TPixel source, TPixel upper, TPixel lower, byte[] bytes, int index, int x, int y, int width, int height)
+        public void Dither<TPixel>(ImageBase<TPixel> image, TPixel source, TPixel upper, TPixel lower, byte[] bytes, int index, int x, int y, int width, int height)
             where TPixel : struct, IPixel<TPixel>
         {
             // TODO: This doesn't really cut it for me.
-            // I'd rather be using float but we need to add some sort of movalization vector methods to all IPixel implementations
+            // I'd rather be using float but we need to add some sort of normalization vector methods to all IPixel implementations
             // before we can do that as the vectors all cover different ranges.
             source.ToXyzwBytes(bytes, 0);
-            pixels[x, y] = this.matrix[y % 3, x % 3] >= bytes[index] ? lower : upper;
+            image[x, y] = this.matrix[y % 3, x % 3] >= bytes[index] ? lower : upper;
         }
     }
 }

--- a/src/ImageSharp/Formats/Gif/Sections/GifGraphicsControlExtension.cs
+++ b/src/ImageSharp/Formats/Gif/Sections/GifGraphicsControlExtension.cs
@@ -29,7 +29,7 @@ namespace ImageSharp.Formats
         /// The Transparency Index is such that when encountered, the corresponding pixel
         /// of the display device is not modified and processing goes on to the next pixel.
         /// </summary>
-        public int TransparencyIndex { get; set; }
+        public byte TransparencyIndex { get; set; }
 
         /// <summary>
         /// Gets or sets the delay time.

--- a/src/ImageSharp/Image/IImageBase{TPixel}.cs
+++ b/src/ImageSharp/Image/IImageBase{TPixel}.cs
@@ -21,14 +21,5 @@ namespace ImageSharp
         /// of the array for calculations. Use Width * Height.
         /// </summary>
         TPixel[] Pixels { get; }
-
-        /// <summary>
-        /// Locks the image providing access to the pixels.
-        /// <remarks>
-        /// It is imperative that the accessor is correctly disposed off after use.
-        /// </remarks>
-        /// </summary>
-        /// <returns>The <see cref="PixelAccessor{TPixel}"/></returns>
-        PixelAccessor<TPixel> Lock();
     }
 }

--- a/src/ImageSharp/Image/IImageBase{TPixel}.cs
+++ b/src/ImageSharp/Image/IImageBase{TPixel}.cs
@@ -16,10 +16,8 @@ namespace ImageSharp
         where TPixel : struct, IPixel<TPixel>
     {
         /// <summary>
-        /// Gets the pixels as an array of the given packed pixel format.
-        /// Important. Due to the nature in the way this is constructed do not rely on the length
-        /// of the array for calculations. Use Width * Height.
+        /// Gets the representation of the pixels as an area of contiguous memory in the given pixel format.
         /// </summary>
-        TPixel[] Pixels { get; }
+        Span<TPixel> Pixels { get; }
     }
 }

--- a/src/ImageSharp/Image/Image.LoadPixelData.cs
+++ b/src/ImageSharp/Image/Image.LoadPixelData.cs
@@ -68,11 +68,10 @@ namespace ImageSharp
             where TPixel : struct, IPixel<TPixel>
         {
             int count = width * height;
-            Guard.MustBeGreaterThanOrEqualTo(data.Length, width * height, nameof(data));
-            var image = new Image<TPixel>(config, width, height);
-            var dest = new Span<TPixel>(image.Pixels, 0, count);
+            Guard.MustBeGreaterThanOrEqualTo(data.Length, count, nameof(data));
 
-            SpanHelper.Copy(data, dest, count);
+            var image = new Image<TPixel>(config, width, height);
+            SpanHelper.Copy(data, image.Pixels, count);
 
             return image;
         }

--- a/src/ImageSharp/Image/ImageBase{TPixel}.cs
+++ b/src/ImageSharp/Image/ImageBase{TPixel}.cs
@@ -232,6 +232,15 @@ namespace ImageSharp
         }
 
         /// <summary>
+        /// Copies the pixels to another <see cref="PixelAccessor{TPixel}"/> of the same size.
+        /// </summary>
+        /// <param name="target">The target pixel buffer accessor.</param>
+        internal void CopyTo(PixelAccessor<TPixel> target)
+        {
+            SpanHelper.Copy(this.span, target.PixelBuffer.Span);
+        }
+
+        /// <summary>
         /// Switches the buffers used by the image and the PixelAccessor meaning that the Image will "own" the buffer from the PixelAccessor and the PixelAccessor will now own the Images buffer.
         /// </summary>
         /// <param name="pixelSource">The pixel source.</param>

--- a/src/ImageSharp/Image/ImageBase{TPixel}.cs
+++ b/src/ImageSharp/Image/ImageBase{TPixel}.cs
@@ -309,7 +309,6 @@ namespace ImageSharp
         {
             PixelDataPool<TPixel>.Return(this.pixelBuffer);
             this.pixelBuffer = null;
-            this.span = null;
         }
 
         /// <summary>

--- a/src/ImageSharp/Image/PixelAccessor{TPixel}.cs
+++ b/src/ImageSharp/Image/PixelAccessor{TPixel}.cs
@@ -48,7 +48,7 @@ namespace ImageSharp
             Guard.MustBeGreaterThan(image.Width, 0, "image width");
             Guard.MustBeGreaterThan(image.Height, 0, "image height");
 
-            this.SetPixelBufferUnsafe(image.Width, image.Height, image.Pixels);
+            this.SetPixelBufferUnsafe(image.Width, image.Height, image.PixelBuffer);
             this.ParallelOptions = image.Configuration.ParallelOptions;
         }
 

--- a/src/ImageSharp/Image/PixelAccessor{TPixel}.cs
+++ b/src/ImageSharp/Image/PixelAccessor{TPixel}.cs
@@ -17,7 +17,7 @@ namespace ImageSharp
     /// Provides per-pixel access to generic <see cref="Image{TPixel}"/> pixels.
     /// </summary>
     /// <typeparam name="TPixel">The pixel format.</typeparam>
-    public sealed class PixelAccessor<TPixel> : IDisposable, IBuffer2D<TPixel>
+    internal sealed class PixelAccessor<TPixel> : IDisposable, IBuffer2D<TPixel>
         where TPixel : struct, IPixel<TPixel>
     {
         /// <summary>
@@ -128,12 +128,14 @@ namespace ImageSharp
         /// <returns>The <see typeparam="TPixel"/> at the specified position.</returns>
         public TPixel this[int x, int y]
         {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get
             {
                 this.CheckCoordinates(x, y);
                 return this.PixelArray[(y * this.Width) + x];
             }
 
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
             set
             {
                 this.CheckCoordinates(x, y);

--- a/src/ImageSharp/Image/PixelAccessor{TPixel}.cs
+++ b/src/ImageSharp/Image/PixelAccessor{TPixel}.cs
@@ -20,6 +20,13 @@ namespace ImageSharp
     internal sealed class PixelAccessor<TPixel> : IDisposable, IBuffer2D<TPixel>
         where TPixel : struct, IPixel<TPixel>
     {
+#pragma warning disable SA1401 // Fields must be private
+        /// <summary>
+        /// The <see cref="Buffer{T}"/> containing the pixel data.
+        /// </summary>
+        internal Buffer2D<TPixel> PixelBuffer;
+#pragma warning restore SA1401 // Fields must be private
+
         /// <summary>
         /// A value indicating whether this instance of the given entity has been disposed.
         /// </summary>
@@ -30,11 +37,6 @@ namespace ImageSharp
         /// life in the Garbage Collector.
         /// </remarks>
         private bool isDisposed;
-
-        /// <summary>
-        /// The <see cref="Buffer{T}"/> containing the pixel data.
-        /// </summary>
-        private Buffer2D<TPixel> pixelBuffer;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="PixelAccessor{TPixel}"/> class.
@@ -88,7 +90,7 @@ namespace ImageSharp
         /// <summary>
         /// Gets the pixel buffer array.
         /// </summary>
-        public TPixel[] PixelArray => this.pixelBuffer.Array;
+        public TPixel[] PixelArray => this.PixelBuffer.Array;
 
         /// <summary>
         /// Gets the size of a single pixel in the number of bytes.
@@ -116,7 +118,7 @@ namespace ImageSharp
         public ParallelOptions ParallelOptions { get; }
 
         /// <inheritdoc />
-        Span<TPixel> IBuffer2D<TPixel>.Span => this.pixelBuffer;
+        Span<TPixel> IBuffer2D<TPixel>.Span => this.PixelBuffer;
 
         private static PixelOperations<TPixel> Operations => PixelOperations<TPixel>.Instance;
 
@@ -156,7 +158,7 @@ namespace ImageSharp
             // Note disposing is done.
             this.isDisposed = true;
 
-            this.pixelBuffer.Dispose();
+            this.PixelBuffer.Dispose();
 
             // This object will be cleaned up by the Dispose method.
             // Therefore, you should call GC.SuppressFinalize to
@@ -171,7 +173,7 @@ namespace ImageSharp
         /// </summary>
         public void Reset()
         {
-            this.pixelBuffer.Clear();
+            this.PixelBuffer.Clear();
         }
 
         /// <summary>
@@ -243,7 +245,7 @@ namespace ImageSharp
         /// <remarks>If <see cref="M:PixelAccessor.PooledMemory"/> is true then caller is responsible for ensuring <see cref="M:PixelDataPool.Return()"/> is called.</remarks>
         internal TPixel[] ReturnCurrentColorsAndReplaceThemInternally(int width, int height, TPixel[] pixels)
         {
-            TPixel[] oldPixels = this.pixelBuffer.TakeArrayOwnership();
+            TPixel[] oldPixels = this.PixelBuffer.TakeArrayOwnership();
             this.SetPixelBufferUnsafe(width, height, pixels);
             return oldPixels;
         }
@@ -254,7 +256,7 @@ namespace ImageSharp
         /// <param name="target">The target pixel buffer accessor.</param>
         internal void CopyTo(PixelAccessor<TPixel> target)
         {
-            SpanHelper.Copy(this.pixelBuffer.Span, target.pixelBuffer.Span);
+            SpanHelper.Copy(this.PixelBuffer.Span, target.PixelBuffer.Span);
         }
 
         /// <summary>
@@ -425,7 +427,7 @@ namespace ImageSharp
         /// <param name="pixels">The pixel buffer</param>
         private void SetPixelBufferUnsafe(int width, int height, Buffer2D<TPixel> pixels)
         {
-            this.pixelBuffer = pixels;
+            this.PixelBuffer = pixels;
 
             this.Width = width;
             this.Height = height;

--- a/src/ImageSharp/Memory/Buffer2D.cs
+++ b/src/ImageSharp/Memory/Buffer2D.cs
@@ -69,7 +69,7 @@ namespace ImageSharp.Memory
         /// <returns>The <see cref="Buffer{T}"/> instance</returns>
         public static Buffer2D<T> CreateClean(int width, int height)
         {
-            Buffer2D<T> buffer = new Buffer2D<T>(width, height);
+            var buffer = new Buffer2D<T>(width, height);
             buffer.Clear();
             return buffer;
         }

--- a/src/ImageSharp/Memory/Buffer2DExtensions.cs
+++ b/src/ImageSharp/Memory/Buffer2DExtensions.cs
@@ -29,7 +29,7 @@ namespace ImageSharp.Memory
         }
 
         /// <summary>
-        /// Gets a <see cref="Span{T}"/> to the row 'y' beginning from the pixel at 'x'.
+        /// Gets a <see cref="Span{T}"/> to the row 'y' beginning from the pixel at the first pixel on that row.
         /// </summary>
         /// <param name="buffer">The buffer</param>
         /// <param name="y">The y (row) coordinate</param>

--- a/src/ImageSharp/Memory/SpanHelper.cs
+++ b/src/ImageSharp/Memory/SpanHelper.cs
@@ -70,7 +70,7 @@ namespace ImageSharp.Memory
         public static void Copy<T>(Span<T> source, Span<T> destination)
             where T : struct
         {
-            Copy(source, destination, source.Length);
+            Copy(source, destination, Math.Min(source.Length, destination.Length));
         }
 
         /// <summary>

--- a/src/ImageSharp/Processing/Processors/Binarization/BinaryThresholdProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Binarization/BinaryThresholdProcessor.cs
@@ -83,25 +83,22 @@ namespace ImageSharp.Processing.Processors
                 startY = 0;
             }
 
-            using (PixelAccessor<TPixel> sourcePixels = source.Lock())
-            {
-                Parallel.For(
-                    minY,
-                    maxY,
-                    this.ParallelOptions,
-                    y =>
-                    {
-                        int offsetY = y - startY;
-                        for (int x = minX; x < maxX; x++)
-                        {
-                            int offsetX = x - startX;
-                            TPixel color = sourcePixels[offsetX, offsetY];
+            Parallel.For(
+                minY,
+                maxY,
+                this.ParallelOptions,
+                y =>
+                {
+                    Span<TPixel> row = source.GetRowSpan(y - startY);
 
-                            // Any channel will do since it's Grayscale.
-                            sourcePixels[offsetX, offsetY] = color.ToVector4().X >= threshold ? upper : lower;
-                        }
-                    });
-            }
+                    for (int x = minX; x < maxX; x++)
+                    {
+                        ref TPixel color = ref row[x - startX];
+
+                        // Any channel will do since it's Grayscale.
+                        color = color.ToVector4().X >= threshold ? upper : lower;
+                    }
+                });
         }
     }
 }

--- a/src/ImageSharp/Processing/Processors/Binarization/ErrorDiffusionDitherProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Binarization/ErrorDiffusionDitherProcessor.cs
@@ -85,18 +85,15 @@ namespace ImageSharp.Processing.Processors
                 startY = 0;
             }
 
-            using (PixelAccessor<TPixel> sourcePixels = source.Lock())
+            for (int y = minY; y < maxY; y++)
             {
-                for (int y = minY; y < maxY; y++)
+                int offsetY = y - startY;
+                for (int x = minX; x < maxX; x++)
                 {
-                    int offsetY = y - startY;
-                    for (int x = minX; x < maxX; x++)
-                    {
-                        int offsetX = x - startX;
-                        TPixel sourceColor = sourcePixels[offsetX, offsetY];
-                        TPixel transformedColor = sourceColor.ToVector4().X >= this.Threshold ? this.UpperColor : this.LowerColor;
-                        this.Diffuser.Dither(sourcePixels, sourceColor, transformedColor, offsetX, offsetY, maxX, maxY);
-                    }
+                    int offsetX = x - startX;
+                    TPixel sourceColor = source[offsetX, offsetY];
+                    TPixel transformedColor = sourceColor.ToVector4().X >= this.Threshold ? this.UpperColor : this.LowerColor;
+                    this.Diffuser.Dither(source, sourceColor, transformedColor, offsetX, offsetY, maxX, maxY);
                 }
             }
         }

--- a/src/ImageSharp/Processing/Processors/Binarization/ErrorDiffusionDitherProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Binarization/ErrorDiffusionDitherProcessor.cs
@@ -88,10 +88,12 @@ namespace ImageSharp.Processing.Processors
             for (int y = minY; y < maxY; y++)
             {
                 int offsetY = y - startY;
+                Span<TPixel> row = source.GetRowSpan(offsetY);
+
                 for (int x = minX; x < maxX; x++)
                 {
                     int offsetX = x - startX;
-                    TPixel sourceColor = source[offsetX, offsetY];
+                    TPixel sourceColor = row[offsetX];
                     TPixel transformedColor = sourceColor.ToVector4().X >= this.Threshold ? this.UpperColor : this.LowerColor;
                     this.Diffuser.Dither(source, sourceColor, transformedColor, offsetX, offsetY, maxX, maxY);
                 }

--- a/src/ImageSharp/Processing/Processors/Binarization/OrderedDitherProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Binarization/OrderedDitherProcessor.cs
@@ -93,21 +93,16 @@ namespace ImageSharp.Processing.Processors
                 startY = 0;
             }
 
-            using (PixelAccessor<TPixel> sourcePixels = source.Lock())
+            byte[] bytes = new byte[4];
+            for (int y = minY; y < maxY; y++)
             {
-                for (int y = minY; y < maxY; y++)
+                int offsetY = y - startY;
+
+                for (int x = minX; x < maxX; x++)
                 {
-                    int offsetY = y - startY;
-                    byte[] bytes = ArrayPool<byte>.Shared.Rent(4);
-
-                    for (int x = minX; x < maxX; x++)
-                    {
-                        int offsetX = x - startX;
-                        TPixel sourceColor = sourcePixels[offsetX, offsetY];
-                        this.Dither.Dither(sourcePixels, sourceColor, this.UpperColor, this.LowerColor, bytes, this.Index, offsetX, offsetY, maxX, maxY);
-                    }
-
-                    ArrayPool<byte>.Shared.Return(bytes);
+                    int offsetX = x - startX;
+                    TPixel sourceColor = source[offsetX, offsetY];
+                    this.Dither.Dither(source, sourceColor, this.UpperColor, this.LowerColor, bytes, this.Index, offsetX, offsetY, maxX, maxY);
                 }
             }
         }

--- a/src/ImageSharp/Processing/Processors/Binarization/OrderedDitherProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Binarization/OrderedDitherProcessor.cs
@@ -97,11 +97,12 @@ namespace ImageSharp.Processing.Processors
             for (int y = minY; y < maxY; y++)
             {
                 int offsetY = y - startY;
+                Span<TPixel> row = source.GetRowSpan(offsetY);
 
                 for (int x = minX; x < maxX; x++)
                 {
                     int offsetX = x - startX;
-                    TPixel sourceColor = source[offsetX, offsetY];
+                    TPixel sourceColor = row[offsetX];
                     this.Dither.Dither(source, sourceColor, this.UpperColor, this.LowerColor, bytes, this.Index, offsetX, offsetY, maxX, maxY);
                 }
             }

--- a/src/ImageSharp/Processing/Processors/Effects/AlphaProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Effects/AlphaProcessor.cs
@@ -61,26 +61,22 @@ namespace ImageSharp.Processing.Processors
                 startY = 0;
             }
 
-            Vector4 alphaVector = new Vector4(1, 1, 1, this.Value);
+            var alphaVector = new Vector4(1, 1, 1, this.Value);
 
-            using (PixelAccessor<TPixel> sourcePixels = source.Lock())
-            {
-                Parallel.For(
-                    minY,
-                    maxY,
-                    this.ParallelOptions,
-                    y =>
+            Parallel.For(
+                minY,
+                maxY,
+                this.ParallelOptions,
+                y =>
+                {
+                    Span<TPixel> row = source.GetRowSpan(y - startY);
+
+                    for (int x = minX; x < maxX; x++)
                     {
-                        int offsetY = y - startY;
-                        for (int x = minX; x < maxX; x++)
-                        {
-                            int offsetX = x - startX;
-                            TPixel packed = default(TPixel);
-                            packed.PackFromVector4(sourcePixels[offsetX, offsetY].ToVector4() * alphaVector);
-                            sourcePixels[offsetX, offsetY] = packed;
-                        }
-                    });
-            }
+                        ref TPixel pixel = ref row[x - startX];
+                        pixel.PackFromVector4(pixel.ToVector4() * alphaVector);
+                    }
+                });
         }
     }
 }

--- a/src/ImageSharp/Processing/Processors/Effects/BackgroundColorProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Effects/BackgroundColorProcessor.cs
@@ -6,7 +6,6 @@
 namespace ImageSharp.Processing.Processors
 {
     using System;
-    using System.Numerics;
     using System.Threading.Tasks;
 
     using ImageSharp.Memory;
@@ -64,9 +63,8 @@ namespace ImageSharp.Processing.Processors
 
             int width = maxX - minX;
 
-            using (Buffer<TPixel> colors = new Buffer<TPixel>(width))
-            using (Buffer<float> amount = new Buffer<float>(width))
-            using (PixelAccessor<TPixel> sourcePixels = source.Lock())
+            using (var colors = new Buffer<TPixel>(width))
+            using (var amount = new Buffer<float>(width))
             {
                 for (int i = 0; i < width; i++)
                 {
@@ -81,11 +79,9 @@ namespace ImageSharp.Processing.Processors
                     this.ParallelOptions,
                     y =>
                     {
-                        int offsetY = y - startY;
+                        Span<TPixel> destination = source.GetRowSpan(y - startY).Slice(minX - startX, width);
 
-                        Span<TPixel> destination = sourcePixels.GetRowSpan(offsetY).Slice(minX - startX, width);
-
-                        // this switched color & destination in the 2nd and 3rd places because we are applying the target colour under the current one
+                        // This switched color & destination in the 2nd and 3rd places because we are applying the target colour under the current one
                         blender.Blend(destination, colors, destination, amount);
                     });
             }

--- a/src/ImageSharp/Processing/Processors/Effects/ContrastProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Effects/ContrastProcessor.cs
@@ -71,12 +71,10 @@ namespace ImageSharp.Processing.Processors
                 this.ParallelOptions,
                 y =>
                     {
-                        int offsetY = y - startY;
                         Span<TPixel> row = source.GetRowSpan(y - startY);
 
                         for (int x = minX; x < maxX; x++)
                         {
-                            int offsetX = x - startX;
                             ref TPixel pixel = ref row[x - startX];
 
                             Vector4 vector = pixel.ToVector4().Expand();

--- a/src/ImageSharp/Processing/Processors/Overlays/GlowProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Overlays/GlowProcessor.cs
@@ -52,7 +52,7 @@ namespace ImageSharp.Processing.Processors
             int startX = sourceRectangle.X;
             int endX = sourceRectangle.Right;
             TPixel glowColor = this.GlowColor;
-            Vector2 centre = Rectangle.Center(sourceRectangle).ToVector2();
+            var centre = Rectangle.Center(sourceRectangle).ToVector2();
             float maxDistance = this.Radius > 0 ? MathF.Min(this.Radius, sourceRectangle.Width * .5F) : sourceRectangle.Width * .5F;
 
             // Align start/end positions.
@@ -73,8 +73,7 @@ namespace ImageSharp.Processing.Processors
             }
 
             int width = maxX - minX;
-            using (Buffer<TPixel> rowColors = new Buffer<TPixel>(width))
-            using (PixelAccessor<TPixel> sourcePixels = source.Lock())
+            using (var rowColors = new Buffer<TPixel>(width))
             {
                 for (int i = 0; i < width; i++)
                 {
@@ -82,26 +81,26 @@ namespace ImageSharp.Processing.Processors
                 }
 
                 Parallel.For(
-                         minY,
-                         maxY,
-                         this.ParallelOptions,
-                         y =>
-                         {
-                             using (Buffer<float> amounts = new Buffer<float>(width))
-                             {
-                                 int offsetY = y - startY;
-                                 int offsetX = minX - startX;
-                                 for (int i = 0; i < width; i++)
-                                 {
-                                     float distance = Vector2.Distance(centre, new Vector2(i + offsetX, offsetY));
-                                     amounts[i] = (this.options.BlendPercentage * (1 - (.95F * (distance / maxDistance)))).Clamp(0, 1);
-                                 }
+                    minY,
+                    maxY,
+                    this.ParallelOptions,
+                    y =>
+                    {
+                        using (var amounts = new Buffer<float>(width))
+                        {
+                            int offsetY = y - startY;
+                            int offsetX = minX - startX;
+                            for (int i = 0; i < width; i++)
+                            {
+                                float distance = Vector2.Distance(centre, new Vector2(i + offsetX, offsetY));
+                                amounts[i] = (this.options.BlendPercentage * (1 - (.95F * (distance / maxDistance)))).Clamp(0, 1);
+                            }
 
-                                 Span<TPixel> destination = sourcePixels.GetRowSpan(offsetY).Slice(offsetX, width);
+                            Span<TPixel> destination = source.GetRowSpan(offsetY).Slice(offsetX, width);
 
-                                 this.blender.Blend(destination, destination, rowColors, amounts);
-                             }
-                         });
+                            this.blender.Blend(destination, destination, rowColors, amounts);
+                        }
+                    });
             }
         }
     }

--- a/src/ImageSharp/Processing/Processors/Overlays/VignetteProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Overlays/VignetteProcessor.cs
@@ -58,7 +58,7 @@ namespace ImageSharp.Processing.Processors
             int startX = sourceRectangle.X;
             int endX = sourceRectangle.Right;
             TPixel vignetteColor = this.VignetteColor;
-            Vector2 centre = Rectangle.Center(sourceRectangle).ToVector2();
+            var centre = Rectangle.Center(sourceRectangle).ToVector2();
             float rX = this.RadiusX > 0 ? MathF.Min(this.RadiusX, sourceRectangle.Width * .5F) : sourceRectangle.Width * .5F;
             float rY = this.RadiusY > 0 ? MathF.Min(this.RadiusY, sourceRectangle.Height * .5F) : sourceRectangle.Height * .5F;
             float maxDistance = MathF.Sqrt((rX * rX) + (rY * rY));
@@ -81,8 +81,7 @@ namespace ImageSharp.Processing.Processors
             }
 
             int width = maxX - minX;
-            using (Buffer<TPixel> rowColors = new Buffer<TPixel>(width))
-            using (PixelAccessor<TPixel> sourcePixels = source.Lock())
+            using (var rowColors = new Buffer<TPixel>(width))
             {
                 for (int i = 0; i < width; i++)
                 {
@@ -95,7 +94,7 @@ namespace ImageSharp.Processing.Processors
                     this.ParallelOptions,
                     y =>
                         {
-                            using (Buffer<float> amounts = new Buffer<float>(width))
+                            using (var amounts = new Buffer<float>(width))
                             {
                                 int offsetY = y - startY;
                                 int offsetX = minX - startX;
@@ -105,7 +104,7 @@ namespace ImageSharp.Processing.Processors
                                     amounts[i] = (this.options.BlendPercentage * (.9F * (distance / maxDistance))).Clamp(0, 1);
                                 }
 
-                                Span<TPixel> destination = sourcePixels.GetRowSpan(offsetY).Slice(offsetX, width);
+                                Span<TPixel> destination = source.GetRowSpan(offsetY).Slice(offsetX, width);
 
                                 this.blender.Blend(destination, destination, rowColors, amounts);
                             }

--- a/src/ImageSharp/Processing/Processors/Transforms/Matrix3x2Processor.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/Matrix3x2Processor.cs
@@ -5,7 +5,6 @@
 
 namespace ImageSharp.Processing.Processors
 {
-    using System;
     using System.Numerics;
 
     using ImageSharp.PixelFormats;
@@ -45,8 +44,8 @@ namespace ImageSharp.Processing.Processors
         /// </returns>
         protected Matrix3x2 GetCenteredMatrix(ImageBase<TPixel> source, Matrix3x2 matrix)
         {
-            Matrix3x2 translationToTargetCenter = Matrix3x2.CreateTranslation(-this.CanvasRectangle.Width * .5F, -this.CanvasRectangle.Height * .5F);
-            Matrix3x2 translateToSourceCenter = Matrix3x2.CreateTranslation(source.Width * .5F, source.Height * .5F);
+            var translationToTargetCenter = Matrix3x2.CreateTranslation(-this.CanvasRectangle.Width * .5F, -this.CanvasRectangle.Height * .5F);
+            var translateToSourceCenter = Matrix3x2.CreateTranslation(source.Width * .5F, source.Height * .5F);
             return (translationToTargetCenter * matrix) * translateToSourceCenter;
         }
     }

--- a/src/ImageSharp/Processing/Processors/Transforms/ResamplingWeightedProcessor.Weights.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/ResamplingWeightedProcessor.Weights.cs
@@ -1,3 +1,8 @@
+// <copyright file="ResamplingWeightedProcessor.Weights.cs" company="James Jackson-South">
+// Copyright (c) James Jackson-South and contributors.
+// Licensed under the Apache License, Version 2.0.
+// </copyright>
+
 namespace ImageSharp.Processing.Processors
 {
     using System;

--- a/src/ImageSharp/Processing/Processors/Transforms/ResamplingWeightedProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/ResamplingWeightedProcessor.cs
@@ -6,9 +6,7 @@
 namespace ImageSharp.Processing.Processors
 {
     using System;
-    using System.Buffers;
     using System.Runtime.CompilerServices;
-    using System.Runtime.InteropServices;
 
     using ImageSharp.PixelFormats;
 
@@ -90,7 +88,7 @@ namespace ImageSharp.Processing.Processors
 
             IResampler sampler = this.Sampler;
             float radius = MathF.Ceiling(scale * sampler.Radius);
-            WeightsBuffer result = new WeightsBuffer(sourceSize, destinationSize);
+            var result = new WeightsBuffer(sourceSize, destinationSize);
 
             for (int i = 0; i < destinationSize; i++)
             {

--- a/src/ImageSharp/Processing/Processors/Transforms/RotateProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/RotateProcessor.cs
@@ -8,7 +8,7 @@ namespace ImageSharp.Processing.Processors
     using System;
     using System.Numerics;
     using System.Threading.Tasks;
-
+    using ImageSharp.Memory;
     using ImageSharp.PixelFormats;
 
     /// <summary>
@@ -45,26 +45,26 @@ namespace ImageSharp.Processing.Processors
             int width = this.CanvasRectangle.Width;
             Matrix3x2 matrix = this.GetCenteredMatrix(source, this.processMatrix);
 
-            using (PixelAccessor<TPixel> targetPixels = new PixelAccessor<TPixel>(width, height))
+            using (var targetPixels = new PixelAccessor<TPixel>(width, height))
             {
-                using (PixelAccessor<TPixel> sourcePixels = source.Lock())
-                {
-                    Parallel.For(
-                        0,
-                        height,
-                        this.ParallelOptions,
-                        y =>
+                Parallel.For(
+                    0,
+                    height,
+                    this.ParallelOptions,
+                    y =>
+                    {
+                        Span<TPixel> targetRow = targetPixels.GetRowSpan(y);
+
+                        for (int x = 0; x < width; x++)
                         {
-                            for (int x = 0; x < width; x++)
+                            var transformedPoint = Point.Rotate(new Point(x, y), matrix);
+
+                            if (source.Bounds.Contains(transformedPoint.X, transformedPoint.Y))
                             {
-                                Point transformedPoint = Point.Rotate(new Point(x, y), matrix);
-                                if (source.Bounds.Contains(transformedPoint.X, transformedPoint.Y))
-                                {
-                                    targetPixels[x, y] = sourcePixels[transformedPoint.X, transformedPoint.Y];
-                                }
+                                targetRow[x] = source[transformedPoint.X, transformedPoint.Y];
                             }
-                        });
-                }
+                        }
+                    });
 
                 source.SwapPixelsBuffers(targetPixels);
             }
@@ -128,7 +128,7 @@ namespace ImageSharp.Processing.Processors
             int width = source.Width;
             int height = source.Height;
 
-            using (PixelAccessor<TPixel> targetPixels = new PixelAccessor<TPixel>(height, width))
+            using (var targetPixels = new PixelAccessor<TPixel>(height, width))
             {
                 using (PixelAccessor<TPixel> sourcePixels = source.Lock())
                 {
@@ -161,24 +161,22 @@ namespace ImageSharp.Processing.Processors
             int width = source.Width;
             int height = source.Height;
 
-            using (PixelAccessor<TPixel> targetPixels = new PixelAccessor<TPixel>(width, height))
+            using (var targetPixels = new PixelAccessor<TPixel>(width, height))
             {
-                using (PixelAccessor<TPixel> sourcePixels = source.Lock())
-                {
-                    Parallel.For(
-                        0,
-                        height,
-                        this.ParallelOptions,
-                        y =>
+                Parallel.For(
+                    0,
+                    height,
+                    this.ParallelOptions,
+                    y =>
+                    {
+                        Span<TPixel> sourceRow = source.GetRowSpan(y);
+                        Span<TPixel> targetRow = targetPixels.GetRowSpan(height - y - 1);
+
+                        for (int x = 0; x < width; x++)
                         {
-                            for (int x = 0; x < width; x++)
-                            {
-                                int newX = width - x - 1;
-                                int newY = height - y - 1;
-                                targetPixels[newX, newY] = sourcePixels[x, y];
-                            }
-                        });
-                }
+                            targetRow[width - x - 1] = sourceRow[x];
+                        }
+                    });
 
                 source.SwapPixelsBuffers(targetPixels);
             }
@@ -193,23 +191,21 @@ namespace ImageSharp.Processing.Processors
             int width = source.Width;
             int height = source.Height;
 
-            using (PixelAccessor<TPixel> targetPixels = new PixelAccessor<TPixel>(height, width))
+            using (var targetPixels = new PixelAccessor<TPixel>(height, width))
             {
-                using (PixelAccessor<TPixel> sourcePixels = source.Lock())
-                {
-                    Parallel.For(
-                        0,
-                        height,
-                        this.ParallelOptions,
-                        y =>
+                Parallel.For(
+                    0,
+                    height,
+                    this.ParallelOptions,
+                    y =>
+                    {
+                        Span<TPixel> sourceRow = source.GetRowSpan(y);
+                        int newX = height - y - 1;
+                        for (int x = 0; x < width; x++)
                         {
-                            for (int x = 0; x < width; x++)
-                            {
-                                int newX = height - y - 1;
-                                targetPixels[newX, x] = sourcePixels[x, y];
-                            }
-                        });
-                }
+                            targetPixels[newX, x] = sourceRow[x];
+                        }
+                    });
 
                 source.SwapPixelsBuffers(targetPixels);
             }

--- a/src/ImageSharp/Processing/Processors/Transforms/SkewProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/SkewProcessor.cs
@@ -8,7 +8,7 @@ namespace ImageSharp.Processing.Processors
     using System;
     using System.Numerics;
     using System.Threading.Tasks;
-
+    using ImageSharp.Memory;
     using ImageSharp.PixelFormats;
 
     /// <summary>
@@ -45,26 +45,26 @@ namespace ImageSharp.Processing.Processors
             int width = this.CanvasRectangle.Width;
             Matrix3x2 matrix = this.GetCenteredMatrix(source, this.processMatrix);
 
-            using (PixelAccessor<TPixel> targetPixels = new PixelAccessor<TPixel>(width, height))
+            using (var targetPixels = new PixelAccessor<TPixel>(width, height))
             {
-                using (PixelAccessor<TPixel> sourcePixels = source.Lock())
-                {
-                    Parallel.For(
-                        0,
-                        height,
-                        this.ParallelOptions,
-                        y =>
+                Parallel.For(
+                    0,
+                    height,
+                    this.ParallelOptions,
+                    y =>
+                        {
+                            Span<TPixel> targetRow = targetPixels.GetRowSpan(y);
+
+                            for (int x = 0; x < width; x++)
                             {
-                                for (int x = 0; x < width; x++)
+                                var transformedPoint = Point.Skew(new Point(x, y), matrix);
+
+                                if (source.Bounds.Contains(transformedPoint.X, transformedPoint.Y))
                                 {
-                                    Point transformedPoint = Point.Skew(new Point(x, y), matrix);
-                                    if (source.Bounds.Contains(transformedPoint.X, transformedPoint.Y))
-                                    {
-                                        targetPixels[x, y] = sourcePixels[transformedPoint.X, transformedPoint.Y];
-                                    }
+                                    targetRow[x] = source[transformedPoint.X, transformedPoint.Y];
                                 }
-                            });
-                }
+                            }
+                        });
 
                 source.SwapPixelsBuffers(targetPixels);
             }

--- a/src/ImageSharp/Quantizers/OctreeQuantizer{TPixel}.cs
+++ b/src/ImageSharp/Quantizers/OctreeQuantizer{TPixel}.cs
@@ -66,7 +66,7 @@ namespace ImageSharp.Quantizers
         }
 
         /// <inheritdoc/>
-        protected override void SecondPass(PixelAccessor<TPixel> source, byte[] output, int width, int height)
+        protected override void SecondPass(ImageBase<TPixel> source, byte[] output, int width, int height)
         {
             // Load up the values for the first pixel. We can use these to speed up the second
             // pass of the algorithm by avoiding transforming rows of identical color.
@@ -490,7 +490,7 @@ namespace ImageSharp.Quantizers
                         byte b = (this.blue / this.pixelCount).ToByte();
 
                         // And set the color of the palette entry
-                        TPixel pixel = default(TPixel);
+                        var pixel = default(TPixel);
                         pixel.PackFromBytes(r, g, b, 255);
                         palette[index] = pixel;
 

--- a/src/ImageSharp/Quantizers/OctreeQuantizer{TPixel}.cs
+++ b/src/ImageSharp/Quantizers/OctreeQuantizer{TPixel}.cs
@@ -36,7 +36,7 @@ namespace ImageSharp.Quantizers
         /// <summary>
         /// Maximum allowed color depth
         /// </summary>
-        private int colors;
+        private byte colors;
 
         /// <summary>
         /// The reduced image palette
@@ -58,7 +58,7 @@ namespace ImageSharp.Quantizers
         /// <inheritdoc/>
         public override QuantizedImage<TPixel> Quantize(ImageBase<TPixel> image, int maxColors)
         {
-            this.colors = maxColors.Clamp(1, 255);
+            this.colors = (byte)maxColors.Clamp(1, 255);
             this.octree = new Octree(this.GetBitsNeededForColorDepth(this.colors));
             this.palette = null;
 
@@ -123,7 +123,7 @@ namespace ImageSharp.Quantizers
         /// <inheritdoc/>
         protected override TPixel[] GetPalette()
         {
-            return this.palette ?? (this.palette = this.octree.Palletize(Math.Max(this.colors, 1)));
+            return this.palette ?? (this.palette = this.octree.Palletize(Math.Max(this.colors, (byte)1)));
         }
 
         /// <summary>
@@ -141,6 +141,12 @@ namespace ImageSharp.Quantizers
                 // The colors have changed so we need to use Euclidean distance caclulation to find the closest value.
                 // This palette can never be null here.
                 return this.GetClosestPixel(pixel, this.palette, this.colorMap);
+            }
+
+            pixel.ToXyzwBytes(this.pixelBuffer, 0);
+            if (this.pixelBuffer[3] == 0)
+            {
+                return this.colors;
             }
 
             return (byte)this.octree.GetPaletteIndex(pixel, this.pixelBuffer);

--- a/src/ImageSharp/Quantizers/OctreeQuantizer{TPixel}.cs
+++ b/src/ImageSharp/Quantizers/OctreeQuantizer{TPixel}.cs
@@ -78,11 +78,13 @@ namespace ImageSharp.Quantizers
 
             for (int y = 0; y < height; y++)
             {
+                Span<TPixel> row = source.GetRowSpan(y);
+
                 // And loop through each column
                 for (int x = 0; x < width; x++)
                 {
                     // Get the pixel.
-                    sourcePixel = source[x, y];
+                    sourcePixel = row[x];
 
                     // Check if this is the same as the last pixel. If so use that value
                     // rather than calculating it again. This is an inexpensive optimization.

--- a/src/ImageSharp/Quantizers/PaletteQuantizer{TPixel}.cs
+++ b/src/ImageSharp/Quantizers/PaletteQuantizer{TPixel}.cs
@@ -84,11 +84,13 @@ namespace ImageSharp.Quantizers
 
             for (int y = 0; y < height; y++)
             {
+                Span<TPixel> row = source.GetRowSpan(y);
+
                 // And loop through each column
                 for (int x = 0; x < width; x++)
                 {
                     // Get the pixel.
-                    sourcePixel = source[x, y];
+                    sourcePixel = row[x];
 
                     // Check if this is the same as the last pixel. If so use that value
                     // rather than calculating it again. This is an inexpensive optimization.

--- a/src/ImageSharp/Quantizers/PaletteQuantizer{TPixel}.cs
+++ b/src/ImageSharp/Quantizers/PaletteQuantizer{TPixel}.cs
@@ -51,7 +51,7 @@ namespace ImageSharp.Quantizers
                 for (int i = 0; i < constants.Length; i++)
                 {
                     constants[i].ToXyzwBytes(this.pixelBuffer, 0);
-                    TPixel packed = default(TPixel);
+                    var packed = default(TPixel);
                     packed.PackFromBytes(this.pixelBuffer[0], this.pixelBuffer[1], this.pixelBuffer[2], this.pixelBuffer[3]);
                     safe[i] = packed;
                 }
@@ -72,7 +72,7 @@ namespace ImageSharp.Quantizers
         }
 
         /// <inheritdoc/>
-        protected override void SecondPass(PixelAccessor<TPixel> source, byte[] output, int width, int height)
+        protected override void SecondPass(ImageBase<TPixel> source, byte[] output, int width, int height)
         {
             // Load up the values for the first pixel. We can use these to speed up the second
             // pass of the algorithm by avoiding transforming rows of identical color.

--- a/src/ImageSharp/Quantizers/Quantizer{TPixel}.cs
+++ b/src/ImageSharp/Quantizers/Quantizer{TPixel}.cs
@@ -5,6 +5,7 @@
 
 namespace ImageSharp.Quantizers
 {
+    using System;
     using System.Collections.Generic;
     using System.Numerics;
     using System.Runtime.CompilerServices;
@@ -93,11 +94,13 @@ namespace ImageSharp.Quantizers
             // Loop through each row
             for (int y = 0; y < height; y++)
             {
+                Span<TPixel> row = source.GetRowSpan(y);
+
                 // And loop through each column
                 for (int x = 0; x < width; x++)
                 {
                     // Now I have the pixel, call the FirstPassQuantize function...
-                    this.InitialQuantizePixel(source[x, y]);
+                    this.InitialQuantizePixel(row[x]);
                 }
             }
         }

--- a/src/ImageSharp/Quantizers/Quantizer{TPixel}.cs
+++ b/src/ImageSharp/Quantizers/Quantizer{TPixel}.cs
@@ -54,34 +54,29 @@ namespace ImageSharp.Quantizers
             int height = image.Height;
             int width = image.Width;
             byte[] quantizedPixels = new byte[width * height];
-            TPixel[] colorPalette;
 
-            using (PixelAccessor<TPixel> pixels = image.Lock())
+            // Call the FirstPass function if not a single pass algorithm.
+            // For something like an Octree quantizer, this will run through
+            // all image pixels, build a data structure, and create a palette.
+            if (!this.singlePass)
             {
-                // Call the FirstPass function if not a single pass algorithm.
-                // For something like an Octree quantizer, this will run through
-                // all image pixels, build a data structure, and create a palette.
-                if (!this.singlePass)
-                {
-                    this.FirstPass(pixels, width, height);
-                }
+                this.FirstPass(image, width, height);
+            }
 
-                // Collect the palette. Required before the second pass runs.
-                colorPalette = this.GetPalette();
+            // Collect the palette. Required before the second pass runs.
+            TPixel[] colorPalette = this.GetPalette();
 
-                if (this.Dither)
+            if (this.Dither)
+            {
+                // We clone the image as we don't want to alter the original.
+                using (var clone = new Image<TPixel>(image))
                 {
-                    // We clone the image as we don't want to alter the original.
-                    using (Image<TPixel> clone = new Image<TPixel>(image))
-                    using (PixelAccessor<TPixel> clonedPixels = clone.Lock())
-                    {
-                        this.SecondPass(clonedPixels, quantizedPixels, width, height);
-                    }
+                    this.SecondPass(clone, quantizedPixels, width, height);
                 }
-                else
-                {
-                    this.SecondPass(pixels, quantizedPixels, width, height);
-                }
+            }
+            else
+            {
+                this.SecondPass(image, quantizedPixels, width, height);
             }
 
             return new QuantizedImage<TPixel>(width, height, colorPalette, quantizedPixels);
@@ -93,7 +88,7 @@ namespace ImageSharp.Quantizers
         /// <param name="source">The source data</param>
         /// <param name="width">The width in pixels of the image.</param>
         /// <param name="height">The height in pixels of the image.</param>
-        protected virtual void FirstPass(PixelAccessor<TPixel> source, int width, int height)
+        protected virtual void FirstPass(ImageBase<TPixel> source, int width, int height)
         {
             // Loop through each row
             for (int y = 0; y < height; y++)
@@ -114,7 +109,7 @@ namespace ImageSharp.Quantizers
         /// <param name="output">The output pixel array</param>
         /// <param name="width">The width in pixels of the image</param>
         /// <param name="height">The height in pixels of the image</param>
-        protected abstract void SecondPass(PixelAccessor<TPixel> source, byte[] output, int width, int height);
+        protected abstract void SecondPass(ImageBase<TPixel> source, byte[] output, int width, int height);
 
         /// <summary>
         /// Override this to process the pixel in the first pass of the algorithm
@@ -155,7 +150,7 @@ namespace ImageSharp.Quantizers
             // Not found - loop through the palette and find the nearest match.
             byte colorIndex = 0;
             float leastDistance = int.MaxValue;
-            Vector4 vector = pixel.ToVector4();
+            var vector = pixel.ToVector4();
 
             for (int index = 0; index < colorPalette.Length; index++)
             {

--- a/src/ImageSharp/Quantizers/WuQuantizer{TPixel}.cs
+++ b/src/ImageSharp/Quantizers/WuQuantizer{TPixel}.cs
@@ -252,11 +252,13 @@ namespace ImageSharp.Quantizers
 
             for (int y = 0; y < height; y++)
             {
+                Span<TPixel> row = source.GetRowSpan(y);
+
                 // And loop through each column
                 for (int x = 0; x < width; x++)
                 {
                     // Get the pixel.
-                    sourcePixel = source[x, y];
+                    sourcePixel = row[x];
 
                     // Check if this is the same as the last pixel. If so use that value
                     // rather than calculating it again. This is an inexpensive optimization.

--- a/src/ImageSharp/Quantizers/WuQuantizer{TPixel}.cs
+++ b/src/ImageSharp/Quantizers/WuQuantizer{TPixel}.cs
@@ -183,7 +183,7 @@ namespace ImageSharp.Quantizers
                         float b = Volume(this.colorCube[k], this.vmb) / weight;
                         float a = Volume(this.colorCube[k], this.vma) / weight;
 
-                        TPixel color = default(TPixel);
+                        var color = default(TPixel);
                         color.PackFromVector4(new Vector4(r, g, b, a) / 255F);
                         this.palette[k] = color;
                     }
@@ -221,7 +221,7 @@ namespace ImageSharp.Quantizers
         }
 
         /// <inheritdoc/>
-        protected override void FirstPass(PixelAccessor<TPixel> source, int width, int height)
+        protected override void FirstPass(ImageBase<TPixel> source, int width, int height)
         {
             // Build up the 3-D color histogram
             // Loop through each row
@@ -240,7 +240,7 @@ namespace ImageSharp.Quantizers
         }
 
         /// <inheritdoc/>
-        protected override void SecondPass(PixelAccessor<TPixel> source, byte[] output, int width, int height)
+        protected override void SecondPass(ImageBase<TPixel> source, byte[] output, int width, int height)
         {
             // Load up the values for the first pixel. We can use these to speed up the second
             // pass of the algorithm by avoiding transforming rows of identical color.

--- a/tests/ImageSharp.Tests/ImageSharp.Tests.csproj
+++ b/tests/ImageSharp.Tests/ImageSharp.Tests.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="Moq" Version="4.7.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta2-build1317" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\ImageSharp.Drawing\ImageSharp.Drawing.csproj" />

--- a/tests/ImageSharp.Tests/Processors/Filters/AlphaTest.cs
+++ b/tests/ImageSharp.Tests/Processors/Filters/AlphaTest.cs
@@ -22,7 +22,7 @@ namespace ImageSharp.Tests
 
         [Theory]
         [MemberData(nameof(AlphaValues))]
-        public void ImageShouldApplyAlphaFilter(int value)
+        public void ImageShouldApplyAlphaFilter(float value)
         {
             string path = this.CreateOutputDirectory("Alpha");
 
@@ -39,7 +39,7 @@ namespace ImageSharp.Tests
 
         [Theory]
         [MemberData(nameof(AlphaValues))]
-        public void ImageShouldApplyAlphaFilterInBox(int value)
+        public void ImageShouldApplyAlphaFilterInBox(float value)
         {
             string path = this.CreateOutputDirectory("Alpha");
 

--- a/tests/ImageSharp.Tests/Processors/Filters/GrayscaleTest.cs
+++ b/tests/ImageSharp.Tests/Processors/Filters/GrayscaleTest.cs
@@ -25,9 +25,9 @@ namespace ImageSharp.Tests
             {
                 image.Grayscale(value);
                 byte[] data = new byte[3];
-                foreach (TPixel p in image.Pixels)
+                for (int i = 0; i < image.Pixels.Length; i++)
                 {
-                    p.ToXyzBytes(data, 0);
+                    image.Pixels[i].ToXyzBytes(data, 0);
                     Assert.Equal(data[0], data[1]);
                     Assert.Equal(data[1], data[2]);
                 }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/JimBobSquarePants/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practise as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->

<!-- Thanks for contributing to ImageSharp! -->

This PR internalizes `PixelAccesor<TPixel>` allowing us to provide a more sensible API and further optimize our various algorithms. 

Image pixels can now be accessed using:

1. `image[x, y]`;
2. `ref image.GetPixelReference(x, y)` C#7+
3. `image.GetRowSpan(y)`
4. `image.GetRowSpan(x, y)`

Which feels much cleaner to me.

I've also optimized some low hanging fruit in the codebase and am going through all the existing processors at least to replace existing code. This benchmark shows the obvious benefits.
```
BenchmarkDotNet=v0.10.1, OS=Microsoft Windows NT 6.2.9200.0
Processor=Intel(R) Core(TM) i7-6600U CPU 2.60GHz, ProcessorCount=4
Frequency=2742191 Hz, Resolution=364.6719 ns, Timer=TSC
  [Host]     : Clr 4.0.30319.42000, 64bit RyuJIT-v4.7.2046.0
  DefaultJob : Clr 4.0.30319.42000, 64bit RyuJIT-v4.7.2046.0
```


Method |      Mean |    StdDev | Scaled | Scaled-StdDev | Allocated |
-------------------------------- |---------- |---------- |------- |-------------- |---------- |
'PixelAccessor Copy by indexer' | 2.3211 ms | 0.0466 ms |   1.00 |          0.00 |   2.65 kB |
'PixelAccessor Copy by Span' | 1.1721 ms | 0.0235 ms |   0.51 |          0.01 |   2.52 kB |
'Copy by indexer' | 1.7352 ms | 0.0472 ms |   0.75 |          0.02 |   2.41 kB |
'Copy by Span' | 1.1033 ms | 0.0228 ms |   0.48 |          0.01 |   2.27 kB |

I'm sure there's more than can be done internally in places with `PixelOperations` but this is a very healthy start.