### PR TITLE
Repair Benchmarks for VSCode/Linux

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -16,7 +16,7 @@
     {
       "taskName": "build benchmark",
       "suppressTaskName": true,
-      "args": [ "build", "tests/ImageSharp.Benchmarks/project.json", "-f", "netcoreapp1.1", "-c", "Release" ],
+      "args": [ "build", "tests/ImageSharp.Benchmarks/ImageSharp.Benchmarks.csproj", "-f", "netcoreapp1.1", "-c", "Release" ],
       "showOutput": "always",
       "problemMatcher": "$msCompile"
     },

--- a/tests/ImageSharp.Benchmarks/Color/Bulk/PackFromVector4ReferenceVsPointer.cs
+++ b/tests/ImageSharp.Benchmarks/Color/Bulk/PackFromVector4ReferenceVsPointer.cs
@@ -22,7 +22,7 @@
         [Params(16, 128, 1024)]
         public int Count { get; set; }
 
-        [Setup]
+        [GlobalSetup]
         public void Setup()
         {
             this.destination = new Buffer<Rgba32>(this.Count);
@@ -31,7 +31,7 @@
             this.destination.Pin();
         }
 
-        [Cleanup]
+        [GlobalCleanup]
         public void Cleanup()
         {
             this.source.Dispose();

--- a/tests/ImageSharp.Benchmarks/Color/Bulk/PackFromXyzw.cs
+++ b/tests/ImageSharp.Benchmarks/Color/Bulk/PackFromXyzw.cs
@@ -16,14 +16,14 @@ namespace ImageSharp.Benchmarks.Color.Bulk
         [Params(16, 128, 1024)]
         public int Count { get; set; }
 
-        [Setup]
+        [GlobalSetup]
         public void Setup()
         {
             this.destination = new Buffer<TPixel>(this.Count);
             this.source = new Buffer<byte>(this.Count * 4);
         }
 
-        [Cleanup]
+        [GlobalCleanup]
         public void Cleanup()
         {
             this.destination.Dispose();

--- a/tests/ImageSharp.Benchmarks/Color/Bulk/ToVector4.cs
+++ b/tests/ImageSharp.Benchmarks/Color/Bulk/ToVector4.cs
@@ -18,14 +18,14 @@ namespace ImageSharp.Benchmarks.Color.Bulk
         [Params(64, 300, 1024)]
         public int Count { get; set; }
 
-        [Setup]
+        [GlobalSetup]
         public void Setup()
         {
             this.source = new Buffer<TPixel>(this.Count);
             this.destination = new Buffer<Vector4>(this.Count);
         }
 
-        [Cleanup]
+        [GlobalCleanup]
         public void Cleanup()
         {
             this.source.Dispose();

--- a/tests/ImageSharp.Benchmarks/Color/Bulk/ToXyz.cs
+++ b/tests/ImageSharp.Benchmarks/Color/Bulk/ToXyz.cs
@@ -16,14 +16,14 @@ namespace ImageSharp.Benchmarks.Color.Bulk
         [Params(16, 128, 1024)]
         public int Count { get; set; }
 
-        [Setup]
+        [GlobalSetup]
         public void Setup()
         {
             this.source = new Buffer<TPixel>(this.Count);
             this.destination = new Buffer<byte>(this.Count * 3);
         }
 
-        [Cleanup]
+        [GlobalCleanup]
         public void Cleanup()
         {
             this.source.Dispose();

--- a/tests/ImageSharp.Benchmarks/Color/Bulk/ToXyzw.cs
+++ b/tests/ImageSharp.Benchmarks/Color/Bulk/ToXyzw.cs
@@ -21,14 +21,14 @@ namespace ImageSharp.Benchmarks.Color.Bulk
         [Params(16, 128, 1024)]
         public int Count { get; set; }
 
-        [Setup]
+        [GlobalSetup]
         public void Setup()
         {
             this.source = new Buffer<TPixel>(this.Count);
             this.destination = new Buffer<byte>(this.Count * 4);
         }
 
-        [Cleanup]
+        [GlobalCleanup]
         public void Cleanup()
         {
             this.source.Dispose();

--- a/tests/ImageSharp.Benchmarks/Color/RgbToYCbCr.cs
+++ b/tests/ImageSharp.Benchmarks/Color/RgbToYCbCr.cs
@@ -116,7 +116,7 @@
 
         private int[] inputSourceRGBAsInteger = null;
 
-        [Setup]
+        [GlobalSetup]
         public void Setup()
         {
             // Console.WriteLine("Vector<int>.Count: " + Vector<int>.Count);

--- a/tests/ImageSharp.Benchmarks/General/Array2D.cs
+++ b/tests/ImageSharp.Benchmarks/General/Array2D.cs
@@ -27,7 +27,7 @@ namespace ImageSharp.Benchmarks.General
         public int Min { get; private set; }
         public int Max { get; private set; }
 
-        [Setup]
+        [GlobalSetup]
         public void SetUp()
         {
             this.flatArray = new float[this.Count * this.Count];

--- a/tests/ImageSharp.Benchmarks/General/ArrayCopy.cs
+++ b/tests/ImageSharp.Benchmarks/General/ArrayCopy.cs
@@ -20,7 +20,7 @@ namespace ImageSharp.Benchmarks.General
 
         byte[] destination;
 
-        [Setup]
+        [GlobalSetup]
         public void SetUp()
         {
             this.source = new byte[this.Count];

--- a/tests/ImageSharp.Benchmarks/General/ArrayReverse.cs
+++ b/tests/ImageSharp.Benchmarks/General/ArrayReverse.cs
@@ -18,7 +18,7 @@ namespace ImageSharp.Benchmarks.General
 
         byte[] destination;
 
-        [Setup]
+        [GlobalSetup]
         public void SetUp()
         {
             this.source = new byte[this.Count];

--- a/tests/ImageSharp.Benchmarks/General/ClearBuffer.cs
+++ b/tests/ImageSharp.Benchmarks/General/ClearBuffer.cs
@@ -15,13 +15,13 @@ namespace ImageSharp.Benchmarks.General
         [Params(32, 128, 512)]
         public int Count { get; set; }
 
-        [Setup]
+        [GlobalSetup]
         public void Setup()
         {
             this.buffer = new Buffer<Rgba32>(this.Count);
         }
 
-        [Cleanup]
+        [GlobalCleanup]
         public void Cleanup()
         {
             this.buffer.Dispose();

--- a/tests/ImageSharp.Benchmarks/General/IterateArray.cs
+++ b/tests/ImageSharp.Benchmarks/General/IterateArray.cs
@@ -18,7 +18,7 @@ namespace ImageSharp.Benchmarks.General
         [Params(64, 1024)]
         public int Length { get; set; }
 
-        [Setup]
+        [GlobalSetup]
         public void Setup()
         {
             this.buffer = new Buffer<Vector4>(this.Length);

--- a/tests/ImageSharp.Benchmarks/General/PixelIndexing.cs
+++ b/tests/ImageSharp.Benchmarks/General/PixelIndexing.cs
@@ -145,7 +145,7 @@
         // [Params(1024)]
         public int Count { get; set; } = 1024;
 
-        [Setup]
+        [GlobalSetup]
         public void Setup()
         {
             this.width = 2048;
@@ -158,7 +158,7 @@
             this.endIndex = 2048 / 2 + (this.Count / 2);
         }
 
-        [Cleanup]
+        [GlobalCleanup]
         public void Cleanup()
         {
             this.buffer.Dispose();

--- a/tests/ImageSharp.Benchmarks/General/RoundSinglePrecisionBlocks.cs
+++ b/tests/ImageSharp.Benchmarks/General/RoundSinglePrecisionBlocks.cs
@@ -22,7 +22,7 @@
         private Block8x8F inputDividend = default(Block8x8F);
         private Block8x8F inputDivisior = default(Block8x8F);
 
-        [Setup]
+        [GlobalSetup]
         public void Setup()
         {
             for (int i = 0; i < Block8x8F.ScalarCount; i++)

--- a/tests/ImageSharp.Benchmarks/General/Vector4Constants.cs
+++ b/tests/ImageSharp.Benchmarks/General/Vector4Constants.cs
@@ -20,7 +20,7 @@ namespace ImageSharp.Benchmarks.General
 
         private Vector4 parameter;
 
-        [Setup]
+        [GlobalSetup]
         public void Setup()
         {
             this.random = new Random(42);

--- a/tests/ImageSharp.Benchmarks/General/Vectorization/BitwiseOrUint32.cs
+++ b/tests/ImageSharp.Benchmarks/General/Vectorization/BitwiseOrUint32.cs
@@ -15,7 +15,7 @@ namespace ImageSharp.Benchmarks.General.Vectorization
 
         private uint testValue;
 
-        [Setup]
+        [GlobalSetup]
         public void Setup()
         {
             this.input = new uint[this.InputSize];

--- a/tests/ImageSharp.Benchmarks/General/Vectorization/DivFloat.cs
+++ b/tests/ImageSharp.Benchmarks/General/Vectorization/DivFloat.cs
@@ -15,7 +15,7 @@ namespace ImageSharp.Benchmarks.General.Vectorization
 
         private float testValue;
 
-        [Setup]
+        [GlobalSetup]
         public void Setup()
         {
             this.input = new float[this.InputSize];

--- a/tests/ImageSharp.Benchmarks/General/Vectorization/DivUInt32.cs
+++ b/tests/ImageSharp.Benchmarks/General/Vectorization/DivUInt32.cs
@@ -15,7 +15,7 @@ namespace ImageSharp.Benchmarks.General.Vectorization
 
         private uint testValue;
 
-        [Setup]
+        [GlobalSetup]
         public void Setup()
         {
             this.input = new uint[this.InputSize];

--- a/tests/ImageSharp.Benchmarks/General/Vectorization/MulFloat.cs
+++ b/tests/ImageSharp.Benchmarks/General/Vectorization/MulFloat.cs
@@ -15,7 +15,7 @@ namespace ImageSharp.Benchmarks.General.Vectorization
 
         private float testValue;
 
-        [Setup]
+        [GlobalSetup]
         public void Setup()
         {
             this.input = new float[this.InputSize];

--- a/tests/ImageSharp.Benchmarks/General/Vectorization/MulUInt32.cs
+++ b/tests/ImageSharp.Benchmarks/General/Vectorization/MulUInt32.cs
@@ -15,7 +15,7 @@ namespace ImageSharp.Benchmarks.General.Vectorization
 
         private uint testValue;
 
-        [Setup]
+        [GlobalSetup]
         public void Setup()
         {
             this.input = new uint[this.InputSize];

--- a/tests/ImageSharp.Benchmarks/General/Vectorization/ReinterpretUInt32AsFloat.cs
+++ b/tests/ImageSharp.Benchmarks/General/Vectorization/ReinterpretUInt32AsFloat.cs
@@ -25,7 +25,7 @@ namespace ImageSharp.Benchmarks.General.Vectorization
         }
 
 
-        [Setup]
+        [GlobalSetup]
         public void Setup()
         {
             this.input = new uint[this.InputSize];

--- a/tests/ImageSharp.Benchmarks/General/Vectorization/VectorFetching.cs
+++ b/tests/ImageSharp.Benchmarks/General/Vectorization/VectorFetching.cs
@@ -20,7 +20,7 @@ namespace ImageSharp.Benchmarks.General.Vectorization
         [Params(64)]
         public int InputSize { get; set; }
         
-        [Setup]
+        [GlobalSetup]
         public void Setup()
         {
             this.data = new float[this.InputSize];

--- a/tests/ImageSharp.Benchmarks/Image/DecodeBmp.cs
+++ b/tests/ImageSharp.Benchmarks/Image/DecodeBmp.cs
@@ -18,7 +18,7 @@ namespace ImageSharp.Benchmarks.Image
     {
         private byte[] bmpBytes;
 
-        [Setup]
+        [GlobalSetup]
         public void ReadImages()
         {
             if (this.bmpBytes == null)

--- a/tests/ImageSharp.Benchmarks/Image/DecodeFilteredPng.cs
+++ b/tests/ImageSharp.Benchmarks/Image/DecodeFilteredPng.cs
@@ -20,7 +20,7 @@ namespace ImageSharp.Benchmarks.Image
         private MemoryStream filter3;
         private MemoryStream filter4;
 
-        [Setup]
+        [GlobalSetup]
         public void ReadImages()
         {
             this.filter0 = new MemoryStream(File.ReadAllBytes("../ImageSharp.Tests/TestImages/Formats/Png/filter0.png"));

--- a/tests/ImageSharp.Benchmarks/Image/DecodeGif.cs
+++ b/tests/ImageSharp.Benchmarks/Image/DecodeGif.cs
@@ -18,7 +18,7 @@ namespace ImageSharp.Benchmarks.Image
     {
         private byte[] gifBytes;
 
-        [Setup]
+        [GlobalSetup]
         public void ReadImages()
         {
             if (this.gifBytes == null)

--- a/tests/ImageSharp.Benchmarks/Image/DecodeJpeg.cs
+++ b/tests/ImageSharp.Benchmarks/Image/DecodeJpeg.cs
@@ -18,7 +18,7 @@ namespace ImageSharp.Benchmarks.Image
     {
         private byte[] jpegBytes;
 
-        [Setup]
+        [GlobalSetup]
         public void ReadImages()
         {
             if (this.jpegBytes == null)

--- a/tests/ImageSharp.Benchmarks/Image/DecodePng.cs
+++ b/tests/ImageSharp.Benchmarks/Image/DecodePng.cs
@@ -18,7 +18,7 @@ namespace ImageSharp.Benchmarks.Image
     {
         private byte[] pngBytes;
 
-        [Setup]
+        [GlobalSetup]
         public void ReadImages()
         {
             if (this.pngBytes == null)

--- a/tests/ImageSharp.Benchmarks/Image/EncodeBmp.cs
+++ b/tests/ImageSharp.Benchmarks/Image/EncodeBmp.cs
@@ -20,7 +20,7 @@ namespace ImageSharp.Benchmarks.Image
         private Image bmpDrawing;
         private Image<Rgba32> bmpCore;
 
-        [Setup]
+        [GlobalSetup]
         public void ReadImages()
         {
             if (this.bmpStream == null)
@@ -32,7 +32,7 @@ namespace ImageSharp.Benchmarks.Image
             }
         }
 
-        [Cleanup]
+        [GlobalCleanup]
         public void Cleanup()
         {
             this.bmpStream.Dispose();

--- a/tests/ImageSharp.Benchmarks/Image/EncodeGif.cs
+++ b/tests/ImageSharp.Benchmarks/Image/EncodeGif.cs
@@ -20,7 +20,7 @@ namespace ImageSharp.Benchmarks.Image
         private Image bmpDrawing;
         private Image<Rgba32> bmpCore;
 
-        [Setup]
+        [GlobalSetup]
         public void ReadImages()
         {
             if (this.bmpStream == null)
@@ -32,7 +32,7 @@ namespace ImageSharp.Benchmarks.Image
             }
         }
 
-        [Cleanup]
+        [GlobalCleanup]
         public void Cleanup()
         {
             this.bmpStream.Dispose();

--- a/tests/ImageSharp.Benchmarks/Image/EncodeIndexedPng.cs
+++ b/tests/ImageSharp.Benchmarks/Image/EncodeIndexedPng.cs
@@ -27,7 +27,7 @@ namespace ImageSharp.Benchmarks.Image
         [Params(false)]
         public bool LargeImage { get; set; }
 
-        [Setup]
+        [GlobalSetup]
         public void ReadImages()
         {
             if (this.bmpStream == null)
@@ -41,7 +41,7 @@ namespace ImageSharp.Benchmarks.Image
             }
         }
 
-        [Cleanup]
+        [GlobalCleanup]
         public void Cleanup()
         {
             this.bmpStream.Dispose();

--- a/tests/ImageSharp.Benchmarks/Image/EncodeJpeg.cs
+++ b/tests/ImageSharp.Benchmarks/Image/EncodeJpeg.cs
@@ -20,7 +20,7 @@ namespace ImageSharp.Benchmarks.Image
         private Image bmpDrawing;
         private Image<Rgba32> bmpCore;
 
-        [Setup]
+        [GlobalSetup]
         public void ReadImages()
         {
             if (this.bmpStream == null)
@@ -32,7 +32,7 @@ namespace ImageSharp.Benchmarks.Image
             }
         }
 
-        [Cleanup]
+        [GlobalCleanup]
         public void Cleanup()
         {
             this.bmpStream.Dispose();

--- a/tests/ImageSharp.Benchmarks/Image/EncodePng.cs
+++ b/tests/ImageSharp.Benchmarks/Image/EncodePng.cs
@@ -29,7 +29,7 @@ namespace ImageSharp.Benchmarks.Image
         [Params(false)]
         public bool UseOctreeQuantizer { get; set; }
 
-        [Setup]
+        [GlobalSetup]
         public void ReadImages()
         {
             if (this.bmpStream == null)
@@ -44,7 +44,7 @@ namespace ImageSharp.Benchmarks.Image
             }
         }
 
-        [Cleanup]
+        [GlobalCleanup]
         public void Cleanup()
         {
             this.bmpStream.Dispose();

--- a/tests/ImageSharp.Benchmarks/Image/MultiImageBenchmarkBase.cs
+++ b/tests/ImageSharp.Benchmarks/Image/MultiImageBenchmarkBase.cs
@@ -83,7 +83,7 @@ namespace ImageSharp.Benchmarks.Image
 
         protected abstract IEnumerable<string> InputImageSubfoldersOrFiles { get; }
 
-        [Setup]
+        [GlobalSetup]
         public void ReadImages()
         {
             if (!Vector.IsHardwareAccelerated)

--- a/tests/ImageSharp.Benchmarks/ImageSharp.Benchmarks.csproj
+++ b/tests/ImageSharp.Benchmarks/ImageSharp.Benchmarks.csproj
@@ -1,15 +1,25 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <TargetFrameworks>netcoreapp1.1;net461</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net461</TargetFramework>
-    <RuntimeIdentifier>win7-x64</RuntimeIdentifier>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)'=='net461'">
+    <RuntimeIdentifier>win7-x64</RuntimeIdentifier>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.10.2" />
     <PackageReference Include="Colourful" Version="1.1.2" />
     <PackageReference Include="System.Numerics.Vectors" Version="4.3.0" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)'=='net461'">
+    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.10.7" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)'=='netcoreapp1.1'">
+    <PackageReference Include="BenchmarkDotNet" Version="0.10.7" />
+    <PackageReference Include="System.Reflection" Version="4.3.0" />
+    <PackageReference Include="CoreCompat.System.Drawing" Version="1.0.0-beta006" />
+    <PackageReference Include="runtime.linux-x64.CoreCompat.System.Drawing" Version="1.0.0-beta009" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\ImageSharp.Drawing\ImageSharp.Drawing.csproj" />

--- a/tests/ImageSharp.Benchmarks/Samplers/DetectEdges.cs
+++ b/tests/ImageSharp.Benchmarks/Samplers/DetectEdges.cs
@@ -17,7 +17,7 @@ namespace ImageSharp.Benchmarks
     {
         private Image<Rgba32> image;
 
-        [Setup]
+        [GlobalSetup]
         public void ReadImage()
         {
             if (this.image == null)
@@ -29,7 +29,7 @@ namespace ImageSharp.Benchmarks
             }
         }
 
-        [Cleanup]
+        [GlobalCleanup]
         public void Cleanup()
         {
             this.image.Dispose();

--- a/tests/ImageSharp.Benchmarks/Samplers/Glow.cs
+++ b/tests/ImageSharp.Benchmarks/Samplers/Glow.cs
@@ -22,7 +22,7 @@ namespace ImageSharp.Benchmarks
         private GlowProcessor<Rgba32> bulk;
         private GlowProcessorParallel<Rgba32> parallel;
 
-        [Setup]
+        [GlobalSetup]
         public void Setup()
         {
             this.bulk = new GlowProcessor<Rgba32>(NamedColors<Rgba32>.Beige, GraphicsOptions.Default) { Radius = 800 * .5f, };


### PR DESCRIPTION
### Prerequisites

- [X] I have written a descriptive pull-request title
- [X] I have verified that there are no overlapping [pull-requests](https://github.com/JimBobSquarePants/ImageSharp/pulls) open
- [X] I have verified that I am following matches the existing coding patterns and practise as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [X] I have provided test coverage for my change (where applicable)

### Description

After some inactivity in the project I wanted to continue contributing and noticed that since moving to VS2017 the Benchmarks no longer worked under Linux with .Net Core and VSCode.

* I added the target framework _netcoreapp1.1_
* I split the dependencies and restored the references from _project.json_
* I upgraded BenchmarkDotNet since **0.10.2** does not work with _csproj_ and _netcoreapp1.1_
* After the upgrade I replaced the deprecated attributes and performed a fex checks

**TODO:** Someone with Windows (and VS2017) should confirm this still works and runs properly on _net461_
