### PR TITLE
Remove WeightsWindow.Span

### DIFF
--- a/src/ImageSharp/Processing/Processors/Transforms/ResamplingWeightedProcessor.Weights.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/ResamplingWeightedProcessor.Weights.cs
@@ -61,6 +61,7 @@ namespace ImageSharp.Processing.Processors
             /// Gets a reference to the first item of the window.
             /// </summary>
             /// <returns>The reference to the first item of the window</returns>
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public ref float GetStartReference()
             {
                 return ref this.buffer[this.flatStartIndex];

--- a/src/ImageSharp/Processing/Processors/Transforms/ResamplingWeightedProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Transforms/ResamplingWeightedProcessor.cs
@@ -112,7 +112,7 @@ namespace ImageSharp.Processing.Processors
                 WeightsWindow ws = result.GetWeightsWindow(i, left, right);
                 result.Weights[i] = ws;
 
-                ref float weights = ref ws.Ptr;
+                ref float weightsBaseRef = ref ws.GetStartReference();
 
                 for (int j = left; j <= right; j++)
                 {
@@ -120,7 +120,7 @@ namespace ImageSharp.Processing.Processors
                     sum += weight;
 
                     // weights[j - left] = weight:
-                    Unsafe.Add(ref weights, j - left) = weight;
+                    Unsafe.Add(ref weightsBaseRef, j - left) = weight;
                 }
 
                 // Normalise, best to do it here rather than in the pixel loop later on.
@@ -129,7 +129,7 @@ namespace ImageSharp.Processing.Processors
                     for (int w = 0; w < ws.Length; w++)
                     {
                         // weights[w] = weights[w] / sum:
-                        ref float wRef = ref Unsafe.Add(ref weights, w);
+                        ref float wRef = ref Unsafe.Add(ref weightsBaseRef, w);
                         wRef = wRef / sum;
                     }
                 }

--- a/tests/ImageSharp.Tests/Processing/Transforms/ResizeProfilingBenchmarks.cs
+++ b/tests/ImageSharp.Tests/Processing/Transforms/ResizeProfilingBenchmarks.cs
@@ -5,6 +5,7 @@
 
 namespace ImageSharp.Tests.Processing.Transforms
 {
+    using System;
     using System.IO;
     using System.Text;
 
@@ -49,9 +50,10 @@ namespace ImageSharp.Tests.Processing.Transforms
 
             foreach (ResamplingWeightedProcessor<Rgba32>.WeightsWindow window in weights.Weights)
             {
+                Span<float> span = window.GetWindowSpan();
                 for (int i = 0; i < window.Length; i++)
                 {
-                    float value = window.Span[i];
+                    float value = span[i];
                     bld.Append(value);
                     bld.Append("| ");
                 }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/JimBobSquarePants/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practise as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
Fixes #219 by removing the `Span<float>` from the heap utilizing a method call instead.

We incur the cost of creating two spans per `Ptr` request now but the benchmarks still show a 2x speedup over System.Drawing  so I'm comfortable with that. As always, open to better ideas.

<!-- Thanks for contributing to ImageSharp! -->
