### PR TITLE
Updated xunit to 2.3.0-beta3-build3705, fixed errors reported by xunit analyzer

### DIFF
--- a/tests/ImageSharp.Sandbox46/ImageSharp.Sandbox46.csproj
+++ b/tests/ImageSharp.Sandbox46/ImageSharp.Sandbox46.csproj
@@ -18,7 +18,7 @@
   <ItemGroup>
     <!--<PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />-->
     <PackageReference Include="Moq" Version="4.7.1" />
-    <PackageReference Include="xunit" Version="2.3.0-beta2-build3683" />
+    <PackageReference Include="xunit" Version="2.3.0-beta3-build3705" />
     <!--<PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />-->
   </ItemGroup>
   <ItemGroup>

--- a/tests/ImageSharp.Tests/Colorspaces/ColorSpaceEqualityTests.cs
+++ b/tests/ImageSharp.Tests/Colorspaces/ColorSpaceEqualityTests.cs
@@ -3,6 +3,7 @@
 // Licensed under the Apache License, Version 2.0.
 // </copyright>
 
+// ReSharper disable InconsistentNaming
 namespace ImageSharp.Tests.Colorspaces
 {
     using System;
@@ -141,7 +142,7 @@ namespace ImageSharp.Tests.Colorspaces
 
         [Theory]
         [MemberData(nameof(EmptyData))]
-        public void Equality(IColorVector color)
+        public void Vector_Equals_WhenTrue(IColorVector color)
         {
             // Act
             bool equal = color.Vector.Equals(Vector3.Zero);
@@ -152,7 +153,7 @@ namespace ImageSharp.Tests.Colorspaces
 
         [Theory]
         [MemberData(nameof(EqualityData))]
-        public void Equality(object first, object second, Type type)
+        public void Equals_WhenTrue(object first, object second, Type type)
         {
             // Act
             bool equal = first.Equals(second);
@@ -165,7 +166,7 @@ namespace ImageSharp.Tests.Colorspaces
         [MemberData(nameof(NotEqualityDataNulls))]
         [MemberData(nameof(NotEqualityDataDifferentObjects))]
         [MemberData(nameof(NotEqualityData))]
-        public void NotEquality(object first, object second, Type type)
+        public void Equals_WhenFalse(object first, object second, Type type)
         {
             // Act
             bool equal = first.Equals(second);
@@ -176,7 +177,7 @@ namespace ImageSharp.Tests.Colorspaces
 
         [Theory]
         [MemberData(nameof(EqualityData))]
-        public void HashCodeEqual(object first, object second, Type type)
+        public void GetHashCode_WhenEqual(object first, object second, Type type)
         {
             // Act
             bool equal = first.GetHashCode() == second.GetHashCode();
@@ -187,7 +188,7 @@ namespace ImageSharp.Tests.Colorspaces
 
         [Theory]
         [MemberData(nameof(NotEqualityDataDifferentObjects))]
-        public void HashCodeNotEqual(object first, object second, Type type)
+        public void GetHashCode_WhenNotEqual(object first, object second, Type type)
         {
             // Act
             bool equal = first.GetHashCode() == second.GetHashCode();
@@ -198,7 +199,7 @@ namespace ImageSharp.Tests.Colorspaces
 
         [Theory]
         [MemberData(nameof(EqualityData))]
-        public void EqualityObject(object first, object second, Type type)
+        public void GenericEquals_WhenTrue(object first, object second, Type type)
         {
             // Arrange
             // Cast to the known object types, this is so that we can hit the
@@ -216,7 +217,7 @@ namespace ImageSharp.Tests.Colorspaces
 
         [Theory]
         [MemberData(nameof(NotEqualityData))]
-        public void NotEqualityObject(object first, object second, Type type)
+        public void GenericEquals_WhenFalse(object first, object second, Type type)
         {
             // Arrange
             // Cast to the known object types, this is so that we can hit the
@@ -253,7 +254,7 @@ namespace ImageSharp.Tests.Colorspaces
 
         [Theory]
         [MemberData(nameof(NotEqualityData))]
-        public void NotEqualityOperator(object first, object second, Type type)
+        public void Operator_WhenTrue(object first, object second, Type type)
         {
             // Arrange
             // Cast to the known object types, this is so that we can hit the

--- a/tests/ImageSharp.Tests/Image/PixelAccessorTests.cs
+++ b/tests/ImageSharp.Tests/Image/PixelAccessorTests.cs
@@ -113,7 +113,7 @@ namespace ImageSharp.Tests
         {
             using (Image<Rgba32> image = new Image<Rgba32>(1, 1))
             {
-                CopyFromZYX(image);
+                CopyFromZYXImpl(image);
             }
         }
         
@@ -122,7 +122,7 @@ namespace ImageSharp.Tests
         {
             using (Image<Rgba32> image = new Image<Rgba32>(1, 1))
             {
-                CopyFromZYXW(image);
+                CopyFromZYXWImpl(image);
             }
         }
         
@@ -131,7 +131,7 @@ namespace ImageSharp.Tests
         {
             using (Image<Rgba32> image = new Image<Rgba32>(1, 1))
             {
-                CopyToZYX(image);
+                CopyToZYXImpl(image);
             }
         }
         
@@ -140,11 +140,11 @@ namespace ImageSharp.Tests
         {
             using (Image<Rgba32> image = new Image<Rgba32>(1, 1))
             {
-                CopyToZYXW(image);
+                CopyToZYXWImpl(image);
             }
         }
         
-        private static void CopyFromZYX<TPixel>(Image<TPixel> image)
+        private static void CopyFromZYXImpl<TPixel>(Image<TPixel> image)
             where TPixel : struct, IPixel<TPixel>
         {
             using (PixelAccessor<TPixel> pixels = image.Lock())
@@ -171,7 +171,7 @@ namespace ImageSharp.Tests
             }
         }
 
-        private static void CopyFromZYXW<TPixel>(Image<TPixel> image)
+        private static void CopyFromZYXWImpl<TPixel>(Image<TPixel> image)
             where TPixel : struct, IPixel<TPixel>
         {
             using (PixelAccessor<TPixel> pixels = image.Lock())
@@ -199,7 +199,7 @@ namespace ImageSharp.Tests
             }
         }
 
-        private static void CopyToZYX<TPixel>(Image<TPixel> image)
+        private static void CopyToZYXImpl<TPixel>(Image<TPixel> image)
           where TPixel : struct, IPixel<TPixel>
         {
             using (PixelAccessor<TPixel> pixels = image.Lock())
@@ -221,7 +221,7 @@ namespace ImageSharp.Tests
             }
         }
 
-        private static void CopyToZYXW<TPixel>(Image<TPixel> image)
+        private static void CopyToZYXWImpl<TPixel>(Image<TPixel> image)
             where TPixel : struct, IPixel<TPixel>
         {
             using (PixelAccessor<TPixel> pixels = image.Lock())

--- a/tests/ImageSharp.Tests/ImageSharp.Tests.csproj
+++ b/tests/ImageSharp.Tests/ImageSharp.Tests.csproj
@@ -12,8 +12,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="Moq" Version="4.7.1" />
-    <PackageReference Include="xunit" Version="2.3.0-beta2-build3683" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta2-build1317" />
+    <PackageReference Include="xunit" Version="2.3.0-beta3-build3705" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta3-build3705" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\ImageSharp.Drawing\ImageSharp.Drawing.csproj" />

--- a/tests/ImageSharp.Tests/PixelFormats/ColorDefinitionTests.cs
+++ b/tests/ImageSharp.Tests/PixelFormats/ColorDefinitionTests.cs
@@ -15,7 +15,18 @@ namespace ImageSharp.Tests
 
     public class ColorDefinitionTests
     {
-        public static IEnumerable<string[]> ColorNames => typeof(NamedColors<Rgba32>).GetTypeInfo().GetFields().Select(x => new[] { x.Name });
+        public static TheoryData<string> ColorNames
+        {
+            get
+            {
+                var result = new TheoryData<string>();
+                foreach (string name in typeof(NamedColors<Rgba32>).GetTypeInfo().GetFields().Select(x =>  x.Name ))
+                {
+                    result.Add(name);
+                }
+                return result;
+            }
+        }
 
         [Theory]
         [MemberData(nameof(ColorNames))]


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/JimBobSquarePants/ImageSharp/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practise as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description

Minor change, but don't wan't to break working test runners for anyone, so created a PR.

- Updated xunit to 2.3.0-beta3-build3705
- Fixed name collisions reported by xunit analyzer
