### PR TITLE
Ensure we consume stream when failing to read ICC profile

### DIFF
--- a/src/ImageSharp/Formats/Jpeg/JpegDecoderCore.cs
+++ b/src/ImageSharp/Formats/Jpeg/JpegDecoderCore.cs
@@ -982,6 +982,7 @@ namespace ImageSharp.Formats
 
             byte[] identifier = new byte[Icclength];
             this.InputProcessor.ReadFull(identifier, 0, Icclength);
+            remaining -= Icclength; // we have read it by this point
 
             if (identifier[0] == 'I' &&
                 identifier[1] == 'C' &&
@@ -996,7 +997,6 @@ namespace ImageSharp.Formats
                 identifier[10] == 'E' &&
                 identifier[11] == '\0')
             {
-                remaining -= Icclength;
                 byte[] profile = new byte[remaining];
                 this.InputProcessor.ReadFull(profile, 0, remaining);
 
@@ -1008,6 +1008,11 @@ namespace ImageSharp.Formats
                 {
                     metadata.IccProfile.Extend(profile);
                 }
+            }
+            else
+            {
+                // not an ICC profile we can handle read the remaining so we can carry on and ignore this.
+                this.InputProcessor.Skip(remaining);
             }
         }
 


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/JimBobSquarePants/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practise as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [ ] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->

We failed to ensure we had read all the bytes of a marked segment when we had decided to skip processing an App2 marker due to it not containing the correct header.

I think this is correct, it seems to work and allows me to load up and resize the photo in issue #238 

Fixes #238 
